### PR TITLE
feat(desktop): add pause and resume for downloads

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -1247,6 +1247,18 @@ pub async fn cancel_download(app_handle: AppHandle, mod_id: String) -> Result<()
 }
 
 #[tauri::command]
+pub async fn pause_download(app_handle: AppHandle, mod_id: String) -> Result<(), Error> {
+  let manager = get_download_manager(app_handle).await;
+  manager.pause_download(&mod_id).await
+}
+
+#[tauri::command]
+pub async fn resume_download(app_handle: AppHandle, mod_id: String) -> Result<(), Error> {
+  let manager = get_download_manager(app_handle).await;
+  manager.resume_download(&mod_id).await
+}
+
+#[tauri::command]
 pub async fn get_download_status(
   app_handle: AppHandle,
   mod_id: String,

--- a/apps/desktop/src-tauri/src/download_manager/downloader.rs
+++ b/apps/desktop/src-tauri/src/download_manager/downloader.rs
@@ -2,7 +2,6 @@ use crate::errors::Error;
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, RANGE};
 use serde::{Deserialize, Serialize};
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -69,13 +68,13 @@ impl Default for PauseHandle {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct PartialMeta {
   etag: Option<String>,
+  last_modified: Option<String>,
 }
 
 fn partial_download_path(target: &Path) -> PathBuf {
-  let name = target.file_name().unwrap_or_default().to_owned();
-  let mut new_name = name;
-  new_name.push(".partial");
-  target.with_file_name(new_name)
+  let mut name = target.file_name().unwrap_or_default().to_owned();
+  name.push(".partial");
+  target.with_file_name(name)
 }
 
 fn partial_meta_path(partial: &Path) -> PathBuf {
@@ -87,17 +86,19 @@ fn partial_meta_path(partial: &Path) -> PathBuf {
 fn header_etag(headers: &HeaderMap) -> Option<String> {
   headers
     .get(reqwest::header::ETAG)
-    .or_else(|| headers.get("etag"))
+    .and_then(|v| v.to_str().ok())
+    .map(std::string::ToString::to_string)
+}
+
+fn header_last_modified(headers: &HeaderMap) -> Option<String> {
+  headers
+    .get(reqwest::header::LAST_MODIFIED)
     .and_then(|v| v.to_str().ok())
     .map(std::string::ToString::to_string)
 }
 
 fn parse_content_range_total(headers: &HeaderMap) -> Option<u64> {
-  let value = headers
-    .get(reqwest::header::CONTENT_RANGE)
-    .or_else(|| headers.get("content-range"))?
-    .to_str()
-    .ok()?;
+  let value = headers.get(reqwest::header::CONTENT_RANGE)?.to_str().ok()?;
   let (_, rest) = value.split_once('/')?;
   rest.trim().parse().ok()
 }
@@ -123,8 +124,7 @@ async fn remove_partial_pair(partial_path: &Path, meta_path: &Path) {
   let _ = tokio::fs::remove_file(meta_path).await;
 }
 
-/// Non-pausing download (still staged via `*.partial` then renamed).
-#[allow(dead_code)] // Public helper; kept for tests and future callers.
+#[allow(dead_code)]
 pub async fn download_file<F>(
   url: &str,
   target_path: &Path,
@@ -194,10 +194,12 @@ where
       .read_timeout(std::time::Duration::from_secs(60))
   })?;
 
-  let start_time = Instant::now();
-  let mut last_progress_time = Instant::now();
+  let mut chunk_retries: u32 = 0;
 
   'retry: loop {
+    let start_time = Instant::now();
+    let mut last_progress_time = Instant::now();
+
     let stored_meta = read_partial_meta(&meta_path).await.unwrap_or_default();
     let resume_from = match tokio::fs::metadata(&partial_path).await {
       Ok(m) => m.len(),
@@ -206,7 +208,7 @@ where
 
     if resume_from == 0 {
       let _ = tokio::fs::remove_file(&meta_path).await;
-    } else if stored_meta.etag.is_none() {
+    } else if stored_meta.etag.is_none() && stored_meta.last_modified.is_none() {
       log::warn!("Partial file without resume metadata; restarting download");
       remove_partial_pair(&partial_path, &meta_path).await;
       continue 'retry;
@@ -242,6 +244,7 @@ where
 
     let headers = response.headers().clone();
     let resp_etag = header_etag(&headers);
+    let resp_last_modified = header_last_modified(&headers);
 
     if resume_from > 0 {
       if status != reqwest::StatusCode::PARTIAL_CONTENT {
@@ -250,15 +253,27 @@ where
         continue 'retry;
       }
 
-      if let Some(ref stored) = stored_meta.etag
-        && resp_etag.as_ref() != Some(stored) {
+      if let Some(ref stored_etag) = stored_meta.etag
+        && resp_etag.as_ref() != Some(stored_etag)
+      {
+        // ETag changed; accept the resume only if Last-Modified still matches.
+        if resp_last_modified.is_none() || resp_last_modified != stored_meta.last_modified {
           log::warn!("ETag changed since partial download; restarting");
           remove_partial_pair(&partial_path, &meta_path).await;
           continue 'retry;
         }
+        log::info!("ETag changed but Last-Modified matches; accepting resume");
+      }
 
       if let Some(total) = parse_content_range_total(&headers) {
         total_entity_size = total_entity_size.max(total);
+        if let Some(limit) = max_bytes
+          && total > limit
+        {
+          return Err(Error::Network(format!(
+            "Refusing to download {total} bytes (limit {limit})"
+          )));
+        }
       }
     } else {
       if let Some(limit) = max_bytes {
@@ -288,6 +303,7 @@ where
         .map_err(|e| Error::FileWriteFailed(format!("Failed to create partial file: {e}")))?;
       let meta = PartialMeta {
         etag: resp_etag.clone(),
+        last_modified: resp_last_modified.clone(),
       };
       if let Err(e) = write_partial_meta(&meta_path, &meta).await {
         log::warn!("Failed to write initial resume meta: {e}");
@@ -313,7 +329,20 @@ where
       }
 
       let chunk = match stream.next().await {
-        Some(c) => c.map_err(|e| Error::Network(format!("Failed to read chunk: {e}")))?,
+        Some(Ok(c)) => c,
+        Some(Err(e)) => {
+          // Stream errors after a long pause are typically stale TCP connections.
+          // Drop the stream and re-issue the Range request using the partial file.
+          if chunk_retries < 3 {
+            chunk_retries += 1;
+            log::warn!("Chunk read error (retry {chunk_retries}/3), re-issuing Range request: {e}");
+            drop(file);
+            continue 'retry;
+          }
+          return Err(Error::Network(format!(
+            "Failed to read chunk after {chunk_retries} retries: {e}"
+          )));
+        }
         None => break,
       };
 

--- a/apps/desktop/src-tauri/src/download_manager/downloader.rs
+++ b/apps/desktop/src-tauri/src/download_manager/downloader.rs
@@ -1,9 +1,15 @@
 use crate::errors::Error;
 use futures::StreamExt;
-use std::path::Path;
+use reqwest::header::{HeaderMap, RANGE};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
-use tokio::fs::File;
+use tokio::fs::{File, OpenOptions};
 use tokio::io::AsyncWriteExt;
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 #[allow(dead_code)]
@@ -16,6 +22,109 @@ pub struct DownloadProgress {
   pub speed: f64,
 }
 
+/// Shared pause gate for in-flight downloads (one per mod).
+#[derive(Clone, Debug)]
+pub struct PauseHandle {
+  paused: Arc<AtomicBool>,
+  notify: Arc<Notify>,
+}
+
+impl PauseHandle {
+  pub fn new() -> Self {
+    Self {
+      paused: Arc::new(AtomicBool::new(false)),
+      notify: Arc::new(Notify::new()),
+    }
+  }
+
+  pub fn pause(&self) {
+    self.paused.store(true, Ordering::SeqCst);
+  }
+
+  pub fn resume(&self) {
+    self.paused.store(false, Ordering::SeqCst);
+    self.notify.notify_waiters();
+  }
+
+  pub fn is_paused(&self) -> bool {
+    self.paused.load(Ordering::SeqCst)
+  }
+
+  pub async fn wait_until_running(&self, cancel_token: &CancellationToken) {
+    while !cancel_token.is_cancelled() && self.is_paused() {
+      tokio::select! {
+        () = self.notify.notified() => {}
+        () = cancel_token.cancelled() => {}
+      }
+    }
+  }
+}
+
+impl Default for PauseHandle {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PartialMeta {
+  etag: Option<String>,
+}
+
+fn partial_download_path(target: &Path) -> PathBuf {
+  let name = target.file_name().unwrap_or_default().to_owned();
+  let mut new_name = name;
+  new_name.push(".partial");
+  target.with_file_name(new_name)
+}
+
+fn partial_meta_path(partial: &Path) -> PathBuf {
+  let mut name = partial.file_name().unwrap_or_default().to_os_string();
+  name.push(".meta");
+  partial.with_file_name(name)
+}
+
+fn header_etag(headers: &HeaderMap) -> Option<String> {
+  headers
+    .get(reqwest::header::ETAG)
+    .or_else(|| headers.get("etag"))
+    .and_then(|v| v.to_str().ok())
+    .map(std::string::ToString::to_string)
+}
+
+fn parse_content_range_total(headers: &HeaderMap) -> Option<u64> {
+  let value = headers
+    .get(reqwest::header::CONTENT_RANGE)
+    .or_else(|| headers.get("content-range"))?
+    .to_str()
+    .ok()?;
+  let (_, rest) = value.split_once('/')?;
+  rest.trim().parse().ok()
+}
+
+async fn read_partial_meta(path: &Path) -> Option<PartialMeta> {
+  let bytes = tokio::fs::read(path).await.ok()?;
+  serde_json::from_slice(&bytes).ok()
+}
+
+async fn write_partial_meta(path: &Path, meta: &PartialMeta) -> Result<(), Error> {
+  if let Some(parent) = path.parent() {
+    tokio::fs::create_dir_all(parent).await.map_err(Error::Io)?;
+  }
+  let data = serde_json::to_vec(meta).map_err(|e| Error::Network(e.to_string()))?;
+  tokio::fs::write(path, data)
+    .await
+    .map_err(|e| Error::FileWriteFailed(format!("Failed to write resume meta: {e}")))?;
+  Ok(())
+}
+
+async fn remove_partial_pair(partial_path: &Path, meta_path: &Path) {
+  let _ = tokio::fs::remove_file(partial_path).await;
+  let _ = tokio::fs::remove_file(meta_path).await;
+}
+
+/// Non-pausing download (still staged via `*.partial` then renamed).
+#[allow(dead_code)] // Public helper; kept for tests and future callers.
 pub async fn download_file<F>(
   url: &str,
   target_path: &Path,
@@ -42,113 +151,272 @@ pub async fn download_file_with_limit<F>(
 where
   F: Fn(DownloadProgress) + Send + 'static,
 {
-  log::info!("Starting download from {url} to {target_path:?} (max_bytes={max_bytes:?})");
+  let pause = PauseHandle::new();
+  download_file_resumable(
+    url,
+    target_path,
+    0,
+    on_progress,
+    cancel_token,
+    pause,
+    max_bytes,
+  )
+  .await
+}
+
+/// Resumable download using a `*.partial` staging file and HTTP Range when supported.
+/// On success, renames the partial file to `target_path`.
+pub async fn download_file_resumable<F>(
+  url: &str,
+  target_path: &Path,
+  expected_size: u64,
+  on_progress: F,
+  cancel_token: CancellationToken,
+  pause: PauseHandle,
+  max_bytes: Option<u64>,
+) -> Result<(), Error>
+where
+  F: Fn(DownloadProgress) + Send + 'static,
+{
+  log::info!(
+    "Starting resumable download from {url} to {target_path:?} (expected_size={expected_size}, max_bytes={max_bytes:?})"
+  );
+
+  let partial_path = partial_download_path(target_path);
+  let meta_path = partial_meta_path(&partial_path);
+
+  if let Some(parent) = target_path.parent() {
+    tokio::fs::create_dir_all(parent).await.map_err(Error::Io)?;
+  }
 
   let client = crate::proxy::build_http_client(|b| {
     b.connect_timeout(std::time::Duration::from_secs(30))
       .read_timeout(std::time::Duration::from_secs(60))
   })?;
 
-  let response = client
-    .get(url)
-    .send()
-    .await
-    .map_err(|e| Error::Network(format!("Failed to send request: {e}")))?;
-
-  if !response.status().is_success() {
-    return Err(Error::Network(format!(
-      "Server returned error status: {}",
-      response.status()
-    )));
-  }
-
-  let total_size = response.content_length().unwrap_or(0);
-  log::info!("Download size: {total_size} bytes");
-
-  if let Some(limit) = max_bytes
-    && total_size > limit
-  {
-    return Err(Error::Network(format!(
-      "Refusing to download {total_size} bytes (limit {limit})"
-    )));
-  }
-
-  if let Some(parent) = target_path.parent() {
-    tokio::fs::create_dir_all(parent).await.map_err(Error::Io)?;
-  }
-
-  let mut file = File::create(target_path)
-    .await
-    .map_err(|e| Error::FileWriteFailed(format!("Failed to create file: {e}")))?;
-
-  let mut stream = response.bytes_stream();
-  let mut downloaded: u64 = 0;
   let start_time = Instant::now();
   let mut last_progress_time = Instant::now();
 
-  while let Some(chunk) = stream.next().await {
-    if cancel_token.is_cancelled() {
-      log::info!("Download cancelled");
-      drop(file);
-      let _ = tokio::fs::remove_file(target_path).await;
-      return Err(Error::DownloadCancelled);
+  'retry: loop {
+    let stored_meta = read_partial_meta(&meta_path).await.unwrap_or_default();
+    let resume_from = match tokio::fs::metadata(&partial_path).await {
+      Ok(m) => m.len(),
+      Err(_) => 0,
+    };
+
+    if resume_from == 0 {
+      let _ = tokio::fs::remove_file(&meta_path).await;
+    } else if stored_meta.etag.is_none() {
+      log::warn!("Partial file without resume metadata; restarting download");
+      remove_partial_pair(&partial_path, &meta_path).await;
+      continue 'retry;
     }
 
-    let chunk = chunk.map_err(|e| Error::Network(format!("Failed to read chunk: {e}")))?;
+    let base_offset = resume_from;
+    let mut session_downloaded: u64 = 0;
+    let mut total_entity_size = expected_size;
 
-    downloaded += chunk.len() as u64;
+    let mut request = client.get(url);
+    if resume_from > 0 {
+      request = request.header(RANGE, format!("bytes={resume_from}-"));
+    }
 
-    if let Some(limit) = max_bytes
-      && downloaded > limit
-    {
-      log::warn!("Download exceeded size limit ({downloaded} > {limit}), aborting");
-      drop(file);
-      let _ = tokio::fs::remove_file(target_path).await;
+    let response = request
+      .send()
+      .await
+      .map_err(|e| Error::Network(format!("Failed to send request: {e}")))?;
+
+    let status = response.status();
+
+    if status == reqwest::StatusCode::RANGE_NOT_SATISFIABLE {
+      log::warn!("Server returned 416; clearing partial and retrying");
+      remove_partial_pair(&partial_path, &meta_path).await;
+      continue 'retry;
+    }
+
+    if !status.is_success() {
       return Err(Error::Network(format!(
-        "Download exceeded size limit of {limit} bytes"
+        "Server returned error status: {status}"
       )));
     }
 
-    file
-      .write_all(&chunk)
-      .await
-      .map_err(|e| Error::FileWriteFailed(format!("Failed to write to file: {e}")))?;
+    let headers = response.headers().clone();
+    let resp_etag = header_etag(&headers);
 
-    let now = Instant::now();
-    let elapsed_since_last = now.duration_since(last_progress_time).as_millis();
+    if resume_from > 0 {
+      if status != reqwest::StatusCode::PARTIAL_CONTENT {
+        log::info!("Resume not honored (status {status}); restarting from scratch");
+        remove_partial_pair(&partial_path, &meta_path).await;
+        continue 'retry;
+      }
 
-    let is_complete = total_size > 0 && downloaded >= total_size;
+      if let Some(ref stored) = stored_meta.etag
+        && resp_etag.as_ref() != Some(stored) {
+          log::warn!("ETag changed since partial download; restarting");
+          remove_partial_pair(&partial_path, &meta_path).await;
+          continue 'retry;
+        }
 
-    if is_complete || elapsed_since_last >= PROGRESS_THROTTLE_MS {
-      let elapsed_total = start_time.elapsed().as_secs_f64();
-      let speed = if elapsed_total > 0.0 {
-        downloaded as f64 / elapsed_total
-      } else {
-        0.0
+      if let Some(total) = parse_content_range_total(&headers) {
+        total_entity_size = total_entity_size.max(total);
+      }
+    } else {
+      if let Some(limit) = max_bytes {
+        let advertised = response.content_length().unwrap_or(0);
+        if advertised > limit {
+          return Err(Error::Network(format!(
+            "Refusing to download {advertised} bytes (limit {limit})"
+          )));
+        }
+      }
+
+      let cl = response.content_length().unwrap_or(0);
+      if cl > 0 {
+        total_entity_size = total_entity_size.max(cl);
+      }
+    }
+
+    let mut file = if resume_from > 0 {
+      OpenOptions::new()
+        .append(true)
+        .open(&partial_path)
+        .await
+        .map_err(|e| Error::FileWriteFailed(format!("Failed to open partial file: {e}")))?
+    } else {
+      let f = File::create(&partial_path)
+        .await
+        .map_err(|e| Error::FileWriteFailed(format!("Failed to create partial file: {e}")))?;
+      let meta = PartialMeta {
+        etag: resp_etag.clone(),
+      };
+      if let Err(e) = write_partial_meta(&meta_path, &meta).await {
+        log::warn!("Failed to write initial resume meta: {e}");
+      }
+      f
+    };
+
+    let mut stream = response.bytes_stream();
+
+    loop {
+      if cancel_token.is_cancelled() {
+        log::info!("Download cancelled");
+        drop(file);
+        remove_partial_pair(&partial_path, &meta_path).await;
+        return Err(Error::DownloadCancelled);
+      }
+
+      pause.wait_until_running(&cancel_token).await;
+      if cancel_token.is_cancelled() {
+        drop(file);
+        remove_partial_pair(&partial_path, &meta_path).await;
+        return Err(Error::DownloadCancelled);
+      }
+
+      let chunk = match stream.next().await {
+        Some(c) => c.map_err(|e| Error::Network(format!("Failed to read chunk: {e}")))?,
+        None => break,
       };
 
-      on_progress(DownloadProgress { downloaded, speed });
+      session_downloaded += chunk.len() as u64;
+      let downloaded_total = base_offset.saturating_add(session_downloaded);
 
-      last_progress_time = now;
+      if let Some(limit) = max_bytes
+        && downloaded_total > limit
+      {
+        log::warn!("Download exceeded size limit ({downloaded_total} > {limit}), aborting");
+        drop(file);
+        remove_partial_pair(&partial_path, &meta_path).await;
+        return Err(Error::Network(format!(
+          "Download exceeded size limit of {limit} bytes"
+        )));
+      }
+
+      file
+        .write_all(&chunk)
+        .await
+        .map_err(|e| Error::FileWriteFailed(format!("Failed to write to file: {e}")))?;
+
+      let now = Instant::now();
+      let elapsed_since_last = now.duration_since(last_progress_time).as_millis();
+
+      let is_complete = total_entity_size > 0 && downloaded_total >= total_entity_size;
+
+      if is_complete || elapsed_since_last >= PROGRESS_THROTTLE_MS {
+        let elapsed_total = start_time.elapsed().as_secs_f64();
+        let speed = if elapsed_total > 0.0 {
+          session_downloaded as f64 / elapsed_total
+        } else {
+          0.0
+        };
+
+        on_progress(DownloadProgress {
+          downloaded: downloaded_total,
+          speed,
+        });
+
+        last_progress_time = now;
+      }
     }
+
+    let final_total = base_offset.saturating_add(session_downloaded);
+    let elapsed_total = start_time.elapsed().as_secs_f64();
+    let final_speed = if elapsed_total > 0.0 {
+      session_downloaded as f64 / elapsed_total
+    } else {
+      0.0
+    };
+    on_progress(DownloadProgress {
+      downloaded: final_total,
+      speed: final_speed,
+    });
+
+    file
+      .flush()
+      .await
+      .map_err(|e| Error::FileWriteFailed(format!("Failed to flush file: {e}")))?;
+
+    drop(file);
+
+    if tokio::fs::metadata(&partial_path)
+      .await
+      .map(|m| m.len())
+      .unwrap_or(0)
+      == 0
+    {
+      remove_partial_pair(&partial_path, &meta_path).await;
+      return Err(Error::Network("Downloaded empty file".to_string()));
+    }
+
+    if let Err(e) = tokio::fs::rename(&partial_path, target_path).await {
+      return Err(Error::FileWriteFailed(format!(
+        "Failed to finalize download: {e}"
+      )));
+    }
+    let _ = tokio::fs::remove_file(&meta_path).await;
+
+    log::info!("Download completed: {target_path:?}");
+    return Ok(());
   }
-
-  file
-    .flush()
-    .await
-    .map_err(|e| Error::FileWriteFailed(format!("Failed to flush file: {e}")))?;
-
-  log::info!("Download completed: {target_path:?}");
-  Ok(())
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  use tempfile::tempdir;
+
+  #[test]
+  fn parse_content_range_total_parses_suffix() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+      reqwest::header::CONTENT_RANGE,
+      reqwest::header::HeaderValue::from_static("bytes 0-1023/9360840"),
+    );
+    assert_eq!(parse_content_range_total(&headers), Some(9_360_840));
+  }
 
   #[tokio::test]
   async fn test_download_file() {
+    use tempfile::tempdir;
+
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("test.txt");
     let cancel_token = CancellationToken::new();

--- a/apps/desktop/src-tauri/src/download_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/download_manager/mod.rs
@@ -734,22 +734,21 @@ impl DownloadManager {
   }
 
   pub async fn pause_download(&self, mod_id: &str) -> Result<(), Error> {
-    {
-      let mut active = self.active_downloads.lock().await;
-      let Some(entry) = active.get_mut(mod_id) else {
-        return Err(Error::InvalidInput(format!(
-          "No active download found for mod: {mod_id}"
-        )));
-      };
-      if entry.status != "downloading" {
-        return Err(Error::InvalidInput(format!(
-          "Download for mod {mod_id} is not active (status: {})",
-          entry.status
-        )));
-      }
-      entry.pause.pause();
-      entry.status = "paused".to_string();
+    let mut active = self.active_downloads.lock().await;
+    let Some(entry) = active.get_mut(mod_id) else {
+      return Err(Error::InvalidInput(format!(
+        "No active download found for mod: {mod_id}"
+      )));
+    };
+    if entry.status != "downloading" {
+      return Err(Error::InvalidInput(format!(
+        "Download for mod {mod_id} is not active (status: {})",
+        entry.status
+      )));
     }
+    entry.pause.pause();
+    entry.status = "paused".to_string();
+    // Emit while holding the lock so the event cannot race with download completion.
     self
       .app_handle
       .emit(
@@ -763,22 +762,21 @@ impl DownloadManager {
   }
 
   pub async fn resume_download(&self, mod_id: &str) -> Result<(), Error> {
-    {
-      let mut active = self.active_downloads.lock().await;
-      let Some(entry) = active.get_mut(mod_id) else {
-        return Err(Error::InvalidInput(format!(
-          "No active download found for mod: {mod_id}"
-        )));
-      };
-      if entry.status != "paused" {
-        return Err(Error::InvalidInput(format!(
-          "Download for mod {mod_id} is not paused (status: {})",
-          entry.status
-        )));
-      }
-      entry.pause.resume();
-      entry.status = "downloading".to_string();
+    let mut active = self.active_downloads.lock().await;
+    let Some(entry) = active.get_mut(mod_id) else {
+      return Err(Error::InvalidInput(format!(
+        "No active download found for mod: {mod_id}"
+      )));
+    };
+    if entry.status != "paused" {
+      return Err(Error::InvalidInput(format!(
+        "Download for mod {mod_id} is not paused (status: {})",
+        entry.status
+      )));
     }
+    entry.pause.resume();
+    entry.status = "downloading".to_string();
+    // Emit while holding the lock so the event cannot race with download completion.
     self
       .app_handle
       .emit(

--- a/apps/desktop/src-tauri/src/download_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/download_manager/mod.rs
@@ -1,7 +1,7 @@
 pub mod downloader;
 
 use crate::errors::Error;
-use downloader::{DownloadProgress as FileProgress, download_file};
+use downloader::{DownloadProgress as FileProgress, PauseHandle, download_file_resumable};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
@@ -82,6 +82,18 @@ pub struct DownloadErrorEvent {
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DownloadPausedEvent {
+  pub mod_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadResumedEvent {
+  pub mod_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DownloadStatus {
   pub mod_id: String,
   pub status: String,
@@ -91,6 +103,7 @@ pub struct DownloadStatus {
 
 struct ActiveDownload {
   cancel_token: CancellationToken,
+  pause: PauseHandle,
   status: String,
   progress: f64,
   speed: f64,
@@ -170,6 +183,7 @@ impl DownloadManager {
   ) -> Result<(), Error> {
     let mod_id = task.mod_id.clone();
     let cancel_token = CancellationToken::new();
+    let pause = PauseHandle::new();
 
     {
       let mut active = active_downloads.lock().await;
@@ -177,6 +191,7 @@ impl DownloadManager {
         mod_id.clone(),
         ActiveDownload {
           cancel_token: cancel_token.clone(),
+          pause: pause.clone(),
           status: "downloading".to_string(),
           progress: 0.0,
           speed: 0.0,
@@ -210,17 +225,20 @@ impl DownloadManager {
     for (file_index, file) in task.files.iter().enumerate() {
       let target_path = task.target_dir.join(&file.name);
       let url = file.url.clone();
+      let file_size = file.size;
       let mod_id_clone = mod_id.clone();
       let app_handle_clone = app_handle.clone();
       let cancel_token_clone = cancel_token.clone();
+      let pause_clone = pause.clone();
       let active_downloads_clone = Arc::clone(&active_downloads);
       let file_sizes_clone = file_sizes.clone();
       let file_downloaded_shared = Arc::new(Mutex::new(file_downloaded.clone()));
 
       let handle = tokio::spawn(async move {
-        let result = download_file(
+        let result = download_file_resumable(
           &url,
           &target_path,
+          file_size,
           {
             let app_handle = app_handle_clone.clone();
             let mod_id = mod_id_clone.clone();
@@ -277,6 +295,8 @@ impl DownloadManager {
             }
           },
           cancel_token_clone,
+          pause_clone,
+          None,
         )
         .await;
 
@@ -703,6 +723,7 @@ impl DownloadManager {
 
     let mut active = self.active_downloads.lock().await;
     if let Some(download) = active.remove(mod_id) {
+      download.pause.resume();
       download.cancel_token.cancel();
       Ok(())
     } else {
@@ -710,6 +731,64 @@ impl DownloadManager {
         "No active download found for mod: {mod_id}"
       )))
     }
+  }
+
+  pub async fn pause_download(&self, mod_id: &str) -> Result<(), Error> {
+    {
+      let mut active = self.active_downloads.lock().await;
+      let Some(entry) = active.get_mut(mod_id) else {
+        return Err(Error::InvalidInput(format!(
+          "No active download found for mod: {mod_id}"
+        )));
+      };
+      if entry.status != "downloading" {
+        return Err(Error::InvalidInput(format!(
+          "Download for mod {mod_id} is not active (status: {})",
+          entry.status
+        )));
+      }
+      entry.pause.pause();
+      entry.status = "paused".to_string();
+    }
+    self
+      .app_handle
+      .emit(
+        "download-paused",
+        DownloadPausedEvent {
+          mod_id: mod_id.to_string(),
+        },
+      )
+      .ok();
+    Ok(())
+  }
+
+  pub async fn resume_download(&self, mod_id: &str) -> Result<(), Error> {
+    {
+      let mut active = self.active_downloads.lock().await;
+      let Some(entry) = active.get_mut(mod_id) else {
+        return Err(Error::InvalidInput(format!(
+          "No active download found for mod: {mod_id}"
+        )));
+      };
+      if entry.status != "paused" {
+        return Err(Error::InvalidInput(format!(
+          "Download for mod {mod_id} is not paused (status: {})",
+          entry.status
+        )));
+      }
+      entry.pause.resume();
+      entry.status = "downloading".to_string();
+    }
+    self
+      .app_handle
+      .emit(
+        "download-resumed",
+        DownloadResumedEvent {
+          mod_id: mod_id.to_string(),
+        },
+      )
+      .ok();
+    Ok(())
   }
 
   pub async fn get_download_status(&self, mod_id: &str) -> Result<Option<DownloadStatus>, Error> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -157,6 +157,8 @@ pub fn run() {
       commands::open_addons_backups_folder,
       commands::queue_download,
       commands::cancel_download,
+      commands::pause_download,
+      commands::resume_download,
       commands::get_download_status,
       commands::get_all_downloads,
       commands::replace_mod_vpks,

--- a/apps/desktop/src/components/dashboard/quick-stats-strip.tsx
+++ b/apps/desktop/src/components/dashboard/quick-stats-strip.tsx
@@ -32,7 +32,9 @@ export const QuickStatsStrip = () => {
   ).length;
   const downloadingCount = localMods.filter(
     (m) =>
-      m.status === ModStatus.Downloading || m.status === ModStatus.Downloaded,
+      m.status === ModStatus.Downloading ||
+      m.status === ModStatus.Paused ||
+      m.status === ModStatus.Downloaded,
   ).length;
 
   return (

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -1,6 +1,10 @@
+import { Button } from "@deadlock-mods/ui/components/button";
 import { Card } from "@deadlock-mods/ui/components/card";
-import { useMemo } from "react";
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { Pause, Play } from "@phosphor-icons/react";
+import { type MouseEvent, useMemo } from "react";
 import { useNavigate } from "react-router";
+import { downloadManager } from "@/lib/download/manager";
 import { usePersistedStore } from "@/lib/store";
 import { cn, formatSize, formatSpeed } from "@/lib/utils";
 import { type LocalMod, ModStatus } from "@/types/mods";
@@ -22,6 +26,12 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
         label: "Downloading",
         pillClass: "bg-primary/15 text-primary",
         dotClass: "bg-primary animate-pulse",
+      };
+    case ModStatus.Paused:
+      return {
+        label: "Paused",
+        pillClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+        dotClass: "bg-amber-500",
       };
     case ModStatus.Downloaded:
       return {
@@ -78,7 +88,9 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
   const { getModProgress } = usePersistedStore();
   const modProgress = getModProgress(download.remoteId);
   const isDownloading = download.status === ModStatus.Downloading;
-  const percentage = isDownloading ? (modProgress?.percentage ?? 0) : 100;
+  const isPaused = download.status === ModStatus.Paused;
+  const isInProgress = isDownloading || isPaused;
+  const percentage = isInProgress ? (modProgress?.percentage ?? 0) : 100;
   const speed = isDownloading ? (modProgress?.speed ?? 0) : 0;
   const totalSize = useMemo(() => {
     if (!download.downloads || download.downloads.length === 0) {
@@ -88,6 +100,24 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
   }, [download.downloads]);
 
   const handleOpen = () => navigate(`/mods/${download.remoteId}`);
+
+  const handlePause = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    downloadManager.pauseDownload(download.remoteId).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Could not pause download: ${message}`);
+    });
+  };
+
+  const handleResume = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    downloadManager.resumeDownload(download.remoteId).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Could not resume download: ${message}`);
+    });
+  };
 
   return (
     <Card
@@ -137,7 +167,9 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
             )}>
             {isDownloading
               ? `${formatSpeed(speed)} · ${percentage.toFixed(1)}%`
-              : `${percentage.toFixed(0)}%`}
+              : isPaused
+                ? `Paused · ${percentage.toFixed(1)}%`
+                : `${percentage.toFixed(0)}%`}
           </span>
         </div>
       </div>
@@ -151,6 +183,41 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
           style={{ width: `${percentage}%` }}
         />
       </div>
+
+      {(isDownloading || isPaused) && (
+        <div
+          className='mt-3 flex flex-wrap gap-2'
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+          }}
+          role='presentation'>
+          {isDownloading ? (
+            <Button
+              className='h-8'
+              onClick={handlePause}
+              size='sm'
+              type='button'
+              variant='outline'>
+              <Pause aria-hidden className='mr-1 size-4' weight='bold' />
+              Pause
+            </Button>
+          ) : null}
+          {isPaused ? (
+            <Button
+              className='h-8'
+              onClick={handleResume}
+              size='sm'
+              type='button'
+              variant='outline'>
+              <Play aria-hidden className='mr-1 size-4' weight='fill' />
+              Resume
+            </Button>
+          ) : null}
+        </div>
+      )}
     </Card>
   );
 };

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -3,8 +3,10 @@ import { Card } from "@deadlock-mods/ui/components/card";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Pause, Play } from "@phosphor-icons/react";
 import { type MouseEvent, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { downloadManager } from "@/lib/download/manager";
+import { getErrorMessage } from "@/lib/errors";
 import { usePersistedStore } from "@/lib/store";
 import { cn, formatSize, formatSpeed } from "@/lib/utils";
 import { type LocalMod, ModStatus } from "@/types/mods";
@@ -67,7 +69,10 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
 };
 
 const StatusChip = ({ status }: { status: ModStatus }) => {
+  const { t } = useTranslation();
   const variant = getStatusVariant(status);
+  const label =
+    status === ModStatus.Paused ? t("downloads.paused") : variant.label;
   return (
     <span
       className={cn(
@@ -78,12 +83,13 @@ const StatusChip = ({ status }: { status: ModStatus }) => {
         aria-hidden
         className={cn("size-1.5 rounded-full", variant.dotClass)}
       />
-      {variant.label}
+      {label}
     </span>
   );
 };
 
 const DownloadCard = ({ download }: DownloadCardProps) => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { getModProgress } = usePersistedStore();
   const modProgress = getModProgress(download.remoteId);
@@ -105,8 +111,7 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
     e.stopPropagation();
     e.preventDefault();
     downloadManager.pauseDownload(download.remoteId).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error(`Could not pause download: ${message}`);
+      toast.error(t("downloads.pauseError", { message: getErrorMessage(err) }));
     });
   };
 
@@ -114,8 +119,9 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
     e.stopPropagation();
     e.preventDefault();
     downloadManager.resumeDownload(download.remoteId).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error(`Could not resume download: ${message}`);
+      toast.error(
+        t("downloads.resumeError", { message: getErrorMessage(err) }),
+      );
     });
   };
 
@@ -168,7 +174,7 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
             {isDownloading
               ? `${formatSpeed(speed)} · ${percentage.toFixed(1)}%`
               : isPaused
-                ? `Paused · ${percentage.toFixed(1)}%`
+                ? `${t("downloads.paused")} · ${percentage.toFixed(1)}%`
                 : `${percentage.toFixed(0)}%`}
           </span>
         </div>
@@ -189,12 +195,8 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
           className='mt-3 flex flex-wrap gap-2'
           onClick={(e) => {
             e.stopPropagation();
-          }}
-          onKeyDown={(e) => {
-            e.stopPropagation();
-          }}
-          role='presentation'>
-          {isDownloading ? (
+          }}>
+          {isDownloading && (
             <Button
               className='h-8'
               onClick={handlePause}
@@ -202,10 +204,10 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
               type='button'
               variant='outline'>
               <Pause aria-hidden className='mr-1 size-4' weight='bold' />
-              Pause
+              {t("downloads.pause")}
             </Button>
-          ) : null}
-          {isPaused ? (
+          )}
+          {isPaused && (
             <Button
               className='h-8'
               onClick={handleResume}
@@ -213,9 +215,9 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
               type='button'
               variant='outline'>
               <Play aria-hidden className='mr-1 size-4' weight='fill' />
-              Resume
+              {t("downloads.resume")}
             </Button>
-          ) : null}
+          )}
         </div>
       )}
     </Card>

--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -233,7 +233,11 @@ const SidebarItemComponent = ({ item, location, mods }: SidebarItemProps) => {
     count: item.id === "my-mods" ? mods.length : undefined,
     downloads:
       item.id === "downloads"
-        ? mods.filter((mod) => mod.status === ModStatus.Downloading).length
+        ? mods.filter(
+            (mod) =>
+              mod.status === ModStatus.Downloading ||
+              mod.status === ModStatus.Paused,
+          ).length
         : undefined,
   };
 

--- a/apps/desktop/src/components/layout/bottom-bar.tsx
+++ b/apps/desktop/src/components/layout/bottom-bar.tsx
@@ -255,9 +255,12 @@ export const BottomBar = () => {
     false,
   );
 
-  const downloadingMods = localMods.filter(
-    (mod) =>
-      mod.status === ModStatus.Downloading || mod.status === ModStatus.Paused,
+  const downloadingCount = localMods.filter(
+    (mod) => mod.status === ModStatus.Downloading,
+  ).length;
+
+  const pausedCount = localMods.filter(
+    (mod) => mod.status === ModStatus.Paused,
   ).length;
 
   const apiCfg = apiStatusConfig[apiStatus];
@@ -267,12 +270,23 @@ export const BottomBar = () => {
   return (
     <div className='z-30 flex h-8 w-full shrink-0 items-center justify-between border-t bg-background pl-4 pr-3 text-xs text-muted-foreground'>
       <div className='flex items-center gap-3'>
-        {downloadingMods > 0 && (
+        {downloadingCount > 0 && (
           <>
             <div className='flex items-center gap-1'>
               <DownloadSimpleIcon className='h-3 w-3 animate-pulse text-blue-500' />
               <span>
-                {downloadingMods} {t("common.downloading")}
+                {downloadingCount} {t("common.downloading")}
+              </span>
+            </div>
+            <Separator className='mx-1 h-3' orientation='vertical' />
+          </>
+        )}
+        {pausedCount > 0 && (
+          <>
+            <div className='flex items-center gap-1'>
+              <DownloadSimpleIcon className='h-3 w-3 text-amber-500' />
+              <span>
+                {pausedCount} {t("common.paused")}
               </span>
             </div>
             <Separator className='mx-1 h-3' orientation='vertical' />

--- a/apps/desktop/src/components/layout/bottom-bar.tsx
+++ b/apps/desktop/src/components/layout/bottom-bar.tsx
@@ -256,7 +256,8 @@ export const BottomBar = () => {
   );
 
   const downloadingMods = localMods.filter(
-    (mod) => mod.status === ModStatus.Downloading,
+    (mod) =>
+      mod.status === ModStatus.Downloading || mod.status === ModStatus.Paused,
   ).length;
 
   const apiCfg = apiStatusConfig[apiStatus];

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -59,6 +59,8 @@ export const ModStatusIcon = ({
   ];
   const Icon = useMemo(() => {
     switch (status) {
+      case ModStatus.Paused:
+        return Loader2;
       case ModStatus.Downloading:
       case ModStatus.Removing:
       case ModStatus.Installing:
@@ -84,7 +86,10 @@ export const ModStatusIcon = ({
       className={cn(
         "h-4 w-4",
         {
-          "animate-spin": status && loadingStatuses.includes(status),
+          "animate-spin":
+            status &&
+            loadingStatuses.includes(status) &&
+            status !== ModStatus.Paused,
         },
         className,
       )}
@@ -441,7 +446,10 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           getModProgress(remoteMod?.remoteId ?? "")?.percentage ?? 0
         }
         files={availableFiles}
-        isDownloading={localMod?.status === ModStatus.Downloading}
+        isDownloading={
+          localMod?.status === ModStatus.Downloading ||
+          localMod?.status === ModStatus.Paused
+        }
         isOpen={isDialogOpen}
         modName={localMod?.name || t("modForm.unknownMod")}
         onClose={closeDialog}

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -86,10 +86,7 @@ export const ModStatusIcon = ({
       className={cn(
         "h-4 w-4",
         {
-          "animate-spin":
-            status &&
-            loadingStatuses.includes(status) &&
-            status !== ModStatus.Paused,
+          "animate-spin": status && loadingStatuses.includes(status),
         },
         className,
       )}

--- a/apps/desktop/src/components/mod-management/status.tsx
+++ b/apps/desktop/src/components/mod-management/status.tsx
@@ -1,14 +1,16 @@
 import { Badge } from "@deadlock-mods/ui/components/badge";
 import { Check, Download, Loader2, X } from "@deadlock-mods/ui/icons";
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { ModStatus } from "@/types/mods";
 
 const Status = ({ status }: { status: ModStatus }) => {
+  const { t } = useTranslation();
+
   const StatusIcon = useMemo(() => {
     switch (status) {
       case ModStatus.Downloading:
-        return Loader2;
       case ModStatus.Paused:
         return Loader2;
       case ModStatus.Installed:
@@ -23,19 +25,19 @@ const Status = ({ status }: { status: ModStatus }) => {
   const StatusText = useMemo(() => {
     switch (status) {
       case ModStatus.Downloaded:
-        return "Downloaded";
+        return t("modStatus.downloaded");
       case ModStatus.Downloading:
-        return "Downloading";
+        return t("modStatus.downloading");
       case ModStatus.Paused:
-        return "Paused";
+        return t("modStatus.paused");
       case ModStatus.Installed:
-        return "Installed";
+        return t("modStatus.installed");
       case ModStatus.Error:
-        return "Error";
+        return t("modStatus.error");
       default:
-        return "Unknown";
+        return t("modStatus.unknown");
     }
-  }, [status]);
+  }, [status, t]);
 
   return (
     <Badge className='flex w-fit items-center gap-2' variant='secondary'>

--- a/apps/desktop/src/components/mod-management/status.tsx
+++ b/apps/desktop/src/components/mod-management/status.tsx
@@ -9,6 +9,8 @@ const Status = ({ status }: { status: ModStatus }) => {
     switch (status) {
       case ModStatus.Downloading:
         return Loader2;
+      case ModStatus.Paused:
+        return Loader2;
       case ModStatus.Installed:
         return Check;
       case ModStatus.Error:
@@ -24,6 +26,8 @@ const Status = ({ status }: { status: ModStatus }) => {
         return "Downloaded";
       case ModStatus.Downloading:
         return "Downloading";
+      case ModStatus.Paused:
+        return "Paused";
       case ModStatus.Installed:
         return "Installed";
       case ModStatus.Error:

--- a/apps/desktop/src/components/settings/gameinfo-management.tsx
+++ b/apps/desktop/src/components/settings/gameinfo-management.tsx
@@ -22,6 +22,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useConfirm } from "@/components/providers/alert-dialog";
+import { getErrorMessage } from "@/lib/errors";
 import { STALE_TIME_POLL } from "@/lib/query-constants";
 
 type GameInfoStatus = {
@@ -130,7 +131,7 @@ const GameInfoManagement = () => {
       await refetch();
       toast.success(t("game.backupCreatedSuccess"));
     } catch (error) {
-      toast.error(`Failed to create backup: ${error}`);
+      toast.error(`Failed to create backup: ${getErrorMessage(error)}`);
     } finally {
       setIsOperating(false);
     }
@@ -147,7 +148,7 @@ const GameInfoManagement = () => {
       await refetch();
       toast.success(t("game.restoreSuccess"));
     } catch (error) {
-      toast.error(`Failed to restore backup: ${error}`);
+      toast.error(`Failed to restore backup: ${getErrorMessage(error)}`);
     } finally {
       setIsOperating(false);
     }
@@ -164,7 +165,7 @@ const GameInfoManagement = () => {
       await refetch();
       toast.success(t("game.resetSuccess"));
     } catch (error) {
-      toast.error(`Failed to reset to vanilla: ${error}`);
+      toast.error(`Failed to reset to vanilla: ${getErrorMessage(error)}`);
     } finally {
       setIsOperating(false);
     }
@@ -178,7 +179,7 @@ const GameInfoManagement = () => {
       await refetch();
       toast.success(t("game.validationPassed"));
     } catch (error) {
-      toast.error(`Validation failed: ${error}`);
+      toast.error(`Validation failed: ${getErrorMessage(error)}`);
     } finally {
       setIsOperating(false);
     }
@@ -190,7 +191,7 @@ const GameInfoManagement = () => {
       await invoke("open_gameinfo_editor");
       toast.success(t("game.openedInEditor"));
     } catch (error) {
-      toast.error(`Failed to open editor: ${error}`);
+      toast.error(`Failed to open editor: ${getErrorMessage(error)}`);
     } finally {
       setIsOperating(false);
     }

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -100,9 +100,23 @@ export const useDownload = (
     setIsDialogOpen(true);
   };
 
+  const pauseDownload = () => {
+    if (mod) {
+      void downloadManager.pauseDownload(mod.remoteId);
+    }
+  };
+
+  const resumeDownload = () => {
+    if (mod) {
+      void downloadManager.resumeDownload(mod.remoteId);
+    }
+  };
+
   return {
     download: initiateDownload,
     downloadSelectedFiles,
+    pauseDownload,
+    resumeDownload,
     closeDialog: () => setIsDialogOpen(false),
     localMod,
     isDialogOpen,

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -102,13 +102,19 @@ export const useDownload = (
 
   const pauseDownload = () => {
     if (mod) {
-      void downloadManager.pauseDownload(mod.remoteId);
+      downloadManager.pauseDownload(mod.remoteId).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`Could not pause download: ${message}`);
+      });
     }
   };
 
   const resumeDownload = () => {
     if (mod) {
-      void downloadManager.resumeDownload(mod.remoteId);
+      downloadManager.resumeDownload(mod.remoteId).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`Could not resume download: ${message}`);
+      });
     }
   };
 

--- a/apps/desktop/src/lib/client.ts
+++ b/apps/desktop/src/lib/client.ts
@@ -1,15 +1,6 @@
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  if (typeof error === "string" && error) {
-    return error;
-  }
-  return "An unexpected error occurred";
-}
+import { getErrorMessage } from "@/lib/errors";
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({

--- a/apps/desktop/src/lib/download/manager.ts
+++ b/apps/desktop/src/lib/download/manager.ts
@@ -10,6 +10,7 @@ import type {
 import { getGameBananaFileservers } from "../api";
 import { createLogger } from "../logger";
 import { usePersistedStore } from "../store";
+import { ModStatus } from "@/types/mods";
 import { resolveDownloadFileUrls } from "./fileserver";
 
 const logger = createLogger("download-manager");
@@ -51,6 +52,14 @@ interface DownloadFontsFoundEvent {
 interface DownloadErrorEvent {
   modId: string;
   error: string;
+}
+
+interface DownloadPausedEvent {
+  modId: string;
+}
+
+interface DownloadResumedEvent {
+  modId: string;
 }
 
 class DownloadManager {
@@ -186,6 +195,30 @@ class DownloadManager {
       },
     );
 
+    const unlistenPaused = await listen<DownloadPausedEvent>(
+      "download-paused",
+      (event) => {
+        logger
+          .withMetadata({ mod: event.payload.modId })
+          .info("Download paused");
+        usePersistedStore
+          .getState()
+          .setModStatus(event.payload.modId, ModStatus.Paused);
+      },
+    );
+
+    const unlistenResumed = await listen<DownloadResumedEvent>(
+      "download-resumed",
+      (event) => {
+        logger
+          .withMetadata({ mod: event.payload.modId })
+          .info("Download resumed");
+        usePersistedStore
+          .getState()
+          .setModStatus(event.payload.modId, ModStatus.Downloading);
+      },
+    );
+
     this.unlistenFns.push(
       unlistenStarted,
       unlistenProgress,
@@ -193,6 +226,8 @@ class DownloadManager {
       unlistenExtracting,
       unlistenFileTree,
       unlistenFontsFound,
+      unlistenPaused,
+      unlistenResumed,
       unlistenError,
     );
 
@@ -278,6 +313,26 @@ class DownloadManager {
       logger.withMetadata({ mod: modId }).info("Download cancelled");
     } catch (error) {
       logger.withError(error).error("Failed to cancel download");
+      throw error;
+    }
+  }
+
+  async pauseDownload(modId: string) {
+    try {
+      await invoke("pause_download", { modId });
+      logger.withMetadata({ mod: modId }).info("Pause requested");
+    } catch (error) {
+      logger.withError(error).error("Failed to pause download");
+      throw error;
+    }
+  }
+
+  async resumeDownload(modId: string) {
+    try {
+      await invoke("resume_download", { modId });
+      logger.withMetadata({ mod: modId }).info("Resume requested");
+    } catch (error) {
+      logger.withError(error).error("Failed to resume download");
       throw error;
     }
   }

--- a/apps/desktop/src/lib/download/manager.ts
+++ b/apps/desktop/src/lib/download/manager.ts
@@ -231,7 +231,36 @@ class DownloadManager {
       unlistenError,
     );
 
+    await this.reconcilePausedDownloads();
+
     logger.info("Download manager initialized");
+  }
+
+  private async reconcilePausedDownloads() {
+    let activeDownloads: { modId: string }[] = [];
+    try {
+      activeDownloads = (await this.getAllDownloads()) as { modId: string }[];
+    } catch (error) {
+      logger
+        .withError(error)
+        .warn("Could not fetch active downloads for reconciliation");
+      return;
+    }
+
+    const activeIds = new Set(activeDownloads.map((d) => d.modId));
+    const store = usePersistedStore.getState();
+    const stalePaused = store.localMods.filter(
+      (mod) => mod.status === ModStatus.Paused && !activeIds.has(mod.remoteId),
+    );
+
+    for (const mod of stalePaused) {
+      logger
+        .withMetadata({ mod: mod.remoteId })
+        .warn(
+          "Stale Paused status on startup (no backend entry); marking as FailedToDownload",
+        );
+      store.setModStatus(mod.remoteId, ModStatus.FailedToDownload);
+    }
   }
 
   setFontsFoundHandler(

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -1,0 +1,17 @@
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as Record<string, unknown>).message === "string"
+  ) {
+    return (error as Record<string, unknown>).message as string;
+  }
+  if (typeof error === "string" && error) {
+    return error;
+  }
+  return "An unexpected error occurred";
+}

--- a/apps/desktop/src/lib/state-machines/mod-status.ts
+++ b/apps/desktop/src/lib/state-machines/mod-status.ts
@@ -15,7 +15,12 @@ type StateTransitionError = {
  * NOTE: this is an example, it might not be necessary after all.
  */
 const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
-  [ModStatus.Downloading]: [ModStatus.Downloaded, ModStatus.FailedToDownload],
+  [ModStatus.Downloading]: [
+    ModStatus.Downloaded,
+    ModStatus.FailedToDownload,
+    ModStatus.Paused,
+  ],
+  [ModStatus.Paused]: [ModStatus.Downloading, ModStatus.FailedToDownload],
   [ModStatus.Downloaded]: [
     ModStatus.Installing,
     ModStatus.Removing,

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { StateCreator } from "zustand";
+import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { type LocalMod, ModStatus } from "@/types/mods";
 import {
@@ -244,7 +245,7 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
         .withMetadata({ profileId })
         .withError(error)
         .error("Failed to switch profile");
-      result.errors.push(`Failed to switch profile: ${error}`);
+      result.errors.push(`Failed to switch profile: ${getErrorMessage(error)}`);
     } finally {
       set({ isSwitching: false });
     }

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -300,7 +300,12 @@
     "updatedAgo": "Updated {{when}} ago",
     "createdAgo": "Created {{when}} ago",
     "updatedAt": "Updated at {{date}}",
-    "createdAt": "Created at {{date}}"
+    "createdAt": "Created at {{date}}",
+    "pause": "Pause",
+    "resume": "Resume",
+    "paused": "Paused",
+    "pauseError": "Could not pause download: {{message}}",
+    "resumeError": "Could not resume download: {{message}}"
   },
   "notifications": {
     "modInstalledSuccessfully": "Mod installed successfully",
@@ -361,6 +366,7 @@
     "mods": "Mods",
     "installed": "installed",
     "downloading": "downloading",
+    "paused": "paused",
     "gameRunning": "Game Running",
     "gameReady": "Game Ready",
     "gameNotDetected": "Game Not Detected",
@@ -823,6 +829,7 @@
     "added": "Added to my mods",
     "downloading": "Downloading...",
     "downloaded": "Downloaded",
+    "paused": "Paused",
     "failedToDownload": "Failed to download",
     "installing": "Installing...",
     "installed": "Installed",
@@ -830,7 +837,8 @@
     "removing": "Removing...",
     "removed": "Removed",
     "failedToRemove": "Failed to remove",
-    "error": "Error occurred"
+    "error": "Error occurred",
+    "unknown": "Unknown"
   },
   "modButton": {
     "add": "Download Mod",

--- a/apps/desktop/src/pages/downloads.tsx
+++ b/apps/desktop/src/pages/downloads.tsx
@@ -36,6 +36,9 @@ const getDownloadTimestamp = (
   return 0;
 };
 
+const isDownloadInProgress = (status: ModStatus) =>
+  status === ModStatus.Downloading || status === ModStatus.Paused;
+
 const Downloads = () => {
   const { t } = useTranslation();
   const downloads = usePersistedStore((state) => state.localMods);
@@ -46,23 +49,19 @@ const Downloads = () => {
       return downloads;
     }
     if (filter === "active") {
-      return downloads.filter((d) => d.status === ModStatus.Downloading);
+      return downloads.filter((d) => isDownloadInProgress(d.status));
     }
-    return downloads.filter((d) => d.status !== ModStatus.Downloading);
+    return downloads.filter((d) => !isDownloadInProgress(d.status));
   }, [downloads, filter]);
 
   const sortedDownloads = useMemo(() => {
     return [...filteredDownloads].sort((a, b) => {
-      if (
-        a.status === ModStatus.Downloading &&
-        b.status !== ModStatus.Downloading
-      ) {
+      const aActive = isDownloadInProgress(a.status);
+      const bActive = isDownloadInProgress(b.status);
+      if (aActive && !bActive) {
         return -1;
       }
-      if (
-        b.status === ModStatus.Downloading &&
-        a.status !== ModStatus.Downloading
-      ) {
+      if (bActive && !aActive) {
         return 1;
       }
 
@@ -74,12 +73,12 @@ const Downloads = () => {
   }, [filteredDownloads]);
 
   const activeCount = useMemo(
-    () => downloads.filter((d) => d.status === ModStatus.Downloading).length,
+    () => downloads.filter((d) => isDownloadInProgress(d.status)).length,
     [downloads],
   );
 
   const completedCount = useMemo(
-    () => downloads.filter((d) => d.status !== ModStatus.Downloading).length,
+    () => downloads.filter((d) => !isDownloadInProgress(d.status)).length,
     [downloads],
   );
 

--- a/apps/desktop/src/pages/mod.tsx
+++ b/apps/desktop/src/pages/mod.tsx
@@ -32,6 +32,7 @@ import { useReportCounts } from "@/hooks/use-report-counts";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { useScrollBackButton } from "@/hooks/use-scroll-back-button";
 import useUninstall from "@/hooks/use-uninstall";
+import { getErrorMessage } from "@/lib/errors";
 import { usePersistedStore } from "@/lib/store";
 import { useCheckUpdates } from "@/hooks/use-check-updates";
 import { isModOutdated, isModStale } from "@/lib/utils";
@@ -130,7 +131,7 @@ const Mod = () => {
       setDeleting(true);
       await uninstall(localMod, true);
     } catch (error) {
-      toast.error(`Failed to remove mod: ${error}`);
+      toast.error(`Failed to remove mod: ${getErrorMessage(error)}`);
     } finally {
       setDeleting(false);
     }

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -83,6 +83,7 @@ import { useVpkScan } from "@/hooks/use-vpk-scan";
 import { useThemeOverride } from "@/components/providers/theme-overrides";
 import { SortType } from "@/lib/constants";
 import { ModCategory } from "@/lib/constants";
+import { getErrorMessage } from "@/lib/errors";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -208,7 +209,7 @@ const GridModCard = ({ mod }: { mod: LocalMod }) => {
       setDeleting(true);
       await uninstall(mod, true);
     } catch (error) {
-      toast.error(`Failed to remove mod: ${error}`);
+      toast.error(`Failed to remove mod: ${getErrorMessage(error)}`);
     } finally {
       setDeleting(false);
     }
@@ -336,7 +337,7 @@ const ListModCard = ({ mod }: { mod: LocalMod }) => {
       setDeleting(true);
       await uninstall(mod, true);
     } catch (error) {
-      toast.error(`Failed to remove mod: ${error}`);
+      toast.error(`Failed to remove mod: ${getErrorMessage(error)}`);
     } finally {
       setDeleting(false);
     }

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -15,6 +15,7 @@ export type Progress = {
 
 export enum ModStatus {
   Downloading = "downloading",
+  Paused = "paused",
   Downloaded = "downloaded",
   FailedToDownload = "failedToDownload",
   Installing = "installing",


### PR DESCRIPTION
Implement resumable downloads using a *.partial staging file with HTTP Range support and a shared pause gate. Expose pause_download and resume_download Tauri commands, emit download-paused/download-resumed events, and surface a new Paused mod status across the UI (sidebar, bottom bar, downloads page, status indicators).

Closes #DMM-37

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [ ] My code follows the style guidelines of this project (`pnpm lint` passes)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds pause-and-resume for downloads in the desktop application, enabling temporary halting and restarting of downloads while preserving progress via partial staging files and HTTP Range support.

## Affected Apps/Packages
- apps/desktop (TypeScript/React frontend)
- apps/desktop/src-tauri (Rust backend)

No other apps/packages are modified (api, bot, www, docs, shared packages unchanged).

No cross-package dependency changes, no database migrations, no Tauri plugin changes, and no Rust FFI boundary changes.

## Functional Changes

### Rust backend (apps/desktop/src-tauri)
- Resumable downloads:
  - New download pipeline `download_file_resumable(...)` that writes to target_path.partial and persists metadata in target_path.partial.meta (ETag/Last-Modified) to validate resume attempts.
  - Sends `Range: bytes={resume_from}-` when resuming; handles 416 Range Not Satisfiable by clearing partial state and restarting.
  - Retries requests on certain failures; enforces max-bytes against cumulative downloaded bytes across resume sessions.
  - Finalization renames flushed partial to final target and removes metadata; partial state removed on cancellation/errors.
  - Progress reporting changed to cumulative bytes (base_offset + session_downloaded) with per-session speed calculation.
  - Unit test added for parsing Content-Range totals.

- Pause/resume coordination:
  - New public struct `PauseHandle` with methods new(), pause(), resume(), is_paused(), wait_until_running() (used inside download loops to block/resume without cancelling).
  - Downloads now accept a PauseHandle to allow coordinated per-mod pausing.

- DownloadManager changes:
  - ActiveDownload now stores a PauseHandle with its CancellationToken.
  - New public methods: `pause_download(mod_id)` and `resume_download(mod_id)` that validate current status, toggle the PauseHandle, update stored status, and emit events.
  - `cancel_download()` calls `pause.resume()` before cancelling to ensure downloads are not left paused while cancelling.
  - New Tauri events: `download-paused` and `download-resumed` with payload types `DownloadPausedEvent` / `DownloadResumedEvent`.

- Tauri IPC:
  - New Tauri commands exposed: `pause_download(app_handle, mod_id)` and `resume_download(app_handle, mod_id)` registered in the command handler.

### Frontend UI and Type System (apps/desktop)
- Types/state:
  - Added `ModStatus.Paused = "paused"`.
  - State machine transitions (`VALID_TRANSITIONS`) updated to allow Downloading ↔ Paused.

- Frontend download manager:
  - `DownloadManager.init()` listens for `download-paused` and `download-resumed` events to set persisted mod status (Paused or Downloading).
  - Added `pauseDownload(modId)` and `resumeDownload(modId)` methods that call the new Tauri commands and log/rethrow on errors.
  - Reconciler added to detect stale persisted Paused entries not present in backend and mark them `FailedToDownload`.

- UI updates:
  - Download card: shows Pause/Resume buttons for downloading/paused states; when paused shows "Paused · {percentage}%" using persisted progress; toggles icons (Pause/Play).
  - Status components: `StatusIcon` and `StatusText` include Paused state (uses loader icon, localized paused label); memoization updated for translations.
  - ModButton / MultiFileDownloadDialog: treat Paused as "isDownloading" where appropriate.
  - Counters and pages: sidebar downloads counter, bottom-bar indicators, quick-stats, and downloads page now include paused mods in "in-progress" counts and sorting.
  - Hook `useDownload()` now exposes fire-and-forget `pauseDownload()` and `resumeDownload()` callbacks that invoke the frontend DownloadManager.

### Other changes (UX/error handling)
- Introduced `getErrorMessage(error: unknown): string` utility and replaced several local error-string constructions to normalize toast messages across a few UI modules.

## Risks / Review Notes
- High-impact backend changes: large Rust download pipeline refactor, new PauseHandle, and cumulative max-bytes enforcement (careful review for race/cancellation/partial-file edge cases required).
- UI and state changes are broad but largely localized to desktop app; ensure persisted mod statuses and reconciliation logic behave correctly after upgrades.
- No external dependency or migration work required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->