### PR TITLE
ci(aur): add aur deployment gh action

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -16,8 +16,7 @@ jobs:
         run: |
           cd deadlock-modmanager
           VERSION=${GITHUB_REF##*/v}
-          VERSION=${VERSION//-/_}
-          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+          sed -i "s/^_pkgver=.*/_pkgver=${VERSION}/" PKGBUILD
           sed -i -E "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
 
       - name: Publish to AUR


### PR DESCRIPTION
adds a github action to automatically update the stable AUR package when a new version tag is pushed. tested locally with [nektos/act](https://github.com/nektos/act) and with [one tag push to my fork on github](https://github.com/yobson1/deadlock-modmanager/actions/runs/17556519623/job/49861970418). aur package users will get updates immediately without needing to wait for me to update the PKGBUILD manually. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Automated publishing of tagged releases to the Arch User Repository (AUR), improving release availability for Arch users.
  - PKGBUILD now auto-updates from release tags (versioning, checksums) with pkgrel reset to 1 for new versions.
  - Standardized release commit messages and metadata during AUR updates.
  - Triggers on semantic version tags.
  - No changes to application functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->