### PR TITLE
docs: fix repository name references in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Before you begin, ensure you have the following installed:
 2. **Clone your fork** locally:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/deadlock-modmanager.git
-   cd deadlock-modmanager
+   git clone https://github.com/YOUR_USERNAME/deadlock-mod-manager.git
+   cd deadlock-mod-manager
    ```
 
 3. **Install dependencies**:
@@ -114,7 +114,7 @@ pnpm db:seed
 This is a monorepo organized as follows:
 
 ```
-deadlock-modmanager/
+deadlock-mod-manager/
 ├── apps/
 │   ├── api/          # Backend API (Bun + Hono)
 │   ├── desktop/      # Main desktop app (Tauri + React)


### PR DESCRIPTION
## Description
Fixed incorrect repository name references in CONTRIBUTING.md. The repository name was listed as `deadlock-modmanager` in clone commands and file paths, but the correct name is `deadlock-mod-manager` (with hyphen).

### Changes Made
- Updated git clone command to use correct repository name
- Fixed directory name in cd command
- Corrected project structure diagram to show proper repository name

## Type of Change
- [x] 📚 Documentation update

## Related Issues
N/A - Documentation correction

## Testing
- [x] I have tested these changes locally
- [x] I have verified the correct repository name
- [x] My changes generate no new warnings or errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings

## Additional Notes
This fixes a copy-paste error that would cause new contributors to fail when following the setup instructions. The incorrect repository name (`deadlock-modmanager`) would result in a 404 error when attempting to clone. The correct repository name is `deadlock-mod-manager` (with hyphen between "mod" and "manager").

**Files changed:** CONTRIBUTING.md (3 additions, 3 deletions)

## For Maintainers
- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the contributing guide to use the correct repository name, replacing outdated slug references in the Quick Start clone commands and monorepo structure examples.
  * Fixed clone URLs and directory paths to prevent setup errors and ensure consistency for new contributors.
  * No functional or behavioral changes; documentation text only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->