### PR TITLE
fix(shared): accept v2 shared profiles

### DIFF
--- a/packages/shared/src/schemas/profile.schemas.ts
+++ b/packages/shared/src/schemas/profile.schemas.ts
@@ -38,7 +38,15 @@ export const v1ProfileSchema = z.object({
   }),
 });
 
-export const profileSchema = z.union([v1ProfileSchema]);
+export const v2ProfileSchema = z.object({
+  version: z.literal("2"),
+  payload: z.object({
+    mods: z.array(profileModSchema),
+    loadOrder: z.array(z.string()),
+  }),
+});
+
+export const profileSchema = z.union([v1ProfileSchema, v2ProfileSchema]);
 
 export type SharedProfile = z.infer<typeof profileSchema>;
 export type ProfileModDownload = z.infer<typeof profileModDownloadSchema>;

--- a/packages/shared/src/tests/profile.schemas.spec.ts
+++ b/packages/shared/src/tests/profile.schemas.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { profileSchema } from "../schemas/profile.schemas";
+
+describe("profileSchema", () => {
+  it("parses v1 profiles", () => {
+    const profile = profileSchema.parse({
+      version: "1",
+      payload: {
+        mods: [{ remoteId: "mod-a" }, { remoteId: "mod-b" }],
+      },
+    });
+
+    expect(profile.version).toBe("1");
+    expect(profile.payload.mods).toHaveLength(2);
+  });
+
+  it("parses v2 profiles with load order", () => {
+    const profile = profileSchema.parse({
+      version: "2",
+      payload: {
+        mods: [
+          { remoteId: "mod-b" },
+          { remoteId: "mod-c" },
+          { remoteId: "mod-a" },
+        ],
+        loadOrder: ["mod-a", "mod-b", "mod-c"],
+      },
+    });
+
+    expect(profile.version).toBe("2");
+    expect(profile.payload.mods).toHaveLength(3);
+    expect(profile.payload.loadOrder).toEqual(["mod-a", "mod-b", "mod-c"]);
+  });
+});


### PR DESCRIPTION
## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #387 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Copilot, Used for: Schema generation and testing
## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for v2 shared profiles, extending the profile schema to include a `loadOrder` field while maintaining backward compatibility with v1 profiles.

## Affected Packages
- **packages/shared**: Core schema changes
- **apps/desktop**: Uses updated `profileSchema` in profile sharing and import workflows
- **apps/api**: Uses updated `profileSchema` in profile validation and retrieval endpoints

## Changes
### Schema Updates (packages/shared)
- Added new `v2ProfileSchema` that enforces `version: "2"` and includes a `payload` with:
  - `mods`: array of profile mod configurations (existing in v1)
  - `loadOrder`: array of strings (new in v2)
- Updated `profileSchema` to union both `v1ProfileSchema` and `v2ProfileSchema`
- Updated `SharedProfile` type inference to accept both versions

### Test Coverage
- Added new test file validating both v1 and v2 profile parsing
- Tests confirm v1 profiles parse with mods array
- Tests confirm v2 profiles parse with both mods and loadOrder arrays

## Functional Impact
The expanded schema automatically enables:
- **API profile endpoints** (`/v2/profiles`) to accept and validate v2 profiles in the `ShareProfileInputSchema`
- **Desktop app** profile sharing dialog to serialize and share profiles with loadOrder information
- **Profile import workflows** to handle v2 profiles seamlessly

The change is backward compatible—existing v1 profiles continue to work without modification. No changes required in consuming packages since validation already uses the shared `profileSchema`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->