### PR TITLE
fix(desktop): resolve install hang on file selector dialog exit

### DIFF
--- a/.changeset/eleven-things-wait.md
+++ b/.changeset/eleven-things-wait.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fixed installation hang if user exits the install popup.

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -107,7 +107,6 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     isAnalyzing,
     currentFileTree,
     showFileSelector,
-    setShowFileSelector,
     confirmInstallation,
     cancelInstallation,
     currentMod,
@@ -163,7 +162,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
               });
             },
             onError: (mod, error) => {
-              setModStatus(mod.remoteId, ModStatus.FailedToInstall);
+              setModStatus(mod.remoteId, ModStatus.Downloaded);
               toast.error(
                 error.message || t("notifications.failedToInstallMod"),
               );
@@ -354,7 +353,11 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         modName={currentMod?.name}
         onCancel={cancelInstallation}
         onConfirm={confirmInstallation}
-        onOpenChange={setShowFileSelector}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelInstallation();
+          }
+        }}
       />
 
       <MultiFileDownloadDialog

--- a/apps/desktop/src/components/mod-management/install-with-collection.tsx
+++ b/apps/desktop/src/components/mod-management/install-with-collection.tsx
@@ -18,7 +18,6 @@ export const InstallWithCollection: React.FC<InstallWithCollectionProps> = ({
     isAnalyzing,
     currentFileTree,
     showFileSelector,
-    setShowFileSelector,
     confirmInstallation,
     cancelInstallation,
     currentMod,
@@ -34,7 +33,11 @@ export const InstallWithCollection: React.FC<InstallWithCollectionProps> = ({
         modName={currentMod?.name}
         onCancel={cancelInstallation}
         onConfirm={confirmInstallation}
-        onOpenChange={setShowFileSelector}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelInstallation();
+          }
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Description

Fixes an issue where if you X out of the install file selector it will the state of the mod will hang forever.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## AI Disclosure

- [ ] No significant AI assistance used
- [X] AI-assisted — Tool: claude, Used for: verifying my code is fine.

## Testing

- [X] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Checklist

- [X] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [X] My code follows the style guidelines of this project (`pnpm lint` passes)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [X] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes an issue where closing the install file selector caused the mod state to hang indefinitely.

## Affected Packages
- `@deadlock-mods/desktop` (patch release)

## Functional Changes

**Installation State Management**
- Replaced direct `setShowFileSelector` binding with a `cancelInstallation()` callback in the `FileSelectorDialog` component to properly clean up installation state when the file selector is closed
- Updated install error handling to set mod status to `ModStatus.Downloaded` instead of `ModStatus.FailedToInstall` when installation fails

**Files Modified**
- `apps/desktop/src/components/mod-browsing/mod-button.tsx`
- `apps/desktop/src/components/mod-management/install-with-collection.tsx`

This is a localized bug fix with no cross-package dependencies, database changes, or platform-level modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->