### PR TITLE
fix(ci): resolve windows asset name in latest.json

### DIFF
--- a/.github/actions/update-latest-json/action.yml
+++ b/.github/actions/update-latest-json/action.yml
@@ -28,12 +28,13 @@ runs:
       with:
         script: |
           const fs = require('fs');
+          const path = require('path');
 
           function toGitHubAssetName(name) {
             return name
               .trim()
               .replace(/[^a-zA-Z0-9_-]/g, '.')
-              .replace(/\.\./g, '.');
+              .replace(/\.+/g, '.');
           }
 
           const releaseId = parseInt(process.env.RELEASE_ID);
@@ -87,7 +88,9 @@ runs:
           if (exeAsset) {
             console.log(`Resolved Windows executable asset via GitHub asset name match: ${exeAsset.name}`);
           } else {
-            console.log(`Could not match ${exeFile} to release asset ${githubAssetName}, falling back to encoded URL`);
+            const message = `Could not match ${exeFile} to release asset ${githubAssetName}, falling back to encoded URL`;
+            console.log(message);
+            core.warning(message);
           }
 
           const exeUrl = exeAsset?.browser_download_url ?? `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/${version}/${encodeURIComponent(exeFile)}`;

--- a/.github/actions/update-latest-json/action.yml
+++ b/.github/actions/update-latest-json/action.yml
@@ -28,7 +28,13 @@ runs:
       with:
         script: |
           const fs = require('fs');
-          const path = require('path');
+
+          function toGitHubAssetName(name) {
+            return name
+              .trim()
+              .replace(/[^a-zA-Z0-9_-]/g, '.')
+              .replace(/\.\./g, '.');
+          }
 
           const releaseId = parseInt(process.env.RELEASE_ID);
           const version = process.env.VERSION;
@@ -75,7 +81,15 @@ runs:
           const newSignature = fs.readFileSync(path.join(artifactPath, sigFile), 'utf8').trim();
           console.log(`Read new signature from ${sigFile}`);
 
-          const exeAsset = release.assets.find(a => a.name === exeFile);
+          const githubAssetName = toGitHubAssetName(exeFile);
+          const exeAsset = release.assets.find(a => a.name === githubAssetName);
+
+          if (exeAsset) {
+            console.log(`Resolved Windows executable asset via GitHub asset name match: ${exeAsset.name}`);
+          } else {
+            console.log(`Could not match ${exeFile} to release asset ${githubAssetName}, falling back to encoded URL`);
+          }
+
           const exeUrl = exeAsset?.browser_download_url ?? `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/${version}/${encodeURIComponent(exeFile)}`;
 
           // Update or add Windows NSIS entries


### PR DESCRIPTION
## Description

Fixes the GithubAssetName resolution in action.yml to resolve the correct release asset rather than the local artifact name.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #352 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for Windows asset name resolution in latest.json

**Affected Package:** Desktop app (Tauri)

**What Changed:**
Updated `.github/actions/update-latest-json/action.yml` to correctly resolve the Windows executable asset name in release artifacts. The action now includes a `toGitHubAssetName()` helper function that normalizes executable filenames to match GitHub's asset naming conventions (replacing special characters with periods, collapsing consecutive dots).

**Functional Impact:**
This fix ensures that during stable and nightly releases, the `latest.json` file (which contains platform-specific download URLs and signatures) correctly references the Windows executable asset from the GitHub release. Previously, mismatches between local artifact names and GitHub asset names could cause the action to fall back to encoded URL workarounds. The fix allows direct asset URL matching, improving the reliability of the release process for the desktop app.

**Related Issue:** #352

<!-- end of auto-generated comment: release notes by coderabbit.ai -->