### PR TITLE
ci: fix aur-git action

### DIFF
--- a/.github/workflows/aur-git.yml
+++ b/.github/workflows/aur-git.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Get new pkgver
         id: get_version


### PR DESCRIPTION
- update pkgver & reset pkgrel to 1

## Description

Fixes the aur-git action to correctly update the pkgver and reset pkgrel to 1 whenever pkgver is updated

## Type of Change

CI fix

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

tested with act locally

## Additional Notes

pkgrel should only increment when pkgver is the same but something changed with the packaging/PKGBUILD itself, if pkgver is updated pkgrel should always go back to 1.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions
