### PR TITLE
fix(desktop): only pre-select previously installed downloads when updating mods

### DIFF
--- a/.changeset/crisp-glasses-fold.md
+++ b/.changeset/crisp-glasses-fold.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": patch
 ---
 
-Fix mod update dialog pre-selecting all available downloads instead of only the ones the user previously installed
+Fix update dialog to preselect only previously installed downloads

--- a/.changeset/crisp-glasses-fold.md
+++ b/.changeset/crisp-glasses-fold.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix mod update dialog pre-selecting all available downloads instead of only the ones the user previously installed

--- a/apps/desktop/src/hooks/use-batch-update.ts
+++ b/apps/desktop/src/hooks/use-batch-update.ts
@@ -64,17 +64,24 @@ export const useBatchUpdate = () => {
         let selectedDownloads: ModDownloadItem[];
         if (update.downloads.length === 1) {
           selectedDownloads = update.downloads;
-        } else if (
-          localMod?.selectedDownloads &&
-          localMod.selectedDownloads.length > 0
-        ) {
-          const savedSelections = localMod.selectedDownloads;
-          const matched = update.downloads.filter((d) =>
-            savedSelections.some((sd) => sd.name === d.name),
+        } else {
+          // Match by previously saved download selections
+          const savedNames = new Set(
+            (localMod?.selectedDownloads ?? []).map((sd) => sd.name),
+          );
+          // Also match by archive names from installed file tree
+          // (installedFileTree is populated during download, while
+          // selectedDownloads is only set after the first update)
+          const installedArchiveNames = new Set(
+            (localMod?.installedFileTree?.files ?? [])
+              .filter((f) => f.is_selected)
+              .map((f) => f.archive_name),
+          );
+
+          const matched = update.downloads.filter(
+            (d) => savedNames.has(d.name) || installedArchiveNames.has(d.name),
           );
           selectedDownloads = matched.length > 0 ? matched : update.downloads;
-        } else {
-          selectedDownloads = update.downloads;
         }
 
         return {

--- a/apps/desktop/src/hooks/use-batch-update.ts
+++ b/apps/desktop/src/hooks/use-batch-update.ts
@@ -81,7 +81,7 @@ export const useBatchUpdate = () => {
           const matched = update.downloads.filter(
             (d) => savedNames.has(d.name) || installedArchiveNames.has(d.name),
           );
-          selectedDownloads = matched.length > 0 ? matched : update.downloads;
+          selectedDownloads = matched;
         }
 
         return {

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -28,7 +28,10 @@ export const useDownload = (
       return;
     }
 
-    addLocalMod(mod as unknown as ModDto, { downloads: selectedFiles });
+    addLocalMod(mod as unknown as ModDto, {
+      downloads: selectedFiles,
+      selectedDownloads: selectedFiles,
+    });
 
     const activeProfile = getActiveProfile();
     const profileFolder = activeProfile?.folderName ?? null;


### PR DESCRIPTION
## Description

- Fix update dialog pre-selecting all available download files instead of only the ones the user previously installed 
- Use installedFileTree archive names as an additional matching source for download selection
- Populate selectedDownloads during initial mod download so future updates match correctly                                                                                                                                                     

Limitations:
- Only works automatically for mods installed after this change. For existing mods, users need to manually select the correct files during one update, and after that, future updates will match correctly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #355 
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code, Used for: triage

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Functional Impact

**Package affected:** `@deadlock-mods/desktop` (patch release)

**Apps affected:** Desktop application only

**No cross-package dependency changes, database migrations, Tauri plugin changes, or Rust FFI boundary changes.**

## Changes Summary

### Bug Fix: Mod Update Dialog Pre-Selection (PR #368)

Fixes a regression where the update dialog pre-selected all available download files instead of only the files the user previously installed.

Implementation:
1. `use-download.ts` — Persist `selectedDownloads` alongside `downloads` when enqueuing an initial mod download so the user's original file selections are recorded for future updates.
2. `use-batch-update.ts` — Update `prepareUpdates` logic to compute pre-selected update downloads by matching available `update.downloads` against two sources:
   - saved selections (`localMod.selectedDownloads` by `name`), and
   - archive names from the installed file tree (`localMod.installedFileTree.files` where `is_selected` is true, comparing `archive_name` to download `name`).
   The code now only pre-selects downloads that match either source and no longer falls back to selecting all available downloads when no matches are found.

Limitation: Automatic matching only applies reliably to mods installed after this change. For existing mods, users must manually select the correct files once during an update for future automatic matching to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->