### PR TITLE
feat(api,database): handle trashed mods during GameBanana sync

### DIFF
--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -327,42 +327,24 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
     mod: GameBananaSubmission,
     source: GameBananaSubmissionSource,
   ): Promise<NewMod & { isTrashed: boolean }> {
-    const isSound = source === "sound";
-    const profile = isSound
-      ? await this.getMod(mod._idRow.toString(), "Sound")
-      : await this.getMod(mod._idRow.toString(), "Mod");
+    if (source === "sound") {
+      return this.createSoundModPayload(mod);
+    }
+    return this.createRegularModPayload(mod);
+  }
+
+  private async createSoundModPayload(
+    mod: GameBananaSubmission,
+  ): Promise<NewMod & { isTrashed: boolean }> {
+    const profile = await this.getMod(mod._idRow.toString(), "Sound");
 
     if (profile._bIsTrashed === true) {
-      return {
-        remoteId: profile._idRow.toString(),
-        name: profile._sName,
-        description: "",
-        tags: [],
-        author: profile._aSubmitter._sName,
-        likes: 0,
-        hero: null,
-        downloadCount: 0,
-        remoteUrl: profile._sProfileUrl,
-        category: "",
-        downloadable: false,
-        remoteAddedAt: new Date(profile._tsDateAdded * 1000),
-        remoteUpdatedAt: new Date(profile._tsDateModified * 1000),
-        images: [],
-        isNSFW: false,
-        isObsolete: false,
-        isTrashed: true,
-        isMap: false,
-      };
+      return this.createTrashedPayload(profile);
     }
 
     const description = profile._sText || profile._sDescription || "";
-    const isMap = isSound
-      ? false
-      : categoryFromGameBananaProfile(
-          profile as GameBanana.GameBananaModProfile,
-        ) === MAPS_CATEGORY_NAME;
 
-    const basePayload: NewMod & { isTrashed: boolean } = {
+    return {
       remoteId: profile._idRow.toString(),
       name: profile._sName,
       description,
@@ -376,30 +358,89 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       downloadable: (profile._aFiles?.length ?? 0) > 0,
       remoteAddedAt: new Date(profile._tsDateAdded * 1000),
       remoteUpdatedAt: new Date(profile._tsDateModified * 1000),
-      images: isSound
-        ? []
-        : (
-            profile as GameBanana.GameBananaModProfile
-          )._aPreviewMedia._aImages.map(
-            (image) => `${image._sBaseUrl}/${image._sFile}`,
-          ),
+      images: [],
+      isNSFW: classifyNSFW(profile),
+      isObsolete: profile._bIsObsolete ?? false,
+      isTrashed: false,
+      isMap: false,
+      isAudio: true,
+      audioUrl: profile._aPreviewMedia._aMetadata._sAudioUrl,
+      metadata: buildMetadata({
+        description,
+        isMap: false,
+        donationMethods: profile._aSubmitter._aDonationMethods,
+      }),
+    };
+  }
+
+  private async createRegularModPayload(
+    mod: GameBananaSubmission,
+  ): Promise<NewMod & { isTrashed: boolean }> {
+    const profile = await this.getMod(mod._idRow.toString(), "Mod");
+
+    if (profile._bIsTrashed === true) {
+      return this.createTrashedPayload(profile);
+    }
+
+    const description = profile._sText || profile._sDescription || "";
+    const category = categoryFromGameBananaProfile(profile);
+    const isMap = category === MAPS_CATEGORY_NAME;
+
+    return {
+      remoteId: profile._idRow.toString(),
+      name: profile._sName,
+      description,
+      tags: parseTags(profile._aTags),
+      author: profile._aSubmitter._sName,
+      likes: profile._nLikeCount ?? 0,
+      hero: guessHero(profile._sName),
+      downloadCount: profile._nDownloadCount ?? 0,
+      remoteUrl: profile._sProfileUrl,
+      category,
+      downloadable: (profile._aFiles?.length ?? 0) > 0,
+      remoteAddedAt: new Date(profile._tsDateAdded * 1000),
+      remoteUpdatedAt: new Date(profile._tsDateModified * 1000),
+      images: profile._aPreviewMedia._aImages.map(
+        (image) => `${image._sBaseUrl}/${image._sFile}`,
+      ),
       isNSFW: classifyNSFW(profile),
       isObsolete: profile._bIsObsolete ?? false,
       isTrashed: false,
       isMap,
-      isAudio: isSound,
-      audioUrl: isSound
-        ? (profile as GameBanana.GameBananaSoundProfile)._aPreviewMedia
-            ._aMetadata._sAudioUrl
-        : undefined,
+      isAudio: false,
       metadata: buildMetadata({
         description,
         isMap,
         donationMethods: profile._aSubmitter._aDonationMethods,
       }),
     };
+  }
 
-    return basePayload;
+  private createTrashedPayload(
+    profile:
+      | GameBanana.GameBananaModProfile
+      | GameBanana.GameBananaSoundProfile,
+  ): NewMod & { isTrashed: boolean } {
+    return {
+      remoteId: profile._idRow.toString(),
+      name: profile._sName,
+      description: "",
+      tags: [],
+      author: profile._aSubmitter._sName,
+      likes: 0,
+      hero: null,
+      downloadCount: 0,
+      remoteUrl: profile._sProfileUrl,
+      category: "",
+      downloadable: false,
+      remoteAddedAt: new Date(profile._tsDateAdded * 1000),
+      remoteUpdatedAt: new Date(profile._tsDateModified * 1000),
+      images: [],
+      isNSFW: false,
+      isObsolete: false,
+      isTrashed: true,
+      isMap: false,
+    };
   }
 
   async createMod(

--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -1,4 +1,4 @@
-import { ProviderError, ValidationError } from "@deadlock-mods/common";
+import { ProviderError } from "@deadlock-mods/common";
 import {
   db,
   type Mod,
@@ -326,152 +326,90 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
   async createModPayload(
     mod: GameBananaSubmission,
     source: GameBananaSubmissionSource,
-  ): Promise<NewMod> {
-    if (source === "featured") {
-      const featuredSubmission = mod as GameBanana.GameBananaSubmission;
-      const submission = await this.getMod(
-        featuredSubmission._idRow.toString(),
-        "Mod",
-      );
-      const description = submission._sText || submission._sDescription || "";
-      const isMap =
-        categoryFromGameBananaProfile(submission) === MAPS_CATEGORY_NAME;
-      return {
-        remoteId: featuredSubmission._idRow.toString(),
-        name: featuredSubmission._sName,
-        description,
-        tags: parseTags(submission._aTags),
-        author: featuredSubmission._aSubmitter._sName,
-        likes: featuredSubmission._nLikeCount ?? 0,
-        hero: guessHero(featuredSubmission._sName),
-        downloadCount: submission._nDownloadCount ?? 0,
-        remoteUrl: featuredSubmission._sProfileUrl,
-        category: categoryFromGameBananaProfile(submission),
-        downloadable: featuredSubmission._bHasFiles,
-        remoteAddedAt: new Date(submission._tsDateAdded * 1000),
-        remoteUpdatedAt: new Date(submission._tsDateModified * 1000),
-        images: submission._aPreviewMedia._aImages.map(
-          (image) => `${image._sBaseUrl}/${image._sFile}`,
-        ),
-        isNSFW: classifyNSFW(submission),
-        isObsolete: submission._bIsObsolete ?? false,
-        isMap,
-        metadata: buildMetadata({
-          description,
-          isMap,
-          donationMethods: submission._aSubmitter._aDonationMethods,
-        }),
-      };
-    }
+  ): Promise<NewMod & { isTrashed: boolean }> {
+    const isSound = source === "sound";
+    const profile = isSound
+      ? await this.getMod(mod._idRow.toString(), "Sound")
+      : await this.getMod(mod._idRow.toString(), "Mod");
 
-    if (source === "top") {
-      const topSubmission = mod as GameBanana.GameBananaTopSubmission;
-      const submission = await this.getMod(
-        topSubmission._idRow.toString(),
-        "Mod",
-      );
-      const description = submission._sText || submission._sDescription || "";
-      const isMap =
-        categoryFromGameBananaProfile(submission) === MAPS_CATEGORY_NAME;
+    if (profile._bIsTrashed === true) {
       return {
-        remoteId: topSubmission._idRow.toString(),
-        name: topSubmission._sName,
-        description,
-        tags: parseTags(submission._aTags),
-        author: topSubmission._aSubmitter._sName,
-        likes: topSubmission._nLikeCount,
-        hero: guessHero(topSubmission._sName),
-        downloadCount: submission._nDownloadCount,
-        remoteUrl: topSubmission._sProfileUrl,
-        category: categoryFromGameBananaProfile(submission),
-        downloadable: (submission?._aFiles?.length ?? 0) > 0,
-        remoteAddedAt: new Date(submission._tsDateAdded * 1000),
-        remoteUpdatedAt: new Date(submission._tsDateModified * 1000),
-        images: submission._aPreviewMedia._aImages.map(
-          (image) => `${image._sBaseUrl}/${image._sFile}`,
-        ),
-        isNSFW: classifyNSFW(submission),
-        isObsolete: submission._bIsObsolete ?? false,
-        isMap,
-        metadata: buildMetadata({
-          description,
-          isMap,
-          donationMethods: submission._aSubmitter._aDonationMethods,
-        }),
-      };
-    }
-
-    if (source === "all") {
-      const submission = await this.getMod(mod._idRow.toString(), "Mod");
-      const description = submission._sText || submission._sDescription || "";
-      const isMap =
-        categoryFromGameBananaProfile(submission) === MAPS_CATEGORY_NAME;
-      return {
-        remoteId: submission._idRow.toString(),
-        name: submission._sName,
-        description,
-        tags: parseTags(submission._aTags),
-        author: submission._aSubmitter._sName,
-        likes: submission._nLikeCount,
-        hero: guessHero(submission._sName),
-        downloadCount: submission._nDownloadCount,
-        remoteUrl: submission._sProfileUrl,
-        category: categoryFromGameBananaProfile(submission),
-        downloadable: (submission?._aFiles?.length ?? 0) > 0,
-        remoteAddedAt: new Date(submission._tsDateAdded * 1000),
-        remoteUpdatedAt: new Date(submission._tsDateModified * 1000),
-        images: submission._aPreviewMedia._aImages.map(
-          (image) => `${image._sBaseUrl}/${image._sFile}`,
-        ),
-        isNSFW: classifyNSFW(submission),
-        isObsolete: submission._bIsObsolete ?? false,
-        isMap,
-        metadata: buildMetadata({
-          description,
-          isMap,
-          donationMethods: submission._aSubmitter._aDonationMethods,
-        }),
-      };
-    }
-
-    if (source === "sound") {
-      const submission = await this.getMod(mod._idRow.toString(), "Sound");
-      const description = submission._sText || submission._sDescription || "";
-      return {
-        remoteId: submission._idRow.toString(),
-        name: submission._sName,
-        description,
-        tags: parseTags(submission._aTags),
-        author: submission._aSubmitter._sName,
-        likes: submission._nLikeCount,
-        hero: guessHero(submission._sName),
-        downloadCount: submission._nDownloadCount,
-        remoteUrl: submission._sProfileUrl,
-        category: categoryFromGameBananaProfile(submission),
-        downloadable: (submission?._aFiles?.length ?? 0) > 0,
-        remoteAddedAt: new Date(submission._tsDateAdded * 1000),
-        remoteUpdatedAt: new Date(submission._tsDateModified * 1000),
+        remoteId: profile._idRow.toString(),
+        name: profile._sName,
+        description: "",
+        tags: [],
+        author: profile._aSubmitter._sName,
+        likes: 0,
+        hero: null,
+        downloadCount: 0,
+        remoteUrl: profile._sProfileUrl,
+        category: "",
+        downloadable: false,
+        remoteAddedAt: new Date(profile._tsDateAdded * 1000),
+        remoteUpdatedAt: new Date(profile._tsDateModified * 1000),
         images: [],
-        isAudio: true,
-        audioUrl: submission._aPreviewMedia._aMetadata._sAudioUrl,
-        isNSFW: classifyNSFW(submission),
-        isObsolete: submission._bIsObsolete ?? false,
+        isNSFW: false,
+        isObsolete: false,
+        isTrashed: true,
         isMap: false,
-        metadata: buildMetadata({
-          description,
-          isMap: false,
-          donationMethods: submission._aSubmitter._aDonationMethods,
-        }),
       };
     }
 
-    throw new ValidationError(`Invalid source: ${source}`);
+    const description = profile._sText || profile._sDescription || "";
+    const isMap = isSound
+      ? false
+      : categoryFromGameBananaProfile(
+          profile as GameBanana.GameBananaModProfile,
+        ) === MAPS_CATEGORY_NAME;
+
+    const basePayload: NewMod & { isTrashed: boolean } = {
+      remoteId: profile._idRow.toString(),
+      name: profile._sName,
+      description,
+      tags: parseTags(profile._aTags),
+      author: profile._aSubmitter._sName,
+      likes: profile._nLikeCount ?? 0,
+      hero: guessHero(profile._sName),
+      downloadCount: profile._nDownloadCount ?? 0,
+      remoteUrl: profile._sProfileUrl,
+      category: categoryFromGameBananaProfile(profile),
+      downloadable: (profile._aFiles?.length ?? 0) > 0,
+      remoteAddedAt: new Date(profile._tsDateAdded * 1000),
+      remoteUpdatedAt: new Date(profile._tsDateModified * 1000),
+      images: isSound
+        ? []
+        : (
+            profile as GameBanana.GameBananaModProfile
+          )._aPreviewMedia._aImages.map(
+            (image) => `${image._sBaseUrl}/${image._sFile}`,
+          ),
+      isNSFW: classifyNSFW(profile),
+      isObsolete: profile._bIsObsolete ?? false,
+      isTrashed: false,
+      isMap,
+      isAudio: isSound,
+      audioUrl: isSound
+        ? (profile as GameBanana.GameBananaSoundProfile)._aPreviewMedia
+            ._aMetadata._sAudioUrl
+        : undefined,
+      metadata: buildMetadata({
+        description,
+        isMap,
+        donationMethods: profile._aSubmitter._aDonationMethods,
+      }),
+    };
+
+    return basePayload;
   }
 
   async createMod(
     mod: GameBananaSubmission,
     source: GameBananaSubmissionSource,
-  ): Promise<{ mod: Mod | undefined; filesChanged: boolean }> {
+  ): Promise<{
+    mod: Mod | undefined;
+    filesChanged: boolean;
+    handledAsTrashed?: boolean;
+  }> {
     this.logger
       .withMetadata({
         modId: mod._idRow.toString(),
@@ -480,6 +418,32 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       .debug("Creating/updating mod");
     try {
       const payload = await this.createModPayload(mod, source);
+
+      if (payload.isTrashed) {
+        const { remoteId } = payload;
+        const exists = await modRepository.existsByRemoteId(remoteId);
+        if (!exists) {
+          this.logger
+            .withMetadata({ modId: remoteId, source })
+            .info("Skipping trashed GameBanana mod not in database");
+          return {
+            mod: undefined,
+            filesChanged: false,
+            handledAsTrashed: true,
+          };
+        }
+        await modRepository.markAsTrashed(remoteId);
+        await cache.del(`mod:${remoteId}`);
+        await cache.del("mods:listing");
+        this.logger
+          .withMetadata({ modId: remoteId, source })
+          .info("Marked GameBanana mod as trashed");
+        return {
+          mod: undefined,
+          filesChanged: false,
+          handledAsTrashed: true,
+        };
+      }
 
       const dbMod = await modRepository.upsertByRemoteId(payload);
 

--- a/apps/api/src/providers/registry.ts
+++ b/apps/api/src/providers/registry.ts
@@ -20,7 +20,11 @@ export abstract class Provider<T> {
   abstract createMod(
     mod: T,
     source: string,
-  ): Promise<{ mod: Mod | undefined; filesChanged: boolean }>;
+  ): Promise<{
+    mod: Mod | undefined;
+    filesChanged: boolean;
+    handledAsTrashed?: boolean;
+  }>;
   abstract getModDownload<D>(remoteId: string): Promise<D>;
 }
 

--- a/apps/api/src/services/mod-sync.ts
+++ b/apps/api/src/services/mod-sync.ts
@@ -73,9 +73,10 @@ export class ModSyncService {
       wide?.merge({
         modCreated: !!result.mod,
         filesChanged: result.filesChanged,
+        handledAsTrashed: result.handledAsTrashed === true,
       });
 
-      if (!result.mod) {
+      if (!result.mod && !result.handledAsTrashed) {
         return {
           success: false,
           message: `Failed to synchronize mod ${remoteId}`,
@@ -88,7 +89,10 @@ export class ModSyncService {
 
       return {
         success: true,
-        message: `Mod ${remoteId} synchronized successfully`,
+        message:
+          result.handledAsTrashed === true
+            ? `Mod ${remoteId} is trashed on GameBanana and was hidden from the catalog`
+            : `Mod ${remoteId} synchronized successfully`,
       };
     } catch (error) {
       logger.withError(error).error("Error during single mod synchronization");

--- a/packages/database/drizzle/0050_elite_yellowjacket.sql
+++ b/packages/database/drizzle/0050_elite_yellowjacket.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mod" ADD COLUMN "is_trashed" boolean DEFAULT false NOT NULL;

--- a/packages/database/drizzle/meta/0050_snapshot.json
+++ b/packages/database/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,3095 @@
+{
+  "id": "2d14591b-b262-4c56-ab2e-1d3dfb99f274",
+  "prevId": "d0044b5d-d344-4ec3-b91e-7e11f8a0ff8b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "announcement_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "status": {
+          "name": "status",
+          "type": "announcement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_author_id_user_id_fk": {
+          "name": "announcement_author_id_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "user",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_account_id": {
+          "name": "idx_account_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_access_token_on_access_token": {
+          "name": "idx_oauth_access_token_on_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_token_on_refresh_token": {
+          "name": "idx_oauth_access_token_on_refresh_token",
+          "columns": [
+            {
+              "expression": "refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_application_user_id_user_id_fk": {
+          "name": "oauth_application_user_id_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_created_at": {
+          "name": "idx_user_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_message_session_created": {
+          "name": "idx_chat_message_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_message_session_id_chat_session_id_fk": {
+          "name": "chat_message_session_id_chat_session_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session": {
+      "name": "chat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_session_discord_channel_id": {
+          "name": "idx_chat_session_discord_channel_id",
+          "columns": [
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_chat_session_user_channel": {
+          "name": "unique_chat_session_user_channel",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair_like": {
+      "name": "crosshair_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crosshair_id": {
+          "name": "crosshair_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crosshair_like_crosshair_id_user_id_idx": {
+          "name": "crosshair_like_crosshair_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "crosshair_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_like_user_id": {
+          "name": "idx_crosshair_like_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_like_crosshair_id_crosshair_id_fk": {
+          "name": "crosshair_like_crosshair_id_crosshair_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "crosshair",
+          "columnsFrom": ["crosshair_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crosshair_like_user_id_user_id_fk": {
+          "name": "crosshair_like_user_id_user_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair": {
+      "name": "crosshair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "heroes": {
+          "name": "heroes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crosshair_created_at": {
+          "name": "idx_crosshair_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_likes": {
+          "name": "idx_crosshair_likes",
+          "columns": [
+            {
+              "expression": "likes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_downloads": {
+          "name": "idx_crosshair_downloads",
+          "columns": [
+            {
+              "expression": "downloads",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_user_id": {
+          "name": "idx_crosshair_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_user_id_user_id_fk": {
+          "name": "crosshair_user_id_user_id_fk",
+          "tableFrom": "crosshair",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_setting": {
+      "name": "custom_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_chunks": {
+      "name": "documentation_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documentation_chunks_embedding_idx": {
+          "name": "documentation_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_sync": {
+      "name": "documentation_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::json"
+        },
+        "exposed": {
+          "name": "exposed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_name_unique": {
+          "name": "feature_flags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_flag_overrides": {
+      "name": "user_feature_flag_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feature_flag_overrides_user_id_user_id_fk": {
+          "name": "user_feature_flag_overrides_user_id_user_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk": {
+          "name": "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feature_flag_overrides_user_id_feature_flag_id_unique": {
+          "name": "user_feature_flag_overrides_user_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_lock": {
+      "name": "job_lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_lock_job_name_unique": {
+          "name": "job_lock_job_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_patterns": {
+      "name": "message_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern_type": {
+          "name": "pattern_type",
+          "type": "pattern_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_text": {
+          "name": "pattern_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_patterns_embedding_idx": {
+          "name": "message_patterns_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "message_patterns_pattern_type_idx": {
+          "name": "message_patterns_pattern_type_idx",
+          "columns": [
+            {
+              "expression": "pattern_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_keywords": {
+      "name": "triage_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "triage_keywords_keyword_unique": {
+          "name": "triage_keywords_keyword_unique",
+          "nullsNotDistinct": false,
+          "columns": ["keyword"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mirrored_files": {
+      "name": "mirrored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mirrored_at": {
+          "name": "mirrored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_downloaded_at": {
+          "name": "last_downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated": {
+          "name": "last_validated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stale": {
+          "name": "is_stale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mirrored_files_last_downloaded_at": {
+          "name": "idx_mirrored_files_last_downloaded_at",
+          "columns": [
+            {
+              "expression": "last_downloaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mirrored_files_is_stale": {
+          "name": "idx_mirrored_files_is_stale",
+          "columns": [
+            {
+              "expression": "is_stale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_mod_download_id_and_mod_id": {
+          "name": "unique_mod_download_id_and_mod_id",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mirrored_files_mod_download_id_mod_download_id_fk": {
+          "name": "mirrored_files_mod_download_id_mod_download_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mirrored_files_mod_id_mod_id_fk": {
+          "name": "mirrored_files_mod_id_mod_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mirrored_files_file_hash_unique": {
+          "name": "mirrored_files_file_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_download": {
+      "name": "mod_download",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "md5_checksum": {
+          "name": "md5_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_download_mod_id_remote_id_idx": {
+          "name": "mod_download_mod_id_remote_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_download_created_at": {
+          "name": "idx_mod_download_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mod_download_mod_id_mod_id_fk": {
+          "name": "mod_download_mod_id_mod_id_fk",
+          "tableFrom": "mod_download",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod": {
+      "name": "mod",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloadable": {
+          "name": "downloadable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_added_at": {
+          "name": "remote_added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_updated_at": {
+          "name": "remote_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hero": {
+          "name": "hero",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_audio": {
+          "name": "is_audio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_map": {
+          "name": "is_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_nsfw": {
+          "name": "is_nsfw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_obsolete": {
+          "name": "is_obsolete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_trashed": {
+          "name": "is_trashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_blacklisted": {
+          "name": "is_blacklisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blacklist_reason": {
+          "name": "blacklist_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_at": {
+          "name": "blacklisted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_by": {
+          "name": "blacklisted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_updated_at": {
+          "name": "files_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mod_created_at": {
+          "name": "idx_mod_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_updated_at": {
+          "name": "idx_mod_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_blacklisted_remote_updated": {
+          "name": "idx_mod_blacklisted_remote_updated",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mod_remote_id_unique": {
+          "name": "mod_remote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["remote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hardware_id": {
+          "name": "hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_content_hash_idx": {
+          "name": "profiles_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_hardware_id": {
+          "name": "reporter_hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_mod_id_reporter_hardware_id_idx": {
+          "name": "report_mod_id_reporter_hardware_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_hardware_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_mod_id": {
+          "name": "idx_report_mod_id",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_mod_id_mod_id_fk": {
+          "name": "report_mod_id_mod_id_fk",
+          "tableFrom": "report",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rss_item": {
+      "name": "rss_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gamebanana'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rss_item_link_source_idx": {
+          "name": "rss_item_link_source_idx",
+          "columns": [
+            {
+              "expression": "link",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rss_item_pub_date_idx": {
+          "name": "rss_item_pub_date_idx",
+          "columns": [
+            {
+              "expression": "pub_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_feature_flags": {
+      "name": "segment_feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_feature_flags_segment_id_segments_id_fk": {
+          "name": "segment_feature_flags_segment_id_segments_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_feature_flags_feature_flag_id_feature_flags_id_fk": {
+          "name": "segment_feature_flags_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_feature_flags_segment_id_feature_flag_id_unique": {
+          "name": "segment_feature_flags_segment_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_members": {
+      "name": "segment_members",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_members_segment_id_segments_id_fk": {
+          "name": "segment_members_segment_id_segments_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_members_user_id_user_id_fk": {
+          "name": "segment_members_user_id_user_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_members_segment_id_user_id_unique": {
+          "name": "segment_members_segment_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segments_name_unique": {
+          "name": "segments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vpk": {
+      "name": "vpk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fast_hash": {
+          "name": "fast_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sig": {
+          "name": "content_sig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vpk_version": {
+          "name": "vpk_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_multiparts": {
+          "name": "has_multiparts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_inline_data": {
+          "name": "has_inline_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merkle_root": {
+          "name": "merkle_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "vpk_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_mtime": {
+          "name": "file_mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vpk_sha256_uk": {
+          "name": "vpk_sha256_uk",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_content_sig_idx": {
+          "name": "vpk_content_sig_idx",
+          "columns": [
+            {
+              "expression": "content_sig",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_src_uk": {
+          "name": "vpk_src_uk",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_fast_size_idx": {
+          "name": "vpk_fast_size_idx",
+          "columns": [
+            {
+              "expression": "fast_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_bytes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vpk_mod_id_mod_id_fk": {
+          "name": "vpk_mod_id_mod_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vpk_mod_download_id_mod_download_id_fk": {
+          "name": "vpk_mod_download_id_mod_download_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.announcement_category": {
+      "name": "announcement_category",
+      "schema": "public",
+      "values": ["maintenance", "downtime", "info"]
+    },
+    "public.announcement_status": {
+      "name": "announcement_status",
+      "schema": "public",
+      "values": ["draft", "published", "archived"]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": ["human", "ai", "system"]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["idle", "syncing", "error"]
+    },
+    "public.pattern_type": {
+      "name": "pattern_type",
+      "schema": "public",
+      "values": ["bug_report", "help_request"]
+    },
+    "public.vpk_state": {
+      "name": "vpk_state",
+      "schema": "public",
+      "values": ["ok", "duplicate", "corrupt"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1775504692715,
       "tag": "0049_nostalgic_fixer",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1776618124163,
+      "tag": "0050_elite_yellowjacket",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/repositories/mod.repository.ts
+++ b/packages/database/src/repositories/mod.repository.ts
@@ -11,7 +11,7 @@ export class ModRepository {
     return await this.db
       .select()
       .from(mods)
-      .where(eq(mods.isBlacklisted, false))
+      .where(and(eq(mods.isBlacklisted, false), eq(mods.isTrashed, false)))
       .orderBy(desc(mods.remoteUpdatedAt));
   }
 
@@ -28,7 +28,13 @@ export class ModRepository {
     const result = await this.db
       .select()
       .from(mods)
-      .where(and(eq(mods.remoteId, remoteId), eq(mods.isBlacklisted, false)))
+      .where(
+        and(
+          eq(mods.remoteId, remoteId),
+          eq(mods.isBlacklisted, false),
+          eq(mods.isTrashed, false),
+        ),
+      )
       .limit(1);
     return result.length > 0 ? result[0] : null;
   }
@@ -52,7 +58,11 @@ export class ModRepository {
       .select()
       .from(mods)
       .where(
-        and(inArray(mods.remoteId, remoteIds), eq(mods.isBlacklisted, false)),
+        and(
+          inArray(mods.remoteId, remoteIds),
+          eq(mods.isBlacklisted, false),
+          eq(mods.isTrashed, false),
+        ),
       )
       .orderBy(desc(mods.remoteUpdatedAt));
   }
@@ -94,6 +104,7 @@ export class ModRepository {
       blacklistReason: _blacklistReason,
       blacklistedAt: _blacklistedAt,
       blacklistedBy: _blacklistedBy,
+      isTrashed: _isTrashed,
       overrides: _overrides,
       metadata,
       ...updateableFields
@@ -175,6 +186,36 @@ export class ModRepository {
         blacklistReason: null,
         blacklistedAt: null,
         blacklistedBy: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(mods.remoteId, remoteId))
+      .returning();
+    if (result.length === 0) {
+      throw new EntityNotFoundError("mod", remoteId);
+    }
+    return result[0];
+  }
+
+  async markAsTrashed(remoteId: string): Promise<Mod> {
+    const result = await this.db
+      .update(mods)
+      .set({
+        isTrashed: true,
+        updatedAt: new Date(),
+      })
+      .where(eq(mods.remoteId, remoteId))
+      .returning();
+    if (result.length === 0) {
+      throw new EntityNotFoundError("mod", remoteId);
+    }
+    return result[0];
+  }
+
+  async unmarkAsTrashed(remoteId: string): Promise<Mod> {
+    const result = await this.db
+      .update(mods)
+      .set({
+        isTrashed: false,
         updatedAt: new Date(),
       })
       .where(eq(mods.remoteId, remoteId))

--- a/packages/database/src/schema/mods.ts
+++ b/packages/database/src/schema/mods.ts
@@ -53,6 +53,7 @@ export const mods = pgTable(
     downloadCount: integer("download_count").notNull().default(0),
     isNSFW: boolean("is_nsfw").notNull().default(false),
     isObsolete: boolean("is_obsolete").default(false),
+    isTrashed: boolean("is_trashed").notNull().default(false),
     isBlacklisted: boolean("is_blacklisted").notNull().default(false),
     blacklistReason: text("blacklist_reason"),
     blacklistedAt: timestamp("blacklisted_at", { mode: "date" }),

--- a/packages/shared/src/dto/mod.dto.ts
+++ b/packages/shared/src/dto/mod.dto.ts
@@ -44,5 +44,5 @@ export const modDownloadOverridesToDto = (
   }));
 };
 
-export type ModDto = ReturnType<typeof toModDto>;
+export type ModDto = Omit<ReturnType<typeof toModDto>, "isTrashed">;
 export type ModDownloadDto = ReturnType<typeof toModDownloadDto>;


### PR DESCRIPTION
## Summary

- Detect trashed mods on GameBanana during sync via `_bIsTrashed` flag
- Add `is_trashed` column to mod schema to track trashed status
- Mark existing mods as trashed instead of attempting full sync when trashed upstream
- Refactor `createModPayload` to consolidate duplicate source-handling logic across featured/top/all/sound sources

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔧 Code refactoring (no functional changes)

## Related Issues

- Closes #46

## AI Disclosure

- [x] AI-assisted — Tool: Cursor, Used for: commit message generation

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] I have read the Contributing Guidelines and AI Policy
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [x] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Trashed Mods Handling During GameBanana Sync

This PR introduces detection and handling of trashed mods from GameBanana during the sync process, addressing #46.

### Functional Changes

**Trashed Mod Detection**: The GameBanana provider now detects when a mod is marked as trashed upstream (via the `_bIsTrashed` flag) and handles it appropriately by marking the mod as trashed in the local database rather than attempting a full sync.

**Payload Generation Refactoring**: The `createModPayload` method in the GameBanana provider has been consolidated to unify duplicate source-handling logic across featured, top, all, and sound sources, reducing code duplication while adding trash-awareness. When a mod is detected as trashed, it returns a minimal payload with `isTrashed: true`.

**Sync Flow Changes**: The mod sync service now treats trashed mods as a successful sync operation (distinct from actual synchronization) and records this in telemetry. The sync process skips full processing for trashed mods and returns a specific response indicating the mod was hidden from the catalog.

**Mod Visibility**: Query methods in the mod repository now exclude trashed mods from results, ensuring trashed mods don't appear in listings or lookups by remote ID.

### Affected Packages

- **apps/api**: GameBanana provider (`createModPayload`, `createMod`) and mod sync service updated to detect and handle trashed mods
- **packages/database**: 
  - New schema field: `is_trashed` column added to mod table (boolean, defaults to `false`)
  - New repository methods: `markAsTrashed(remoteId)` and `unmarkAsTrashed(remoteId)` for managing trash status
  - Updated queries: `findAll`, `findByRemoteId`, and `findByRemoteIds` now exclude trashed mods
  - Database migration #50 required

### API Changes

The following method signatures have been updated:
- `GameBananaProvider.createModPayload()`: Return type now includes `{ isTrashed: boolean }`
- `Provider.createMod()`: Return type now includes optional `{ handledAsTrashed?: boolean }`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->