### PR TITLE
feat(desktop): add tooltips to collapsed sidebar icons

### DIFF
--- a/.changeset/gentle-foxes-hover.md
+++ b/.changeset/gentle-foxes-hover.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Add tooltips to collapsed sidebar icons showing the navigation label on hover

--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -47,6 +47,7 @@ type SidebarItem = {
     count?: number;
     downloads?: number;
   }) => React.ReactNode;
+  tooltipLabel: string;
   url: string;
   dialog?: React.ComponentType;
   icon?: Icon;
@@ -64,6 +65,7 @@ const getSidebarItems = (
     {
       id: "dashboard",
       title: () => <span>{t("navigation.dashboard")}</span>,
+      tooltipLabel: t("navigation.dashboard"),
       url: "/",
       icon: HouseIcon,
       group: "general",
@@ -82,6 +84,7 @@ const getSidebarItems = (
           )}
         </div>
       ),
+      tooltipLabel: t("navigation.myMods"),
       url: "/my-mods",
       icon: PackageIcon,
       group: "mods",
@@ -89,6 +92,7 @@ const getSidebarItems = (
     {
       id: "get-mods",
       title: () => <span>{t("navigation.getMods")}</span>,
+      tooltipLabel: t("navigation.getMods"),
       url: "/mods",
       icon: MagnifyingGlassIcon,
       group: "mods",
@@ -103,6 +107,7 @@ const getSidebarItems = (
           )}
         </div>
       ),
+      tooltipLabel: t("navigation.downloads"),
       url: "/downloads",
       icon: DownloadIcon,
       group: "general",
@@ -110,6 +115,7 @@ const getSidebarItems = (
     {
       id: "crosshairs",
       title: () => <span>{t("navigation.crosshairs")}</span>,
+      tooltipLabel: t("navigation.crosshairs"),
       url: "/crosshairs",
       icon: CrosshairIcon,
       group: t("navigation.customization"),
@@ -117,6 +123,7 @@ const getSidebarItems = (
     {
       id: "autoexec",
       title: () => <span>{t("navigation.autoexec")}</span>,
+      tooltipLabel: t("navigation.autoexec"),
       url: "/settings/autoexec",
       icon: ArticleIcon,
       group: t("navigation.customization"),
@@ -124,6 +131,7 @@ const getSidebarItems = (
     {
       id: "settings",
       title: () => <span>{t("navigation.settings")}</span>,
+      tooltipLabel: t("navigation.settings"),
       url: "/settings",
       icon: GearIcon,
       group: "general",
@@ -133,6 +141,7 @@ const getSidebarItems = (
           {
             id: "developer",
             title: () => <span>{t("navigation.developer")}</span>,
+            tooltipLabel: t("navigation.developer"),
             url: "/developer",
             icon: CodeIcon,
             group: "Developer",
@@ -145,6 +154,7 @@ const getSidebarItems = (
           {
             id: "debug",
             title: () => <span>Debug</span>,
+            tooltipLabel: "Debug",
             url: "/debug",
             icon: BugBeetleIcon,
             bottom: true,
@@ -187,7 +197,8 @@ const SidebarItemComponent = ({ item, location, mods }: SidebarItemProps) => {
         <DialogTrigger asChild>
           <SidebarMenuButton
             className='cursor-pointer'
-            isActive={location.pathname === item.url}>
+            isActive={location.pathname === item.url}
+            tooltip={item.tooltipLabel}>
             {renderIcon(item)}
             {item.title({
               isActive: location.pathname === item.url,
@@ -208,7 +219,10 @@ const SidebarItemComponent = ({ item, location, mods }: SidebarItemProps) => {
   }
 
   return (
-    <SidebarMenuButton asChild isActive={location.pathname === item.url}>
+    <SidebarMenuButton
+      asChild
+      isActive={location.pathname === item.url}
+      tooltip={item.tooltipLabel}>
       <Link to={item.url} draggable='false'>
         {renderIcon(item)}
         {item.title({
@@ -315,7 +329,8 @@ export const AppSidebar = () => {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   className='cursor-pointer'
-                  onClick={() => openUrl("https://docs.deadlockmods.app/")}>
+                  onClick={() => openUrl("https://docs.deadlockmods.app/")}
+                  tooltip={t("help.documentation")}>
                   <QuestionIcon weight='duotone' />
                   <span>{t("help.documentation")}</span>
                 </SidebarMenuButton>
@@ -323,7 +338,8 @@ export const AppSidebar = () => {
               <SidebarMenuItem>
                 <SidebarMenuButton
                   className='cursor-pointer'
-                  onClick={() => openUrl(DISCORD_URL)}>
+                  onClick={() => openUrl(DISCORD_URL)}
+                  tooltip={t("help.needHelp")}>
                   <DiscordLogoIcon weight='duotone' />
                   <span>{t("help.needHelp")}</span>
                 </SidebarMenuButton>

--- a/apps/desktop/src/components/layout/sidebar-collapse.tsx
+++ b/apps/desktop/src/components/layout/sidebar-collapse.tsx
@@ -12,7 +12,9 @@ export const SidebarCollapse = () => {
   const { toggleSidebar, open } = useSidebar();
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton onClick={toggleSidebar}>
+      <SidebarMenuButton
+        onClick={toggleSidebar}
+        tooltip={t(open ? "navigation.collapseMenu" : "navigation.expandMenu")}>
         <ArrowLineLeftIcon
           className={cn(
             "transition-all duration-150 ease-linear",

--- a/apps/desktop/src/locales/en/translation.json
+++ b/apps/desktop/src/locales/en/translation.json
@@ -10,6 +10,7 @@
     "whatsNew": "What's New",
     "needHelp": "Need Help ?",
     "collapseMenu": "Collapse menu",
+    "expandMenu": "Expand menu",
     "about": "About",
     "crosshairs": "Crosshairs",
     "customization": "Customization",

--- a/apps/desktop/src/locales/template/template.json
+++ b/apps/desktop/src/locales/template/template.json
@@ -8,6 +8,7 @@
     "whatsNew": "",
     "needHelp": "",
     "collapseMenu": "",
+    "expandMenu": "",
     "about": ""
   },
   "menu": {

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -128,7 +128,7 @@ const SidebarProvider = React.forwardRef<
 
     return (
       <SidebarContext.Provider value={contextValue}>
-        <TooltipProvider delayDuration={0}>
+        <TooltipProvider delayDuration={300}>
           <div
             className={cn(
               "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

When the sidebar is collapsed to icon-only mode, hovering over any navigation icon now shows a tooltip with the item's label. This leverages the existing `tooltip` prop on `SidebarMenuButton` that was already built into the UI primitives but not yet wired up in the desktop app.

A 300ms hover delay prevents tooltip flashing when moving the cursor across icons quickly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes DMM-25

## AI Disclosure

- [x] AI-assisted — Tool: Cursor Agent (Claude), Used for: full implementation

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

### Changes made:

- **`app-sidebar.tsx`**: Added `tooltipLabel` field to the `SidebarItem` type and populated it for all navigation items using their i18n keys. Passed `tooltip={item.tooltipLabel}` to `SidebarMenuButton` in both dialog and link render paths. Also added tooltips to footer items (Documentation, Discord).
- **`sidebar-collapse.tsx`**: Added tooltip to the collapse/expand button. Shows "Expand menu" when collapsed and "Collapse menu" when expanded.
- **`packages/ui/src/components/sidebar.tsx`**: Changed `TooltipProvider delayDuration` from `0` to `300` ms for a better hover experience.
- **`en/translation.json`** and **`template/template.json`**: Added `navigation.expandMenu` i18n key.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DMM-25](https://linear.app/deadlock-mod-manager/issue/DMM-25/collapsed-sidebar-icons-should-have-a-tooltip-with-delay)

<div><a href="https://cursor.com/agents/bc-8342d6dc-4bb9-4142-8aab-34892051035d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8342d6dc-4bb9-4142-8aab-34892051035d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tooltips for Collapsed Sidebar Icons

This PR adds tooltips to navigation icons in the desktop application's collapsed sidebar. When hovering over a collapsed sidebar icon, a tooltip displays the item's label to improve discoverability.

### Functional Changes

**Desktop App** (`apps/desktop`):
- Sidebar navigation and footer items now display tooltips when hovered in collapsed mode
- The sidebar collapse/expand button shows context-aware tooltips: "Expand menu" when collapsed and "Collapse menu" when expanded
- Added `tooltipLabel` field to the `SidebarItem` type, populated with translated strings for each navigation item
- Tooltips passed to `SidebarMenuButton` component for both dialog-trigger and link rendering paths

**UI Package** (`packages/ui`):
- Updated `TooltipProvider` to use a 300ms delay duration instead of 0ms, preventing tooltip flashing when quickly moving the cursor across icons

**Localization**:
- Added `navigation.expandMenu` translation key to support the collapse/expand button tooltip

### Implementation Notes

The tooltip feature leverages the existing `tooltip` prop on the `SidebarMenuButton` UI component that was already present in the primitives. The 300ms delay is applied at the provider level to affect all tooltips within the sidebar context.

This is a purely UI-focused enhancement with no database changes, Tauri plugin modifications, or Rust FFI boundary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->