### PR TITLE
Fix(DOCS/API) Change openapi url to new domain.

### DIFF
--- a/apps/api/src/handlers/api.ts
+++ b/apps/api/src/handlers/api.ts
@@ -25,6 +25,16 @@ export const apiHandler = new OpenAPIHandler(appRouter, {
   plugins: [
     new OpenAPIReferencePlugin({
       schemaConverters: [new ZodToJsonSchemaConverter()],
+      specGenerateOptions: {
+        servers: [
+          {
+            url: "https://api.deadlockmods.app/api"
+          },
+          {
+            url: "http://localhost:9000/api"
+          },
+        ],
+      },
     }),
   ],
   interceptors: [

--- a/apps/api/src/routers/legacy/docs.ts
+++ b/apps/api/src/routers/legacy/docs.ts
@@ -19,7 +19,7 @@ docsRouter.get("/openapi.json", async (c) => {
     },
     servers: [
       {
-        url: "https://api.deadlock-mods.com/api",
+        url: "https://api.deadlockmods.app/api",
         description: "Production server",
       },
       {


### PR DESCRIPTION
## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

In both https://api.deadlockmods.app/api and https://docs.deadlockmods.app/api they both display the wrong URL, with neither able to be used because of it.

<img width="861" height="40" alt="image" src="https://github.com/user-attachments/assets/22848e8f-1632-4251-8874-755de5428489" />
<img width="734" height="319" alt="image" src="https://github.com/user-attachments/assets/2fd77800-773d-4116-ae24-30cc5fc2da30" />



## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [x] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API server configuration to use the api.deadlockmods.app domain in documentation
  * Added local development server endpoint to API specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->