### PR TITLE
Refactor/UI

### DIFF
--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -49,8 +49,9 @@ interface Item {
   isFooter?: boolean;
   tooltipLabel?: string;
   isDev?: boolean;
-  isVisible?: (isVisible: boolean) => boolean;
+  isVisible?: (isVisible: boolean) => boolean | boolean;
 }
+
 type Groups = "general" | "mods" | "customization" | "developer";
 
 const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
@@ -67,6 +68,7 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     title: t("navigation.downloads"),
     url: "/downloads",
     icon: DownloadIcon,
+    tooltipLabel: t("navigation.downloads"),
     group: "general",
     badge:
       badgeContext?.filter(
@@ -77,12 +79,14 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     id: "my-mods",
     title: t("navigation.myMods"),
     url: "/my-mods",
+    tooltipLabel: t("navigation.myMods"),
     icon: PackageIcon,
     badge: badgeContext?.length || undefined,
     group: "mods",
   },
   {
     id: "get-mods",
+    tooltipLabel: t("navigation.getMods"),
     title: t("navigation.getMods"),
     url: "/mods",
     icon: MagnifyingGlassIcon,
@@ -91,6 +95,7 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
   {
     id: "settings",
     title: t("navigation.settings"),
+    tooltipLabel: t("navigation.settings"),
     url: "/settings",
     icon: GearIcon,
     group: "general",
@@ -100,12 +105,14 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     title: t("navigation.maps"),
     tooltipLabel: t("navigation.maps"),
     url: "/maps",
+    isVisible: (flag) => flag,
     icon: MapTrifoldIcon,
     group: "mods",
   },
   {
     id: "crosshairs",
     title: t("navigation.crosshairs"),
+    tooltipLabel: t("navigation.crosshairs"),
     url: "/crosshairs",
     icon: CrosshairIcon,
     group: "customization",
@@ -114,6 +121,7 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     id: "autoexec",
     title: t("navigation.autoexec"),
     url: "/settings/autoexec",
+    tooltipLabel: t("navigation.autoexec"),
     icon: ArticleIcon,
     group: "customization",
   },
@@ -122,6 +130,7 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     id: "developer",
     title: t("navigation.developer"),
     url: "/developer",
+    tooltipLabel: "navigation.developer",
     icon: CodeIcon,
     isDev: true,
     group: "developer",
@@ -139,7 +148,7 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     : ({} as Item),
 ];
 
-export const AppSidebar = () => {
+const AppSidebar = () => {
   const { t } = useTranslation();
   const location = useLocation();
   const mods = usePersistedStore((state) => state.localMods);
@@ -176,6 +185,16 @@ export const AppSidebar = () => {
     },
   };
 
+  const getItemVisibility = (item: Item) => {
+    if (item.isDev) return developerMode;
+
+    if (typeof item.isVisible === "function") {
+      return item.isVisible(!!isCustomMapsEnabled);
+    }
+
+    return item.isVisible;
+  };
+
   const items = sidebarItems({ t, badgeContext: mods });
 
   const generalGroups = (Object.keys(groups) as Groups[]).filter(
@@ -202,6 +221,7 @@ export const AppSidebar = () => {
           const items = topSidebarItems.filter(
             (groupItem) => groupItem.group === group,
           );
+
           return (
             <SidebarGroup className="pb-1">
               <SidebarGroupLabel>{groups[group].label}</SidebarGroupLabel>
@@ -212,13 +232,7 @@ export const AppSidebar = () => {
                       <SidebarItem
                         tooltip={item.tooltipLabel}
                         key={item.id}
-                        isVisible={
-                          item.isDev
-                            ? developerMode
-                            : item.isVisible
-                              ? item.isVisible(!!isCustomMapsEnabled)
-                              : true
-                        }
+                        isVisible={getItemVisibility(item)}
                         isActive={item.url === location.pathname}
                         title={item.title}
                         badge={item.badge}
@@ -258,6 +272,7 @@ export const AppSidebar = () => {
                             key={item.id}
                             isActive={item.url === location.pathname}
                             title={item.title}
+                            isVisible={getItemVisibility(item)}
                             badge={item.badge}
                             icon={
                               <item.icon className="h-5 w-5" weight="duotone" />
@@ -291,3 +306,4 @@ export const AppSidebar = () => {
     </Sidebar>
   );
 };
+export default AppSidebar;

--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -136,17 +136,41 @@ const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
     group: "developer",
     isFooter: true,
   },
-  import.meta.env.DEV
-    ? {
-        id: "debug",
-        title: "Debug",
-        url: "/debug",
-        isFooter: true,
-        icon: BugBeetleIcon,
-        group: "developer",
-      }
-    : ({} as Item),
+  {
+    id: "debug",
+    title: "Debug",
+    url: "/debug",
+    isFooter: true,
+    isVisible: () => import.meta.env.DEV,
+    icon: BugBeetleIcon,
+    group: "developer",
+  },
 ];
+
+const groups: Record<
+  Groups,
+  {
+    label: string;
+    position: "footer" | "general";
+  }
+> = {
+  general: {
+    label: "General",
+    position: "general",
+  },
+  mods: {
+    label: "Mods",
+    position: "general",
+  },
+  customization: {
+    label: "Customization",
+    position: "general",
+  },
+  developer: {
+    label: "Developer",
+    position: "footer",
+  },
+};
 
 const AppSidebar = () => {
   const { t } = useTranslation();
@@ -159,31 +183,6 @@ const AppSidebar = () => {
     "custom-maps",
     false,
   );
-
-  const groups: Record<
-    Groups,
-    {
-      label: string;
-      position: "footer" | "general";
-    }
-  > = {
-    general: {
-      label: "General",
-      position: "general",
-    },
-    mods: {
-      label: "Mods",
-      position: "general",
-    },
-    customization: {
-      label: "Customization",
-      position: "general",
-    },
-    developer: {
-      label: "Developer",
-      position: "footer",
-    },
-  };
 
   const getItemVisibility = (item: Item) => {
     if (item.isDev) return developerMode;
@@ -255,7 +254,8 @@ const AppSidebar = () => {
           <SidebarGroupContent>
             {footerGroups.map((group) => {
               const items = footerSidebarItems.filter(
-                (groupItem) => groupItem.group === group,
+                (groupItem) =>
+                  groupItem.group === group && getItemVisibility(groupItem),
               );
 
               if (!items.length) return null;

--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -1,5 +1,3 @@
-import { Badge } from "@deadlock-mods/ui/components/badge";
-import { Dialog, DialogTrigger } from "@deadlock-mods/ui/components/dialog";
 import { Separator } from "@deadlock-mods/ui/components/separator";
 import {
   Sidebar,
@@ -8,9 +6,8 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
+  SidebarItem,
   SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
 } from "@deadlock-mods/ui/components/sidebar";
 import {
   ArticleIcon,
@@ -28,227 +25,119 @@ import {
   QuestionIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router";
 import { useThemeOverride } from "@/components/providers/theme-overrides";
 import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import { DISCORD_URL } from "@/lib/constants";
 import { usePersistedStore } from "@/lib/store";
-import { ModStatus } from "@/types/mods";
+import { LocalMod, ModStatus } from "@/types/mods";
 import { SidebarCollapse } from "./sidebar-collapse";
 
-type SidebarItem = {
+interface SProps {
+  t: (key: string) => string;
+  badgeContext?: LocalMod[];
+}
+
+interface Item {
   id: string;
-  title: ({
-    isActive,
-    count,
-    downloads,
-  }: {
-    isActive?: boolean;
-    count?: number;
-    downloads?: number;
-  }) => React.ReactNode;
-  tooltipLabel: string;
+  title: string;
+  icon: Icon;
   url: string;
-  dialog?: React.ComponentType;
-  icon?: Icon;
-  iconUrl?: string;
-  bottom?: boolean;
-  group?: string;
-};
+  group: Groups;
+  badge?: string | number;
+  isFooter?: boolean;
+  tooltipLabel?: string;
+  isDev?: boolean;
+  isVisible?: (isVisible: boolean) => boolean;
+}
+type Groups = "general" | "mods" | "customization" | "developer";
 
-const getSidebarItems = (
-  t: (key: string) => string,
-  developerMode: boolean,
-  group?: string,
-): SidebarItem[] => {
-  const allItems: SidebarItem[] = [
-    {
-      id: "dashboard",
-      title: () => <span>{t("navigation.dashboard")}</span>,
-      tooltipLabel: t("navigation.dashboard"),
-      url: "/",
-      icon: HouseIcon,
-      group: "general",
-    },
-    {
-      id: "my-mods",
-      title: ({ isActive, count }: { isActive?: boolean; count?: number }) => (
-        <div className='flex items-center justify-between w-full'>
-          <span>{t("navigation.myMods")}</span>
-          {count !== undefined && (
-            <Badge
-              className='px-1 py-0.1 text-xs'
-              variant={isActive ? "inverted" : "default"}>
-              {count}
-            </Badge>
-          )}
-        </div>
-      ),
-      tooltipLabel: t("navigation.myMods"),
-      url: "/my-mods",
-      icon: PackageIcon,
-      group: "mods",
-    },
-    {
-      id: "get-mods",
-      title: () => <span>{t("navigation.getMods")}</span>,
-      tooltipLabel: t("navigation.getMods"),
-      url: "/mods",
-      icon: MagnifyingGlassIcon,
-      group: "mods",
-    },
-    {
-      id: "maps",
-      title: () => <span>{t("navigation.maps")}</span>,
-      tooltipLabel: t("navigation.maps"),
-      url: "/maps",
-      icon: MapTrifoldIcon,
-      group: "mods",
-    },
-    {
-      id: "downloads",
-      title: ({ downloads }: { downloads?: number }) => (
-        <div className='flex items-center justify-between w-full'>
-          {t("navigation.downloads")}{" "}
-          {downloads !== undefined && downloads > 0 && (
-            <Badge className='px-1 py-0.1 text-xs'>{downloads}</Badge>
-          )}
-        </div>
-      ),
-      tooltipLabel: t("navigation.downloads"),
-      url: "/downloads",
-      icon: DownloadIcon,
-      group: "general",
-    },
-    {
-      id: "crosshairs",
-      title: () => <span>{t("navigation.crosshairs")}</span>,
-      tooltipLabel: t("navigation.crosshairs"),
-      url: "/crosshairs",
-      icon: CrosshairIcon,
-      group: t("navigation.customization"),
-    },
-    {
-      id: "autoexec",
-      title: () => <span>{t("navigation.autoexec")}</span>,
-      tooltipLabel: t("navigation.autoexec"),
-      url: "/settings/autoexec",
-      icon: ArticleIcon,
-      group: t("navigation.customization"),
-    },
-    {
-      id: "settings",
-      title: () => <span>{t("navigation.settings")}</span>,
-      tooltipLabel: t("navigation.settings"),
-      url: "/settings",
-      icon: GearIcon,
-      group: "general",
-    },
-    ...(developerMode
-      ? [
-          {
-            id: "developer",
-            title: () => <span>{t("navigation.developer")}</span>,
-            tooltipLabel: t("navigation.developer"),
-            url: "/developer",
-            icon: CodeIcon,
-            group: "Developer",
-            bottom: true,
-          },
-        ]
-      : []),
-    ...(import.meta.env.DEV
-      ? [
-          {
-            id: "debug",
-            title: () => <span>Debug</span>,
-            tooltipLabel: "Debug",
-            url: "/debug",
-            icon: BugBeetleIcon,
-            bottom: true,
-            group: "Developer",
-          },
-        ]
-      : []),
-  ];
+const sidebarItems = ({ t, badgeContext }: SProps): Array<Item> => [
+  {
+    id: "dashboard",
+    title: t("navigation.dashboard"),
+    url: "/",
+    tooltipLabel: t("navigation.dashboard"),
+    icon: HouseIcon,
+    group: "general",
+  },
+  {
+    id: "downloads",
+    title: t("navigation.downloads"),
+    url: "/downloads",
+    icon: DownloadIcon,
+    group: "general",
+    badge:
+      badgeContext?.filter(
+        (mod: { status: ModStatus }) => mod.status === ModStatus.Downloading,
+      ).length || undefined,
+  },
+  {
+    id: "my-mods",
+    title: t("navigation.myMods"),
+    url: "/my-mods",
+    icon: PackageIcon,
+    badge: badgeContext?.length || undefined,
+    group: "mods",
+  },
+  {
+    id: "get-mods",
+    title: t("navigation.getMods"),
+    url: "/mods",
+    icon: MagnifyingGlassIcon,
+    group: "mods",
+  },
+  {
+    id: "settings",
+    title: t("navigation.settings"),
+    url: "/settings",
+    icon: GearIcon,
+    group: "general",
+  },
+  {
+    id: "maps",
+    title: t("navigation.maps"),
+    tooltipLabel: t("navigation.maps"),
+    url: "/maps",
+    icon: MapTrifoldIcon,
+    group: "mods",
+  },
+  {
+    id: "crosshairs",
+    title: t("navigation.crosshairs"),
+    url: "/crosshairs",
+    icon: CrosshairIcon,
+    group: "customization",
+  },
+  {
+    id: "autoexec",
+    title: t("navigation.autoexec"),
+    url: "/settings/autoexec",
+    icon: ArticleIcon,
+    group: "customization",
+  },
 
-  if (group) {
-    return allItems.filter((item) => item.group === group);
-  }
-
-  return allItems;
-};
-
-type SidebarItemProps = {
-  item: SidebarItem;
-  location: ReturnType<typeof useLocation>;
-  mods: Array<{ status: ModStatus; remoteId: string }>;
-};
-
-const renderIcon = (item: SidebarItem) => {
-  if (item.icon) {
-    return <item.icon weight='duotone' />;
-  }
-  if (item.iconUrl) {
-    return <img alt='' className='h-5 w-5' src={item.iconUrl} />;
-  }
-  return null;
-};
-
-const SidebarItemComponent = ({ item, location, mods }: SidebarItemProps) => {
-  const [dialogOpen, setDialogOpen] = useState(false);
-
-  if (item.dialog) {
-    const DialogComponent = item.dialog;
-    return (
-      <Dialog onOpenChange={setDialogOpen} open={dialogOpen}>
-        <DialogTrigger asChild>
-          <SidebarMenuButton
-            isActive={location.pathname === item.url}
-            tooltip={item.tooltipLabel}>
-            {renderIcon(item)}
-            {item.title({
-              isActive: location.pathname === item.url,
-              count: item.id === "my-mods" ? mods.length : undefined,
-              downloads:
-                item.id === "downloads"
-                  ? mods.filter(
-                      (mod: { status: ModStatus }) =>
-                        mod.status === ModStatus.Downloading,
-                    ).length
-                  : undefined,
-            })}
-          </SidebarMenuButton>
-        </DialogTrigger>
-        <DialogComponent />
-      </Dialog>
-    );
-  }
-
-  return (
-    <SidebarMenuButton
-      asChild
-      isActive={location.pathname === item.url}
-      tooltip={item.tooltipLabel}>
-      <Link to={item.url} draggable='false'>
-        {renderIcon(item)}
-        {item.title({
-          isActive: location.pathname === item.url,
-          count: item.id === "my-mods" ? mods.length : undefined,
-          downloads:
-            item.id === "downloads"
-              ? mods.filter(
-                  (mod: { status: ModStatus }) =>
-                    mod.status === ModStatus.Downloading,
-                ).length
-              : undefined,
-        })}
-      </Link>
-    </SidebarMenuButton>
-  );
-};
+  {
+    id: "developer",
+    title: t("navigation.developer"),
+    url: "/developer",
+    icon: CodeIcon,
+    isDev: true,
+    group: "developer",
+    isFooter: true,
+  },
+  import.meta.env.DEV
+    ? {
+        id: "debug",
+        title: "Debug",
+        url: "/debug",
+        isFooter: true,
+        icon: BugBeetleIcon,
+        group: "developer",
+      }
+    : ({} as Item),
+];
 
 export const AppSidebar = () => {
   const { t } = useTranslation();
@@ -262,48 +151,82 @@ export const AppSidebar = () => {
     false,
   );
 
-  const allItems = getSidebarItems(t, developerMode).filter(
-    (item) => item.id !== "maps" || isCustomMapsEnabled,
+  const groups: Record<
+    Groups,
+    {
+      label: string;
+      position: "footer" | "general";
+    }
+  > = {
+    general: {
+      label: "General",
+      position: "general",
+    },
+    mods: {
+      label: "Mods",
+      position: "general",
+    },
+    customization: {
+      label: "Customization",
+      position: "general",
+    },
+    developer: {
+      label: "Developer",
+      position: "footer",
+    },
+  };
+
+  const items = sidebarItems({ t, badgeContext: mods });
+
+  const generalGroups = (Object.keys(groups) as Groups[]).filter(
+    (group) => groups[group].position === "general",
+  );
+  const footerGroups = (Object.keys(groups) as Groups[]).filter(
+    (group) => groups[group].position === "footer",
   );
 
-  const topItems = allItems.filter((item) => !item.bottom);
-  const bottomItems = allItems.filter((item) => item.bottom);
+  const topSidebarItems = [...new Set(items.filter((item) => !item.isFooter))];
 
-  const topGroups = [...new Set(topItems.map((item) => item.group))].filter(
-    Boolean,
-  ) as string[];
-  const bottomGroups = [
-    ...new Set(bottomItems.map((item) => item.group)),
-  ].filter(Boolean) as string[];
-
-  const groupLabels: Record<string, string> = {
-    mods: "Mods",
-    general: "General",
-  };
+  const footerSidebarItems = [
+    ...new Set(items.filter((item) => item.isFooter)),
+  ];
 
   return (
     <Sidebar
-      className='z-50 flex h-[calc(100vh-96px)] absolute bottom-0 left-0 w-[12rem] flex-col border-t'
-      collapsible='icon'
-      variant='sidebar'>
-      <SidebarContent className='flex-grow pt-2'>
-        {topGroups.map((group) => {
-          const groupItems = topItems.filter((item) => item.group === group);
+      className="z-50 flex h-[calc(100vh-96px)] absolute bottom-0 left-0 w-[12rem] flex-col border-t"
+      collapsible="icon"
+      variant="sidebar"
+    >
+      <SidebarContent className="flex-grow inline pt-2">
+        {generalGroups.map((group) => {
+          const items = topSidebarItems.filter(
+            (groupItem) => groupItem.group === group,
+          );
           return (
-            <SidebarGroup key={group}>
-              <SidebarGroupLabel>
-                {groupLabels[group] || group}
-              </SidebarGroupLabel>
+            <SidebarGroup className="pb-1">
+              <SidebarGroupLabel>{groups[group].label}</SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
-                  {groupItems.map((item) => (
-                    <SidebarMenuItem key={item.id}>
-                      <SidebarItemComponent
-                        item={item}
-                        location={location}
-                        mods={mods}
+                  {items.map((item) => (
+                    <Link to={item.url}>
+                      <SidebarItem
+                        tooltip={item.tooltipLabel}
+                        key={item.id}
+                        isVisible={
+                          item.isDev
+                            ? developerMode
+                            : item.isVisible
+                              ? item.isVisible(!!isCustomMapsEnabled)
+                              : true
+                        }
+                        isActive={item.url === location.pathname}
+                        title={item.title}
+                        badge={item.badge}
+                        icon={
+                          <item.icon className="h-5 w-5" weight="duotone" />
+                        }
                       />
-                    </SidebarMenuItem>
+                    </Link>
                   ))}
                 </SidebarMenu>
               </SidebarGroupContent>
@@ -312,51 +235,53 @@ export const AppSidebar = () => {
         })}
         {SidebarContentExtra ? <SidebarContentExtra /> : null}
       </SidebarContent>
-      <SidebarFooter>
+      <SidebarFooter className="min-h-fit">
         {SidebarFooterExtra ? <SidebarFooterExtra /> : null}
-        {bottomGroups.map((group) => {
-          const groupItems = bottomItems.filter((item) => item.group === group);
-          return (
-            <SidebarGroup key={group}>
-              <SidebarGroupLabel>
-                {groupLabels[group] || group}
-              </SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {groupItems.map((item) => (
-                    <SidebarMenuItem key={item.id}>
-                      <SidebarItemComponent
-                        item={item}
-                        location={location}
-                        mods={mods}
-                      />
-                    </SidebarMenuItem>
-                  ))}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          );
-        })}
-        <SidebarGroup>
+        <SidebarGroup className="group-data-[collapsible=icon]:pb-0">
           <SidebarGroupContent>
-            <SidebarMenu>
-              <Separator />
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  onClick={() => openUrl("https://docs.deadlockmods.app/")}
-                  tooltip={t("help.documentation")}>
-                  <QuestionIcon weight='duotone' />
-                  <span>{t("help.documentation")}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  onClick={() => openUrl(DISCORD_URL)}
-                  tooltip={t("help.needHelp")}>
-                  <DiscordLogoIcon weight='duotone' />
-                  <span>{t("help.needHelp")}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
+            {footerGroups.map((group) => {
+              const items = footerSidebarItems.filter(
+                (groupItem) => groupItem.group === group,
+              );
+
+              if (!items.length) return null;
+
+              return (
+                <div className="pb-1">
+                  <SidebarGroupLabel>{groups[group].label}</SidebarGroupLabel>
+                  <SidebarGroupContent>
+                    <SidebarMenu>
+                      {items.map((item) => (
+                        <Link to={item.url}>
+                          <SidebarItem
+                            tooltip={item.tooltipLabel}
+                            key={item.id}
+                            isActive={item.url === location.pathname}
+                            title={item.title}
+                            badge={item.badge}
+                            icon={
+                              <item.icon className="h-5 w-5" weight="duotone" />
+                            }
+                          />
+                        </Link>
+                      ))}
+                    </SidebarMenu>
+                  </SidebarGroupContent>
+                </div>
+              );
+            })}
+            <Separator />
+            <SidebarMenu className="py-1">
+              <SidebarItem
+                icon={<QuestionIcon className="w-5 h-5" weight="duotone" />}
+                title={t("help.documentation")}
+                onClick={() => openUrl("https://docs.deadlockmods.app/")}
+              />
+              <SidebarItem
+                icon={<DiscordLogoIcon className="w-5 h-5" weight="duotone" />}
+                title={t("help.needHelp")}
+                onClick={() => openUrl(DISCORD_URL)}
+              />
               <Separator />
               <SidebarCollapse />
             </SidebarMenu>

--- a/apps/desktop/src/components/layout/sidebar-collapse.tsx
+++ b/apps/desktop/src/components/layout/sidebar-collapse.tsx
@@ -1,29 +1,24 @@
-import {
-  SidebarMenuButton,
-  SidebarMenuItem,
-  useSidebar,
-} from "@deadlock-mods/ui/components/sidebar";
+import { SidebarItem, useSidebar } from "@deadlock-mods/ui/components/sidebar";
 import { ArrowLineLeftIcon } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
-
 export const SidebarCollapse = () => {
   const { t } = useTranslation();
   const { toggleSidebar, open } = useSidebar();
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton
-        onClick={toggleSidebar}
-        tooltip={t(open ? "navigation.collapseMenu" : "navigation.expandMenu")}>
+    <SidebarItem
+      icon={
         <ArrowLineLeftIcon
           className={cn(
-            "transition-all duration-150 ease-linear",
+            "transition-all duration-150 w-5 h-5 ease-linear",
             open ? "" : "rotate-180",
           )}
-          weight='duotone'
+          weight="duotone"
         />
-        <span>{t("navigation.collapseMenu")}</span>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
+      }
+      title={t("navigation.collapseMenu")}
+      tooltip={t(open ? "navigation.collapseMenu" : "navigation.expandMenu")}
+      onClick={toggleSidebar}
+    />
   );
 };

--- a/apps/desktop/src/layout.tsx
+++ b/apps/desktop/src/layout.tsx
@@ -4,7 +4,7 @@ import {
   SidebarProvider,
 } from "@deadlock-mods/ui/components/sidebar";
 import { Toaster } from "@deadlock-mods/ui/components/sonner";
-import { AppSidebar } from "./components/layout/app-sidebar";
+import AppSidebar from "./components/layout/app-sidebar";
 import { BottomBar } from "./components/layout/bottom-bar";
 import { Titlebar } from "./components/layout/titlebar";
 import { Toolbar } from "./components/layout/toolbar";
@@ -21,7 +21,7 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <>
-      <main className='h-screen overflow-hidden'>
+      <main className="h-screen overflow-hidden">
         <Titlebar />
         <Topbar />
         <SidebarProvider>
@@ -31,7 +31,8 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
               <div className={cn("flex h-full w-full flex-col")}>
                 <Toolbar />
                 <div
-                  className={cn("flex pr-2 pl-2 pt-4 h-[calc(100vh-198px)]")}>
+                  className={cn("flex pr-2 pl-2 pt-4 h-[calc(100vh-198px)]")}
+                >
                   {children}
                 </div>
                 <BottomBar />
@@ -44,7 +45,8 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
 
       <Dialog
         onOpenChange={(open) => !open && markVersionAsSeen()}
-        open={showWhatsNew}>
+        open={showWhatsNew}
+      >
         <WhatsNewDialog onClose={markVersionAsSeen} />
       </Dialog>
     </>

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -15,6 +15,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./tooltip";
+import { ReactNode } from "react";
+import { Badge } from "./badge.tsx";
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -142,7 +144,8 @@ const SidebarProvider = React.forwardRef<
                 ...style,
               } as React.CSSProperties
             }
-            {...props}>
+            {...props}
+          >
             {children}
           </div>
         </TooltipProvider>
@@ -181,7 +184,8 @@ const Sidebar = React.forwardRef<
             className,
           )}
           ref={ref}
-          {...props}>
+          {...props}
+        >
           {children}
         </div>
       );
@@ -191,16 +195,17 @@ const Sidebar = React.forwardRef<
       return (
         <Sheet onOpenChange={setOpenMobile} open={openMobile} {...props}>
           <SheetContent
-            className='w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden'
-            data-mobile='true'
-            data-sidebar='sidebar'
+            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            data-mobile="true"
+            data-sidebar="sidebar"
             side={side}
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
               } as React.CSSProperties
-            }>
-            <div className='flex h-full w-full flex-col'>{children}</div>
+            }
+          >
+            <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>
       );
@@ -208,12 +213,13 @@ const Sidebar = React.forwardRef<
 
     return (
       <div
-        className='group peer hidden text-sidebar-foreground md:block'
+        className="group peer hidden text-sidebar-foreground md:block"
         data-collapsible={state === "collapsed" ? collapsible : ""}
         data-side={side}
         data-state={state}
         data-variant={variant}
-        ref={ref}>
+        ref={ref}
+      >
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
@@ -237,10 +243,12 @@ const Sidebar = React.forwardRef<
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className,
           )}
-          {...props}>
+          {...props}
+        >
           <div
-            className='flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow'
-            data-sidebar='sidebar'>
+            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            data-sidebar="sidebar"
+          >
             {children}
           </div>
         </div>
@@ -259,15 +267,16 @@ const SidebarTrigger = React.forwardRef<
   return (
     <Button
       className={cn(className)}
-      data-sidebar='trigger'
+      data-sidebar="trigger"
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
       }}
       ref={ref}
-      variant='ghost'
-      {...props}>
-      <PanelLeft className='h-7 w-7' />
+      variant="ghost"
+      {...props}
+    >
+      <PanelLeft className="h-7 w-7" />
       <span>Toggle Sidebar</span>
     </Button>
   );
@@ -282,7 +291,7 @@ const SidebarRail = React.forwardRef<
 
   return (
     <button
-      aria-label='Toggle Sidebar'
+      aria-label="Toggle Sidebar"
       className={cn(
         "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex",
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
@@ -292,11 +301,11 @@ const SidebarRail = React.forwardRef<
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
         className,
       )}
-      data-sidebar='rail'
+      data-sidebar="rail"
       onClick={toggleSidebar}
       ref={ref}
       tabIndex={-1}
-      title='Toggle Sidebar'
+      title="Toggle Sidebar"
       {...props}
     />
   );
@@ -331,7 +340,7 @@ const SidebarInput = React.forwardRef<
         "h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
         className,
       )}
-      data-sidebar='input'
+      data-sidebar="input"
       ref={ref}
       {...props}
     />
@@ -346,7 +355,7 @@ const SidebarHeader = React.forwardRef<
   return (
     <div
       className={cn("flex flex-col gap-2 p-2", className)}
-      data-sidebar='header'
+      data-sidebar="header"
       ref={ref}
       {...props}
     />
@@ -361,7 +370,7 @@ const SidebarFooter = React.forwardRef<
   return (
     <div
       className={cn("flex flex-col gap-2 py-2", className)}
-      data-sidebar='footer'
+      data-sidebar="footer"
       ref={ref}
       {...props}
     />
@@ -376,7 +385,7 @@ const SidebarSeparator = React.forwardRef<
   return (
     <Separator
       className={cn("mx-2 w-auto bg-sidebar-border", className)}
-      data-sidebar='separator'
+      data-sidebar="separator"
       ref={ref}
       {...props}
     />
@@ -391,10 +400,10 @@ const SidebarContent = React.forwardRef<
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-col gap-1 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
-      data-sidebar='content'
+      data-sidebar="content"
       ref={ref}
       {...props}
     />
@@ -409,7 +418,7 @@ const SidebarGroup = React.forwardRef<
   return (
     <div
       className={cn("relative flex w-full min-w-0 flex-col px-2", className)}
-      data-sidebar='group'
+      data-sidebar="group"
       ref={ref}
       {...props}
     />
@@ -430,7 +439,7 @@ const SidebarGroupLabel = React.forwardRef<
         "group-data-[collapsible=icon]:hidden",
         className,
       )}
-      data-sidebar='group-label'
+      data-sidebar="group-label"
       ref={ref}
       {...props}
     />
@@ -453,7 +462,7 @@ const SidebarGroupAction = React.forwardRef<
         "group-data-[collapsible=icon]:hidden",
         className,
       )}
-      data-sidebar='group-action'
+      data-sidebar="group-action"
       ref={ref}
       {...props}
     />
@@ -467,7 +476,7 @@ const SidebarGroupContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     className={cn("w-full text-sm", className)}
-    data-sidebar='group-content'
+    data-sidebar="group-content"
     ref={ref}
     {...props}
   />
@@ -480,7 +489,7 @@ const SidebarMenu = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ul
     className={cn("flex w-full min-w-0 flex-col gap-1", className)}
-    data-sidebar='menu'
+    data-sidebar="menu"
     ref={ref}
     {...props}
   />
@@ -496,7 +505,7 @@ const SidebarMenuItem = React.forwardRef<
       "group/menu-item relative transition-all duration-300 ease-in-out",
       className,
     )}
-    data-sidebar='menu-item'
+    data-sidebar="menu-item"
     ref={ref}
     {...props}
   />
@@ -504,7 +513,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button cursor-pointer select-none group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate group-data-[collapsible=icon]:[&>span:last-child]:sr-only group-data-[collapsible=icon]:[&>div:last-child]:sr-only [&>svg]:size-5 [&>svg]:shrink-0",
+  "peer/menu-button group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -552,7 +561,7 @@ const SidebarMenuButton = React.forwardRef<
       <Comp
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
         data-active={isActive}
-        data-sidebar='menu-button'
+        data-sidebar="menu-button"
         data-size={size}
         ref={ref}
         {...props}
@@ -573,9 +582,9 @@ const SidebarMenuButton = React.forwardRef<
       <Tooltip>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent
-          align='center'
+          align="center"
           hidden={state !== "collapsed" || isMobile}
-          side='right'
+          side="right"
           {...tooltip}
         />
       </Tooltip>
@@ -607,7 +616,7 @@ const SidebarMenuAction = React.forwardRef<
           "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0",
         className,
       )}
-      data-sidebar='menu-action'
+      data-sidebar="menu-action"
       ref={ref}
       {...props}
     />
@@ -629,7 +638,7 @@ const SidebarMenuBadge = React.forwardRef<
       "group-data-[collapsible=icon]:hidden",
       className,
     )}
-    data-sidebar='menu-badge'
+    data-sidebar="menu-badge"
     ref={ref}
     {...props}
   />
@@ -650,18 +659,19 @@ const SidebarMenuSkeleton = React.forwardRef<
   return (
     <div
       className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
-      data-sidebar='menu-skeleton'
+      data-sidebar="menu-skeleton"
       ref={ref}
-      {...props}>
+      {...props}
+    >
       {showIcon && (
         <Skeleton
-          className='size-4 rounded-md'
-          data-sidebar='menu-skeleton-icon'
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
         />
       )}
       <Skeleton
-        className='h-4 max-w-[--skeleton-width] flex-1'
-        data-sidebar='menu-skeleton-text'
+        className="h-4 max-w-[--skeleton-width] flex-1"
+        data-sidebar="menu-skeleton-text"
         style={
           {
             "--skeleton-width": width,
@@ -683,7 +693,7 @@ const SidebarMenuSub = React.forwardRef<
       "group-data-[collapsible=icon]:hidden",
       className,
     )}
-    data-sidebar='menu-sub'
+    data-sidebar="menu-sub"
     ref={ref}
     {...props}
   />
@@ -717,7 +727,7 @@ const SidebarMenuSubButton = React.forwardRef<
         className,
       )}
       data-active={isActive}
-      data-sidebar='menu-sub-button'
+      data-sidebar="menu-sub-button"
       data-size={size}
       ref={ref}
       {...props}
@@ -725,6 +735,51 @@ const SidebarMenuSubButton = React.forwardRef<
   );
 });
 SidebarMenuSubButton.displayName = "SidebarMenuSubButton";
+
+interface SidebarItemProps {
+  title: string;
+  icon: ReactNode;
+  isActive?: boolean;
+  url?: string;
+  badge?: ReactNode;
+  tooltip?: string;
+  isVisible?: boolean;
+  onClick?: () => void;
+}
+
+const SidebarItem = ({
+  title,
+  icon,
+  tooltip,
+  badge,
+  isActive,
+  isVisible = true,
+  onClick,
+}: SidebarItemProps) => {
+  return (
+    isVisible && (
+      <SidebarMenuButton
+        tooltip={tooltip}
+        onClick={onClick}
+        className="justify-between"
+        isActive={isActive}
+      >
+        <div className="flex items-center gap-2">
+          <div>{icon}</div>
+          <span className="group-data-[collapsible=icon]:hidden">{title}</span>
+        </div>
+        {badge && (
+          <Badge
+            variant={isActive ? "inverted" : "default"}
+            className="px-1 py-0.1 text-xs group-data-[collapsible=icon]:absolute group-data-[collapsible=icon]:right-[1px] group-data-[collapsible=icon]:top-[-2px]"
+          >
+            {badge}
+          </Badge>
+        )}
+      </SidebarMenuButton>
+    )
+  );
+};
 
 export {
   Sidebar,
@@ -748,6 +803,7 @@ export {
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
+  SidebarItem,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,


### PR DESCRIPTION
## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [ ] My code follows the style guidelines of this project (`pnpm lint` passes)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Functional Impact

This PR refactors the sidebar navigation UI across the desktop application and shared UI components, introducing a new data-driven component model with improved feature flag support.

## Affected Packages/Apps

- **packages/ui**: Added new `SidebarItem` component to the shared UI library
- **apps/desktop**: Refactored sidebar navigation to use the new `SidebarItem` component

## Cross-Package Dependency Changes

The desktop app (`apps/desktop`) now depends on the new `SidebarItem` component exported from `packages/ui/src/components/sidebar.tsx`. This is a new inter-package integration where the desktop app replaces its internal usage of low-level sidebar primitives (`SidebarMenuButton`, `SidebarMenuItem`) with the higher-level `SidebarItem` component.

## Key Architectural Changes

**Sidebar Navigation Refactoring:**
- Moved from a dynamic, render-per-item approach to a data-driven model using a typed `Item` interface
- Items are now defined as static data objects with properties for `id`, `title`, `icon`, `url`, `group`, optional `badge`, and visibility controls
- Introduced grouped sidebar sections: "general", "mods", "customization", and "developer" groups with separate rendering for general and footer sections

**Feature Flag Integration:**
- Added feature flag-aware visibility logic for sidebar items (e.g., "maps" visibility controlled by `custom-maps` feature flag, "debug" visibility by `import.meta.env.DEV`)
- Visibility is now determined by `isDev`, `isVisible`, and the `developerMode` feature flag state
- Badge values are computed dynamically from `badgeContext` (local mods) for specific sections like "downloads" and "my-mods"

**Component Updates:**
- New `SidebarItem` component in the UI package provides: `title`, `icon`, optional `isActive`/`badge`/`tooltip`, `isVisible` (default `true`), and `onClick` callback
- Sidebar collapse control simplified to use `SidebarItem` instead of composition of menu primitives
- `AppSidebar` now exports both named and default exports

No database migrations, Tauri plugin changes, or Rust FFI boundary modifications are involved in this refactoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->