### PR TITLE
fix(desktop): correct stop game button when game is not running

### DIFF
--- a/.changeset/calm-wolves-glow.md
+++ b/.changeset/calm-wolves-glow.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix "Stop Game" button incorrectly showing when the game is not running

--- a/apps/desktop/src-tauri/src/mod_manager/game_process_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/game_process_manager.rs
@@ -1,3 +1,6 @@
+use std::thread;
+use std::time::Duration;
+
 use crate::errors::Error;
 use log;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
@@ -70,6 +73,14 @@ impl GameProcessManager {
 
     if stopped_count > 0 {
       log::info!("Stopped {stopped_count} game process(es)");
+      // Wait for the OS to fully reap the killed processes before returning,
+      // so the next is_game_running() call won't see stale entries.
+      thread::sleep(Duration::from_millis(500));
+      self.system.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::everything(),
+      );
       Ok(())
     } else {
       Err(Error::GameNotRunning)

--- a/apps/desktop/src/components/layout/toolbar.tsx
+++ b/apps/desktop/src/components/layout/toolbar.tsx
@@ -37,6 +37,7 @@ export const Toolbar = () => {
     queryFn: () => isGameRunning(),
     staleTime: STALE_TIME_POLL,
     refetchInterval: 5000,
+    enabled: !!gamePath,
   });
 
   return (
@@ -90,7 +91,7 @@ export const Toolbar = () => {
           disabled={!gamePath}
           onClick={() => {
             if (isRunning) {
-              invoke("stop_game").then(() => refetch());
+              invoke("stop_game").finally(() => refetch());
             } else {
               setModdedAnimating(true);
               launch();

--- a/apps/desktop/src/hooks/use-launch.ts
+++ b/apps/desktop/src/hooks/use-launch.ts
@@ -1,4 +1,5 @@
 import { toast } from "@deadlock-mods/ui/components/sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
@@ -7,6 +8,7 @@ import type { ErrorKind } from "@/types/tauri";
 
 export const useLaunch = () => {
   const { settings, getActiveProfile } = usePersistedStore();
+  const queryClient = useQueryClient();
   const launchVanillaNoArgs =
     settings?.["launch-vanilla-no-args"]?.enabled ?? false;
 
@@ -27,6 +29,10 @@ export const useLaunch = () => {
             ? ""
             : await getAdditionalArgs(Object.values(settings)),
         profileFolder,
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: ["is-game-running"],
       });
     } catch (error) {
       logger.errorOnly(


### PR DESCRIPTION
Gate is-game-running polling on gamePath, invalidate after launch, refresh process list after stop, and refetch on stop_game failure.

Closes #282

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [ ] My code follows the style guidelines of this project (`pnpm lint` passes)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for "Stop Game" button state issue

**Affected package:** `@deadlock-mods/desktop` (patch release)

**Functional changes:**

1. **Game-running state polling gating** (`toolbar.tsx`): The `is-game-running` React Query is now only executed when `gamePath` is populated, preventing unnecessary polling when no game path is configured.

2. **Post-launch state invalidation** (`use-launch.ts`): After successfully launching the game via Tauri, the `is-game-running` cached query is explicitly invalidated to refresh the button state immediately.

3. **Post-stop process refresh** (`game_process_manager.rs`): Added a 500ms delay and immediate `sysinfo` process refresh after successfully stopping game processes, ensuring subsequent `is_game_running()` checks read up-to-date process entries rather than stale OS-level state.

4. **Refetch on stop failure** (`toolbar.tsx`): The stop_game invocation now refetches the `is-game-running` state on both success and failure, ensuring button state is updated even if the stop command fails.

These changes work together to keep the "Stop Game" button state synchronized with the actual game process state across launch, stop, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->