### PR TITLE
feat(reports): disable report submissions for specific mods

### DIFF
--- a/.changeset/quiet-foxes-march.md
+++ b/.changeset/quiet-foxes-march.md
@@ -1,0 +1,7 @@
+---
+"@deadlock-mods/api": minor
+"@deadlock-mods/desktop": minor
+"@deadlock-mods/shared": minor
+---
+
+Add ability to disable mod report submissions for specific mods

--- a/apps/api/src/routers/v2/reports.ts
+++ b/apps/api/src/routers/v2/reports.ts
@@ -1,5 +1,9 @@
 import { db, ModRepository, ReportRepository } from "@deadlock-mods/database";
-import { toReportDto, toReportWithModDto } from "@deadlock-mods/shared";
+import {
+  REPORT_DISABLED_MOD_IDS,
+  toReportDto,
+  toReportWithModDto,
+} from "@deadlock-mods/shared";
 import { ORPCError } from "@orpc/server";
 import { CACHE_TTL } from "@/lib/constants";
 import { logger } from "@/lib/logger";
@@ -44,6 +48,17 @@ export const reportsRouter = {
           throw new ORPCError("NOT_FOUND", {
             message: "Mod not found",
           });
+        }
+
+        if (REPORT_DISABLED_MOD_IDS.has(mod.remoteId)) {
+          logger
+            .withMetadata({ modId: input.modId, remoteId: mod.remoteId })
+            .warn("Report submission blocked for disabled mod");
+          return {
+            id: "",
+            status: "error" as const,
+            error: "Reports are disabled for this mod",
+          };
         }
 
         // Check for duplicate reports from same reporter

--- a/apps/desktop/src/components/reports/report-button.tsx
+++ b/apps/desktop/src/components/reports/report-button.tsx
@@ -1,4 +1,5 @@
 import type { ModDto } from "@deadlock-mods/shared";
+import { REPORT_DISABLED_MOD_IDS } from "@deadlock-mods/shared";
 import { Button } from "@deadlock-mods/ui/components/button";
 import { Flag } from "@deadlock-mods/ui/icons";
 import { useState } from "react";
@@ -13,8 +14,12 @@ export const ReportButton = ({ mod }: ReportButtonProps) => {
   const { t } = useTranslation();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
+  if (REPORT_DISABLED_MOD_IDS.has(mod.remoteId)) {
+    return null;
+  }
+
   const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent card navigation
+    e.stopPropagation();
     setIsDialogOpen(true);
   };
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -47,6 +47,12 @@ export const DeadlockHeroesByAlias = Object.keys(DeadlockHeroes).reduce(
   {},
 );
 
+/**
+ * Mod remote IDs (GameBanana) for which report submissions are disabled.
+ * Reports cannot be created for these mods via the API or desktop UI.
+ */
+export const REPORT_DISABLED_MOD_IDS: ReadonlySet<string> = new Set(["650634"]);
+
 export enum CustomSettingType {
   LAUNCH_OPTION = "launch_option",
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add the ability to disable report submissions for certain mods. A shared `REPORT_DISABLED_MOD_IDS` constant (currently hardcoded with mod remote ID `650634`) is checked both server-side (API rejects with an error response) and client-side (report button is hidden in the desktop UI).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes DMM-41

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Cursor Cloud Agent, Used for: implementation of the feature

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Changes span three packages:
- **`packages/shared`** - Added `REPORT_DISABLED_MOD_IDS` constant (`ReadonlySet<string>`) with `"650634"` hardcoded
- **`apps/api`** - `createReport` handler checks the mod's `remoteId` against the set after verifying the mod exists; returns an error response if disabled
- **`apps/desktop`** - `ReportButton` component returns `null` for disabled mods, hiding the report UI entirely

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DMM-41](https://linear.app/deadlock-mod-manager/issue/DMM-41/add-the-ability-to-disable-reports-for-certain-mods)

<div><a href="https://cursor.com/agents/bc-e88dbc9b-a605-4bf7-8b76-647d00d50f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e88dbc9b-a605-4bf7-8b76-647d00d50f84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces the ability to disable report submissions for specific mods through a new shared constant, with enforcement at both the API and desktop application layers.

## Affected Packages
- `@deadlock-mods/shared` — New constant
- `@deadlock-mods/api` — Report submission validation
- `@deadlock-mods/desktop` — Report UI visibility

## Changes

### packages/shared
Added new exported constant `REPORT_DISABLED_MOD_IDS` as a `ReadonlySet<string>` containing hardcoded GameBanana mod ID `"650634"`. This constant serves as a shared source of truth for report disabling across packages.

### apps/api
The `createReport` handler now imports and checks `REPORT_DISABLED_MOD_IDS` after confirming the mod exists. If the mod's `remoteId` is in the disabled set, the handler returns an error response (`status: "error"`, `error: "Reports are disabled for this mod"`) without creating the report or publishing the new-report event.

### apps/desktop
The `ReportButton` component now imports `REPORT_DISABLED_MOD_IDS` and returns `null` if the mod's `remoteId` is disabled, preventing the report button and dialog from rendering.

## Cross-Package Dependencies
New dependency flow: `shared` → `api` and `shared` → `desktop` (both consume `REPORT_DISABLED_MOD_IDS`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->