### PR TITLE
feat: implement addons-based mod management with smart grouping and p…

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -975,6 +975,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 name = "deadlock-mod-manager"
 version = "0.8.2"
 dependencies = [
+ "chrono",
  "dotenvy",
  "keyvalues-serde",
  "log",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ tauri-plugin-deep-link = "2.4"
 sha2 = "0.10"
 tauri-plugin-posthog = "0.2.2"
 dotenvy = "0.15"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.22.0"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -337,3 +337,32 @@ pub async fn remove_mod_folder(mod_path: String) -> Result<(), Error> {
   mod_manager.remove_mod_folder(&path)?;
   Ok(())
 }
+
+// Addons System Commands
+#[tauri::command]
+pub async fn activate_mod(mod_id: String, mod_name: String, vpks: Vec<String>) -> Result<(), Error> {
+  log::info!("Activating mod: {} ({})", mod_name, mod_id);
+  let mut mod_manager = MANAGER.lock().unwrap();
+  mod_manager.activate_mod(&mod_id, &mod_name, &vpks)
+}
+
+#[tauri::command]
+pub async fn deactivate_mod(mod_id: String, mod_name: String, vpks: Vec<String>) -> Result<(), Error> {
+  log::info!("Deactivating mod: {} ({})", mod_name, mod_id);
+  let mut mod_manager = MANAGER.lock().unwrap();
+  mod_manager.deactivate_mod(&mod_id, &mod_name, &vpks)
+}
+
+#[tauri::command]
+pub async fn get_installed_mods_from_addons() -> Result<Vec<crate::mod_manager::addons_manager::ModCatalogEntry>, Error> {
+  log::info!("Getting installed mods from addons system");
+  let mod_manager = MANAGER.lock().unwrap();
+  mod_manager.get_installed_mods_from_addons()
+}
+
+#[tauri::command]
+pub async fn get_active_mods_from_addons() -> Result<Vec<crate::mod_manager::addons_manager::ActiveMod>, Error> {
+  log::info!("Getting active mods from addons system");
+  let mod_manager = MANAGER.lock().unwrap();
+  mod_manager.get_active_mods_from_addons()
+}

--- a/apps/desktop/src-tauri/src/errors.rs
+++ b/apps/desktop/src-tauri/src/errors.rs
@@ -47,6 +47,10 @@ pub enum Error {
   ExternalModification(String),
   #[error("Unauthorized path access attempted: {0}")]
   UnauthorizedPath(String),
+  #[error("JSON serialization/deserialization error: {0}")]
+  Json(#[from] serde_json::Error),
+  #[error("Invalid gameinfo.gi file")]
+  InvalidGameInfo,
   #[error("Tauri error: {0}")]
   Tauri(#[from] tauri::Error),
 }
@@ -84,6 +88,8 @@ impl serde::Serialize for Error {
       Error::GameInfoValidationFailed(_) => "gameInfoValidationFailed",
       Error::ExternalModification(_) => "externalModification",
       Error::UnauthorizedPath(_) => "unauthorizedPath",
+      Error::Json(_) => "json",
+      Error::InvalidGameInfo => "invalidGameInfo",
       Error::Tauri(_) => "tauri",
     };
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -197,7 +197,12 @@ pub fn run() {
       commands::open_gameinfo_editor,
       commands::set_language,
       commands::extract_archive,
-      commands::remove_mod_folder
+      commands::remove_mod_folder,
+      // Addons System Commands
+      commands::activate_mod,
+      commands::deactivate_mod,
+      commands::get_installed_mods_from_addons,
+      commands::get_active_mods_from_addons
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/mod_manager/addons_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/addons_manager.rs
@@ -1,0 +1,488 @@
+use crate::errors::Error;
+use crate::mod_manager::filesystem_helper::FileSystemHelper;
+use chrono;
+use log;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Manages mods using the addons folder approach with subdirectories
+pub struct AddonsManager {
+    filesystem: FileSystemHelper,
+}
+
+/// Represents an active mod entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActiveMod {
+    pub id: String,
+    pub name: String,
+    pub vpks: Vec<String>,
+    pub folder_name: String,
+}
+
+/// Represents the active mods manifest
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActiveModsManifest {
+    pub active_mods: Vec<ActiveMod>,
+    pub last_updated: String,
+}
+
+/// Represents a mod in the catalog
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModCatalogEntry {
+    pub id: String,
+    pub name: String,
+    pub folder_name: String,
+    pub vpks: Vec<String>,
+    pub installed_at: String,
+    pub enabled: bool,
+}
+
+/// Represents the mods catalog
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModsCatalog {
+    pub mods: HashMap<String, ModCatalogEntry>,
+    pub last_updated: String,
+}
+
+impl AddonsManager {
+    pub fn new() -> Self {
+        Self {
+            filesystem: FileSystemHelper::new(),
+        }
+    }
+
+    /// Get the addons directory path
+    pub fn get_addons_path(&self, game_path: &Path) -> PathBuf {
+        game_path.join("game").join("citadel").join("addons")
+    }
+
+    /// Sanitize mod name for folder/file naming
+    fn sanitize_name(&self, name: &str) -> String {
+        // Replace invalid characters with underscores
+        let sanitized = name
+            .chars()
+            .map(|c| if c.is_alphanumeric() || c == ' ' { c } else { '_' })
+            .collect::<String>();
+        
+        // Replace multiple spaces with single underscore
+        let sanitized = Regex::new(r"\s+").unwrap()
+            .replace_all(&sanitized, "_");
+        
+        // Remove leading/trailing underscores
+        sanitized.trim_matches('_').to_string()
+    }
+
+    /// Get the next available VPK number for a mod
+    fn get_next_vpk_number(&self, addons_path: &Path, mod_name: &str) -> Result<u32, Error> {
+        let sanitized_name = self.sanitize_name(mod_name);
+        let mod_folder = addons_path.join(&sanitized_name);
+        let mut highest = 0;
+
+        // Check for active mods in the mod subfolder
+        if mod_folder.exists() {
+            let vpk_pattern = Regex::new(r"pak(\d+)_dir\.vpk").unwrap();
+            
+            for entry in fs::read_dir(&mod_folder)? {
+                let entry = entry?;
+                let path = entry.path();
+                
+                if path.is_file() && path.extension().map_or(false, |ext| ext == "vpk") {
+                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                        if let Some(captures) = vpk_pattern.captures(name) {
+                            if let Ok(num) = captures[1].parse::<u32>() {
+                                highest = highest.max(num);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Also check for disabled mods in root addons folder
+        let disabled_pattern = Regex::new(&format!(r"_{}_pak(\d+)_dir\.vpk", regex::escape(&sanitized_name))).unwrap();
+        
+        for entry in fs::read_dir(addons_path)? {
+            let entry = entry?;
+            let path = entry.path();
+            
+            if path.is_file() && path.extension().map_or(false, |ext| ext == "vpk") {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if let Some(captures) = disabled_pattern.captures(name) {
+                        if let Ok(num) = captures[1].parse::<u32>() {
+                            highest = highest.max(num);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Return the next available number (highest + 1)
+        Ok(highest + 1)
+    }
+
+    /// Install a mod to the addons folder (initially disabled)
+    pub fn install_mod(
+        &self,
+        mod_id: &str,
+        mod_name: &str,
+        vpk_paths: &[PathBuf],
+        game_path: &Path,
+    ) -> Result<Vec<String>, Error> {
+        let addons_path = self.get_addons_path(game_path);
+        self.filesystem.create_directories(&addons_path)?;
+
+        let sanitized_name = self.sanitize_name(mod_name);
+        let mut installed_vpks = Vec::new();
+        let mut current_number = self.get_next_vpk_number(&addons_path, mod_name)?;
+
+        // Install VPKs as disabled mods (with _ prefix)
+        for vpk_path in vpk_paths {
+            let disabled_name = format!("_{}_pak{:02}_dir.vpk", sanitized_name, current_number);
+            let disabled_path = addons_path.join(&disabled_name);
+
+            self.filesystem.copy_file(vpk_path, &disabled_path)?;
+            installed_vpks.push(disabled_name.clone());
+
+            log::info!("Installed disabled VPK: {} as {} (pak{:02})", vpk_path.display(), disabled_name, current_number);
+            current_number += 1;
+        }
+
+        // Update mods catalog
+        self.update_mods_catalog(mod_id, mod_name, &installed_vpks, &addons_path, false)?;
+
+        Ok(installed_vpks)
+    }
+
+    /// Activate a mod (move from disabled to active subfolder)
+    pub fn activate_mod(
+        &self,
+        mod_id: &str,
+        mod_name: &str,
+        vpk_names: &[String],
+        game_path: &Path,
+    ) -> Result<(), Error> {
+        let addons_path = self.get_addons_path(game_path);
+        let sanitized_name = self.sanitize_name(mod_name);
+        let mod_folder = addons_path.join(&sanitized_name);
+
+        // Create mod subfolder
+        self.filesystem.create_directories(&mod_folder)?;
+
+        // Move VPKs from disabled to active
+        for vpk_name in vpk_names {
+            let disabled_path = addons_path.join(vpk_name);
+            let clean_name = vpk_name.replace(&format!("_{}_", sanitized_name), "");
+            let active_path = mod_folder.join(&clean_name);
+
+            if disabled_path.exists() {
+                self.filesystem.move_file(&disabled_path, &active_path)?;
+                log::info!("Activated VPK: {} -> {}", vpk_name, clean_name);
+            }
+        }
+
+        // Update manifests
+        self.update_active_mods_manifest(mod_id, mod_name, vpk_names, &addons_path)?;
+        self.update_mods_catalog(mod_id, mod_name, vpk_names, &addons_path, true)?;
+        self.update_gameinfo_gi(game_path)?;
+
+        Ok(())
+    }
+
+    /// Deactivate a mod (move from active subfolder to disabled)
+    pub fn deactivate_mod(
+        &self,
+        mod_id: &str,
+        mod_name: &str,
+        vpk_names: &[String],
+        game_path: &Path,
+    ) -> Result<(), Error> {
+        let addons_path = self.get_addons_path(game_path);
+        let sanitized_name = self.sanitize_name(mod_name);
+        let mod_folder = addons_path.join(&sanitized_name);
+
+        // Move VPKs from active to disabled
+        for vpk_name in vpk_names {
+            let clean_name = vpk_name.replace(&format!("_{}_", sanitized_name), "");
+            let active_path = mod_folder.join(&clean_name);
+            let disabled_name = format!("_{}_{}", sanitized_name, clean_name);
+            let disabled_path = addons_path.join(&disabled_name);
+
+            if active_path.exists() {
+                self.filesystem.move_file(&active_path, &disabled_path)?;
+                log::info!("Deactivated VPK: {} -> {}", clean_name, disabled_name);
+            }
+        }
+
+        // Remove empty mod folder
+        if mod_folder.exists() && fs::read_dir(&mod_folder)?.next().is_none() {
+            self.filesystem.remove_directory(&mod_folder)?;
+        }
+
+        // Update manifests
+        self.remove_from_active_mods_manifest(mod_id, &addons_path)?;
+        self.update_mods_catalog(mod_id, mod_name, vpk_names, &addons_path, false)?;
+        self.update_gameinfo_gi(game_path)?;
+
+        Ok(())
+    }
+
+    /// Remove a mod completely
+    pub fn remove_mod(
+        &self,
+        mod_id: &str,
+        mod_name: &str,
+        vpk_names: &[String],
+        game_path: &Path,
+    ) -> Result<(), Error> {
+        let addons_path = self.get_addons_path(game_path);
+        let sanitized_name = self.sanitize_name(mod_name);
+
+        // Remove all VPK files (both active and disabled)
+        for vpk_name in vpk_names {
+            let vpk_path = addons_path.join(vpk_name);
+            if vpk_path.exists() {
+                self.filesystem.remove_file(&vpk_path)?;
+                log::info!("Removed VPK: {}", vpk_name);
+            }
+        }
+
+        // Remove mod subfolder if it exists
+        let mod_folder = addons_path.join(&sanitized_name);
+        if mod_folder.exists() {
+            self.filesystem.remove_directory(&mod_folder)?;
+        }
+
+        // Update manifests
+        self.remove_from_active_mods_manifest(mod_id, &addons_path)?;
+        self.remove_from_mods_catalog(mod_id, &addons_path)?;
+        self.update_gameinfo_gi(game_path)?;
+
+        Ok(())
+    }
+
+    /// Update the active mods manifest
+    fn update_active_mods_manifest(
+        &self,
+        mod_id: &str,
+        mod_name: &str,
+        vpk_names: &[String],
+        addons_path: &Path,
+    ) -> Result<(), Error> {
+        let manifest_path = addons_path.join("active_mods.json");
+        let mut manifest = if manifest_path.exists() {
+            let content = fs::read_to_string(&manifest_path)?;
+            serde_json::from_str::<ActiveModsManifest>(&content).unwrap_or_else(|_| ActiveModsManifest {
+                active_mods: Vec::new(),
+                last_updated: chrono::Utc::now().to_rfc3339(),
+            })
+        } else {
+            ActiveModsManifest {
+                active_mods: Vec::new(),
+                last_updated: chrono::Utc::now().to_rfc3339(),
+            }
+        };
+
+        // Remove existing entry if it exists
+        manifest.active_mods.retain(|m| m.id != mod_id);
+
+        // Add new entry
+        let clean_vpks: Vec<String> = vpk_names
+            .iter()
+            .map(|name| name.replace(&format!("_{}_", self.sanitize_name(mod_name)), ""))
+            .collect();
+
+        manifest.active_mods.push(ActiveMod {
+            id: mod_id.to_string(),
+            name: mod_name.to_string(),
+            vpks: clean_vpks,
+            folder_name: self.sanitize_name(mod_name),
+        });
+
+        manifest.last_updated = chrono::Utc::now().to_rfc3339();
+
+        let content = serde_json::to_string_pretty(&manifest)?;
+        fs::write(&manifest_path, content)?;
+
+        Ok(())
+    }
+
+    /// Remove mod from active mods manifest
+    fn remove_from_active_mods_manifest(&self, mod_id: &str, addons_path: &Path) -> Result<(), Error> {
+        let manifest_path = addons_path.join("active_mods.json");
+        if !manifest_path.exists() {
+            return Ok(());
+        }
+
+        let content = fs::read_to_string(&manifest_path)?;
+        let mut manifest = serde_json::from_str::<ActiveModsManifest>(&content)?;
+
+        manifest.active_mods.retain(|m| m.id != mod_id);
+        manifest.last_updated = chrono::Utc::now().to_rfc3339();
+
+        let content = serde_json::to_string_pretty(&manifest)?;
+        fs::write(&manifest_path, content)?;
+
+        Ok(())
+    }
+
+    /// Update the mods catalog
+    fn update_mods_catalog(
+        &self,
+        mod_id: &str,
+        mod_name: &str,
+        vpk_names: &[String],
+        addons_path: &Path,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        let catalog_path = addons_path.join("mods_catalog.json");
+        let mut catalog = if catalog_path.exists() {
+            let content = fs::read_to_string(&catalog_path)?;
+            serde_json::from_str::<ModsCatalog>(&content).unwrap_or_else(|_| ModsCatalog {
+                mods: HashMap::new(),
+                last_updated: chrono::Utc::now().to_rfc3339(),
+            })
+        } else {
+            ModsCatalog {
+                mods: HashMap::new(),
+                last_updated: chrono::Utc::now().to_rfc3339(),
+            }
+        };
+
+        catalog.mods.insert(mod_id.to_string(), ModCatalogEntry {
+            id: mod_id.to_string(),
+            name: mod_name.to_string(),
+            folder_name: self.sanitize_name(mod_name),
+            vpks: vpk_names.to_vec(),
+            installed_at: chrono::Utc::now().to_rfc3339(),
+            enabled,
+        });
+
+        catalog.last_updated = chrono::Utc::now().to_rfc3339();
+
+        let content = serde_json::to_string_pretty(&catalog)?;
+        fs::write(&catalog_path, content)?;
+
+        Ok(())
+    }
+
+    /// Remove mod from mods catalog
+    fn remove_from_mods_catalog(&self, mod_id: &str, addons_path: &Path) -> Result<(), Error> {
+        let catalog_path = addons_path.join("mods_catalog.json");
+        if !catalog_path.exists() {
+            return Ok(());
+        }
+
+        let content = fs::read_to_string(&catalog_path)?;
+        let mut catalog = serde_json::from_str::<ModsCatalog>(&content)?;
+
+        catalog.mods.remove(mod_id);
+        catalog.last_updated = chrono::Utc::now().to_rfc3339();
+
+        let content = serde_json::to_string_pretty(&catalog)?;
+        fs::write(&catalog_path, content)?;
+
+        Ok(())
+    }
+
+    /// Update gameinfo.gi with active mod search paths
+    fn update_gameinfo_gi(&self, game_path: &Path) -> Result<(), Error> {
+        let gameinfo_path = game_path.join("game").join("citadel").join("gameinfo.gi");
+        if !gameinfo_path.exists() {
+            log::warn!("gameinfo.gi not found at: {:?}", gameinfo_path);
+            return Ok(());
+        }
+
+        // Read current gameinfo.gi
+        let content = fs::read_to_string(&gameinfo_path)?;
+        
+        // Read active mods manifest
+        let addons_path = self.get_addons_path(game_path);
+        let manifest_path = addons_path.join("active_mods.json");
+        let active_mods = if manifest_path.exists() {
+            let manifest_content = fs::read_to_string(&manifest_path)?;
+            let manifest: ActiveModsManifest = serde_json::from_str(&manifest_content)?;
+            manifest.active_mods
+        } else {
+            Vec::new()
+        };
+
+        // Generate new search paths
+        let mut search_paths = Vec::new();
+        
+        // Add active mod paths
+        for active_mod in &active_mods {
+            search_paths.push(format!("    Game    citadel/addons/{}", active_mod.folder_name));
+        }
+        
+        // Add base addons path
+        search_paths.push("    Game    citadel/addons".to_string());
+        search_paths.push("    Game    citadel/maps".to_string());
+
+        // Update gameinfo.gi content
+        let updated_content = self.update_gameinfo_search_paths(&content, &search_paths)?;
+        
+        // Write back to file
+        fs::write(&gameinfo_path, updated_content)?;
+        
+        log::info!("Updated gameinfo.gi with {} active mod search paths", active_mods.len());
+        Ok(())
+    }
+
+    /// Update search paths in gameinfo.gi content
+    fn update_gameinfo_search_paths(&self, content: &str, search_paths: &[String]) -> Result<String, Error> {
+        let search_paths_section = format!("SearchPaths\n{{\n{}\n}}", search_paths.join("\n"));
+        
+        // Find and replace the SearchPaths section
+        let pattern = Regex::new(r"SearchPaths\s*\{[^}]*\}").unwrap();
+        let updated_content = if pattern.is_match(content) {
+            pattern.replace(content, &search_paths_section).to_string()
+        } else {
+            // If no SearchPaths section found, add it after the first {
+            let first_brace = content.find('{').ok_or_else(|| Error::InvalidGameInfo)?;
+            let mut result = content.to_string();
+            result.insert_str(first_brace + 1, &format!("\n{}\n", search_paths_section));
+            result
+        };
+
+        Ok(updated_content)
+    }
+
+    /// Get all installed mods (both active and disabled)
+    pub fn get_installed_mods(&self, game_path: &Path) -> Result<Vec<ModCatalogEntry>, Error> {
+        let addons_path = self.get_addons_path(game_path);
+        let catalog_path = addons_path.join("mods_catalog.json");
+        
+        if !catalog_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let content = fs::read_to_string(&catalog_path)?;
+        let catalog: ModsCatalog = serde_json::from_str(&content)?;
+        
+        Ok(catalog.mods.values().cloned().collect())
+    }
+
+    /// Get active mods
+    pub fn get_active_mods(&self, game_path: &Path) -> Result<Vec<ActiveMod>, Error> {
+        let addons_path = self.get_addons_path(game_path);
+        let manifest_path = addons_path.join("active_mods.json");
+        
+        if !manifest_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let content = fs::read_to_string(&manifest_path)?;
+        let manifest: ActiveModsManifest = serde_json::from_str(&content)?;
+        
+        Ok(manifest.active_mods)
+    }
+}
+
+impl Default for AddonsManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/apps/desktop/src-tauri/src/mod_manager/filesystem_helper.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/filesystem_helper.rs
@@ -55,6 +55,26 @@ impl FileSystemHelper {
     Ok(())
   }
 
+  /// Move a file from source to destination
+  pub fn move_file(&self, src: &Path, dest: &Path) -> Result<(), Error> {
+    if let Some(parent) = dest.parent() {
+      self.create_directories(parent)?;
+    }
+
+    log::debug!("Moving file from {:?} to {:?}", src, dest);
+    fs::rename(src, dest)?;
+    Ok(())
+  }
+
+  /// Remove a single directory (must be empty)
+  pub fn remove_directory(&self, path: &Path) -> Result<(), Error> {
+    if path.exists() {
+      log::info!("Removing directory: {:?}", path);
+      fs::remove_dir(path)?;
+    }
+    Ok(())
+  }
+
   /// Check if path exists
   pub fn path_exists(&self, path: &Path) -> bool {
     path.exists()

--- a/apps/desktop/src-tauri/src/mod_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod.rs
@@ -1,4 +1,5 @@
 // Module declarations
+pub mod addons_manager;
 pub mod archive_extractor;
 pub mod file_tree;
 pub mod filesystem_helper;

--- a/apps/desktop/src/hooks/use-deep-link.ts
+++ b/apps/desktop/src/hooks/use-deep-link.ts
@@ -216,8 +216,8 @@ export const useDeepLink = () => {
                         );
                       },
                       onComplete: (mod, result) => {
-                        setModStatus(mod.remoteId, ModStatus.Installed);
                         setInstalledVpks(mod.remoteId, result.installed_vpks);
+                        setModStatus(mod.remoteId, ModStatus.Installed);
                         toast.success(
                           `${mod.name} installed successfully via 1-click!`
                         );

--- a/apps/desktop/src/hooks/use-install-with-collection.ts
+++ b/apps/desktop/src/hooks/use-install-with-collection.ts
@@ -65,6 +65,7 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
         file_tree: fileTree,
       };
 
+      // Install the mod as disabled (this will create the _ModName_pak01_dir.vpk files)
       const result = (await invoke('install_mod', {
         deadlockMod: {
           id: modData.remoteId,

--- a/apps/desktop/src/hooks/use-install.ts
+++ b/apps/desktop/src/hooks/use-install.ts
@@ -27,6 +27,7 @@ const useInstall = () => {
         throw new Error('Mod is already installed!');
       }
 
+      // Install the mod as disabled (this will create the _ModName_pak01_dir.vpk files)
       const result = (await invoke('install_mod', {
         deadlockMod: {
           id: mod.remoteId,

--- a/apps/desktop/src/hooks/use-uninstall.ts
+++ b/apps/desktop/src/hooks/use-uninstall.ts
@@ -41,8 +41,10 @@ const useUninstall = () => {
             vpks: mod.installedVpks ?? [],
           });
         } else {
-          await invoke('uninstall_mod', {
+          // Deactivate the mod (move back to disabled state with _ prefix)
+          await invoke('deactivate_mod', {
             modId: mod.remoteId,
+            modName: mod.name,
             vpks: mod.installedVpks ?? [],
           });
         }

--- a/apps/desktop/src/lib/state-machines/mod-status.ts
+++ b/apps/desktop/src/lib/state-machines/mod-status.ts
@@ -17,7 +17,7 @@ type StateTransitionError = {
 const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
   [ModStatus.Downloading]: [ModStatus.Downloaded, ModStatus.FailedToDownload],
   [ModStatus.Downloaded]: [ModStatus.Installing, ModStatus.Removing],
-  [ModStatus.Installing]: [ModStatus.Installed, ModStatus.FailedToInstall],
+  [ModStatus.Installing]: [ModStatus.Installed, ModStatus.Downloaded, ModStatus.FailedToInstall],
   [ModStatus.Installed]: [ModStatus.Removing, ModStatus.Downloaded],
   [ModStatus.Removing]: [ModStatus.Removed, ModStatus.FailedToRemove],
   [ModStatus.Removed]: [ModStatus.Error],

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -135,7 +135,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     set((state) => ({
       localMods: state.localMods.map((mod) => ({
         ...mod,
-        status: mod.remoteId === remoteId ? ModStatus.Installed : mod.status,
+        // Don't automatically change status - let other functions manage status
         installedVpks: mod.remoteId === remoteId ? vpks : mod.installedVpks,
         installedFileTree:
           mod.remoteId === remoteId ? fileTree : mod.installedFileTree,


### PR DESCRIPTION
This PR implements a new addons-based mod management system that replaces the current localappdata caching approach with direct management in the game's addons folder.

## Key Features:
- **Direct Addons Management**: Mods managed directly in `game/citadel/addons/`
- **Smart Mod Grouping**: Mods with same name automatically group together  
- **Automatic Pak Numbering**: Sequential pak01, pak02, pak03 for grouped mods
- **Disabled State First**: Mods install as disabled and require manual activation
- **Dynamic gameinfo.gi Updates**: Search paths automatically updated

## How It Works:
1. **Download** → Mod appears as disabled (no checkmark)
2. **Install** → VPKs placed as `_ModName_pak##_dir.vpk` in addons root
3. **Activate** → VPKs move to `ModName/` subfolder with clean names
4. **Deactivate** → VPKs move back to prefixed names in addons root

## Example:
game/citadel/addons/
├── SOMA_s_HUD_pak01_dir.vpk (disabled)
├── SOMA_s_HUD_pak02_dir.vpk (disabled)
└── SOMA_s_HUD/ (when activated)
├── pak01_dir.vpk
└── pak02_dir.vpk