### PR TITLE
refactor(desktop): extract profile import logic into reusable flow factory

### DIFF
--- a/.changeset/brave-otters-fall.md
+++ b/.changeset/brave-otters-fall.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/api": patch
+---
+
+Fix crash in GameBanana top mods sync when the API returns null for top submissions

--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -120,9 +120,10 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       if (!response.ok) {
         throw new ProviderError(`HTTP error! status: ${response.status}`);
       }
-      const data =
-        (await response.json()) as GameBanana.GameBananaTopSubmission[];
-      return data;
+      const data = (await response.json()) as
+        | GameBanana.GameBananaTopSubmission[]
+        | null;
+      return data ?? [];
     } catch (error) {
       this.logger.withError(error).error("Failed to fetch top submissions");
       throw error;

--- a/apps/desktop/src/components/profiles/profile-import-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-import-dialog.tsx
@@ -26,11 +26,10 @@ export const ProfileImportDialog = () => {
   const [importedProfile, setImportedProfile] = useState<SharedProfile | null>(
     null,
   );
-  const [isImporting, setIsImporting] = useState(false);
   const { t } = useTranslation();
   const { createProfileFromImport, importProgress } = useProfileImport();
 
-  const { isPending, mutate } = useMutation({
+  const fetchProfileMutation = useMutation({
     mutationFn: (profileId: string) => getProfile(profileId.trim()),
     onSuccess: (data) => {
       setImportedProfile(data);
@@ -42,14 +41,33 @@ export const ProfileImportDialog = () => {
     },
   });
 
-  // Fetch mod details for each mod in the imported profile
+  const createProfileMutation = useMutation({
+    mutationFn: ({
+      profile,
+      availableMods,
+      sourceProfileId,
+    }: {
+      profile: SharedProfile;
+      availableMods: ModDto[];
+      sourceProfileId?: string;
+    }) =>
+      createProfileFromImport(profile, availableMods, {
+        sourceProfileId,
+      }),
+    onSuccess: () => {
+      handleCancel();
+    },
+  });
+
+  const orderedImportedMods = importedProfile
+    ? importedProfile.payload.mods
+    : [];
+
   const modQueries = useQueries({
-    queries:
-      importedProfile?.payload.mods.map((mod) => ({
-        queryKey: ["mod", mod.remoteId],
-        queryFn: () => getMod(mod.remoteId),
-        enabled: !!importedProfile,
-      })) || [],
+    queries: orderedImportedMods.map((mod) => ({
+      queryKey: ["mod", mod.remoteId],
+      queryFn: () => getMod(mod.remoteId),
+    })),
   });
 
   const modsLoading = modQueries.some((query) => query.isPending);
@@ -58,11 +76,14 @@ export const ProfileImportDialog = () => {
     .filter(Boolean) as ModDto[];
 
   const onSubmit = async (values: ProfileImportFormData) => {
-    if (!values.profileId?.trim()) {
+    const profileId = values.profileId?.trim();
+
+    if (!profileId) {
       toast.error(t("profiles.profileIdRequired"));
       return;
     }
-    return mutate(values.profileId);
+
+    await fetchProfileMutation.mutateAsync(profileId);
   };
 
   const handleCancel = () => {
@@ -70,20 +91,16 @@ export const ProfileImportDialog = () => {
     setOpen(false);
   };
 
-  const handleCreateNewProfile = async () => {
+  const handleCreateNewProfile = () => {
     if (!importedProfile) return;
 
-    setIsImporting(true);
+    const sourceProfileId = fetchProfileMutation.variables?.trim();
 
-    try {
-      await createProfileFromImport(importedProfile.payload.mods, modsData);
-      handleCancel();
-    } catch (error) {
-      console.error("Failed to create profile from import:", error);
-      toast.error(t("profiles.createError"));
-    } finally {
-      setIsImporting(false);
-    }
+    createProfileMutation.mutate({
+      profile: importedProfile,
+      availableMods: modsData,
+      sourceProfileId,
+    });
   };
 
   return (
@@ -114,14 +131,14 @@ export const ProfileImportDialog = () => {
             modsData={modsData}
             onCreateNew={handleCreateNewProfile}
             onCancel={handleCancel}
-            isImporting={isImporting}
+            isImporting={createProfileMutation.isPending}
             importProgress={importProgress}
           />
         ) : (
           <ProfileImportForm
             onSubmit={onSubmit}
             onCancel={handleCancel}
-            isLoading={isPending}
+            isLoading={fetchProfileMutation.isPending}
           />
         )}
       </DialogContent>

--- a/apps/desktop/src/components/profiles/profile-preview.tsx
+++ b/apps/desktop/src/components/profiles/profile-preview.tsx
@@ -4,7 +4,7 @@ import { DialogFooter } from "@deadlock-mods/ui/components/dialog";
 import { Progress } from "@deadlock-mods/ui/components/progress";
 import { Download, Package, UserPlus } from "@deadlock-mods/ui/icons";
 import { useTranslation } from "react-i18next";
-import type { ImportProgress } from "@/hooks/use-profile-import";
+import type { ImportProgress } from "@/lib/profiles/types";
 import { ProfileModsList } from "./profile-mods-list";
 
 interface ProfilePreviewProps {

--- a/apps/desktop/src/hooks/use-profile-import.ts
+++ b/apps/desktop/src/hooks/use-profile-import.ts
@@ -1,63 +1,57 @@
-import type { ModDto, ProfileModDownload } from "@deadlock-mods/shared";
-import { toast } from "@deadlock-mods/ui/components/sonner";
-import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getModDownloads } from "@/lib/api";
-import logger from "@/lib/logger";
+import { createProfileImportFlow } from "@/lib/profiles/import-profile";
+import type { ImportProgress } from "@/lib/profiles/types";
 import { usePersistedStore } from "@/lib/store";
-import type {
-  LocalMod,
-  ModFileTree,
-  ProfileImportMod,
-  ProfileImportProgressEvent,
-  ProfileImportResult,
-} from "@/types/mods";
-import { ModStatus } from "@/types/mods";
-import type { ModProfile, ProfileId } from "@/types/profiles";
-import { createProfileId } from "@/types/profiles";
+import type { ProfileImportProgressEvent } from "@/types/mods";
 
-export interface ImportProgress {
-  currentStep: string;
-  currentMod?: string;
-  completedMods: number;
-  totalMods: number;
-  isDownloading: boolean;
-  isInstalling: boolean;
-}
-
-interface ImportedMod {
-  remoteId: string;
-  fileTree?: ModFileTree;
-  selectedDownload?: ProfileModDownload;
-  selectedDownloads?: ProfileModDownload[];
-}
-
-const resolveSelectedFileNames = (
-  selectedDownloads?: ProfileModDownload[],
-  selectedDownload?: ProfileModDownload,
-): string[] | null =>
-  selectedDownloads?.length
-    ? selectedDownloads.map((d) => d.file)
-    : selectedDownload
-      ? [selectedDownload.file]
-      : null;
-
-export const useProfileImport = () => {
+export const useProfileImport = (options?: { listenToProgress?: boolean }) => {
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(
     null,
   );
   const { t } = useTranslation();
-  const {
-    getActiveProfile,
-    setModEnabledInProfile,
-    setModEnabledInCurrentProfile,
-  } = usePersistedStore();
-  const { addLocalMod, setInstalledVpks } = usePersistedStore();
+  const listenToProgress = options?.listenToProgress ?? true;
 
-  // Listen to profile import progress events
+  const upsertProfile = usePersistedStore((s) => s.upsertProfile);
+  const createImportProfileFolder = usePersistedStore(
+    (s) => s.createImportProfileFolder,
+  );
+  const applyImportInstalledModsToProfile = usePersistedStore(
+    (s) => s.applyImportInstalledModsToProfile,
+  );
+  const setProfileFolderName = usePersistedStore((s) => s.setProfileFolderName);
+  const getProfile = usePersistedStore((s) => s.getProfile);
+  const getActiveProfile = usePersistedStore((s) => s.getActiveProfile);
+
+  const { createProfileFromImport, addToCurrentProfile } = useMemo(
+    () =>
+      createProfileImportFlow({
+        setImportProgress,
+        t,
+        upsertProfile,
+        createImportProfileFolder,
+        applyImportInstalledModsToProfile,
+        setProfileFolderName,
+        getProfile,
+        getActiveProfile,
+      }),
+    [
+      t,
+      upsertProfile,
+      createImportProfileFolder,
+      applyImportInstalledModsToProfile,
+      setProfileFolderName,
+      getProfile,
+      getActiveProfile,
+    ],
+  );
+
   useEffect(() => {
+    if (!listenToProgress) {
+      return;
+    }
+
     const unlistenPromise = listen<ProfileImportProgressEvent>(
       "profile-import-progress",
       (event) => {
@@ -76,356 +70,7 @@ export const useProfileImport = () => {
     return () => {
       unlistenPromise.then((unlisten) => unlisten());
     };
-  }, []);
-
-  const createProfileFromImport = async (
-    importedMods: ImportedMod[],
-    modsData: ModDto[],
-  ): Promise<void> => {
-    logger
-      .withMetadata({
-        importedModsCount: importedMods.length,
-        modsDataCount: modsData.length,
-      })
-      .info("Starting profile import");
-
-    // Initialize progress tracking
-    setImportProgress({
-      currentStep: t("profiles.creatingProfile"),
-      completedMods: 0,
-      totalMods: importedMods.length,
-      isDownloading: false,
-      isInstalling: false,
-    });
-
-    // Create new profile in store without creating folder (batch import will create it)
-    const profileId = `profile_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-    const newProfileId = createProfileId(profileId) as ProfileId;
-
-    const newProfile: ModProfile = {
-      id: newProfileId,
-      name: `Imported Profile - ${new Date().toLocaleDateString()}`,
-      description: "Profile imported from shared profile ID",
-      createdAt: new Date(),
-      lastUsed: new Date(),
-      enabledMods: {},
-      isDefault: false,
-      folderName: null, // Will be set after batch import creates the folder
-      mods: [],
-    };
-
-    usePersistedStore.setState((state) => ({
-      profiles: {
-        ...state.profiles,
-        [newProfileId]: newProfile,
-      },
-    }));
-
-    // Prepare mods for batch import
-    const profileImportMods: ProfileImportMod[] = await Promise.all(
-      importedMods.map(async (importedMod) => {
-        const modData = modsData.find(
-          (m) => m.remoteId === importedMod.remoteId,
-        );
-
-        if (!modData) {
-          throw new Error(`Mod ${importedMod.remoteId} not available`);
-        }
-
-        const downloadsResponse = await getModDownloads(modData.remoteId);
-        const downloadFiles = downloadsResponse.downloads || [];
-
-        const selectedFileNames = resolveSelectedFileNames(
-          importedMod.selectedDownloads,
-          importedMod.selectedDownload,
-        );
-        const selectedFiles =
-          selectedFileNames && downloadFiles.length > 0
-            ? downloadFiles.filter((d) => selectedFileNames.includes(d.name))
-            : downloadFiles;
-
-        return {
-          modId: modData.remoteId,
-          modName: modData.name,
-          downloadFiles: selectedFiles.map((d) => ({
-            url: d.url,
-            name: d.name,
-            size: d.size || 0,
-          })),
-          fileTree: importedMod.fileTree
-            ? {
-                ...importedMod.fileTree,
-                files: importedMod.fileTree.files.some((f) => f.is_selected)
-                  ? importedMod.fileTree.files
-                  : importedMod.fileTree.files.map((f) => ({
-                      ...f,
-                      is_selected: true,
-                    })),
-              }
-            : undefined,
-          isMap: modData.isMap,
-        };
-      }),
-    );
-
-    try {
-      // Call Rust batch import command - it will create the profile folder
-      const result = (await invoke("import_profile_batch", {
-        profileName: `Imported Profile - ${new Date().toLocaleDateString()}`,
-        profileDescription: "Profile imported from shared profile ID",
-        profileFolder: "", // Empty - batch import will create it
-        mods: profileImportMods,
-        importType: "create", // Batch import will create the folder
-      })) as ProfileImportResult;
-
-      // Update profile folder name with the one created by batch import
-      const currentProfile = usePersistedStore
-        .getState()
-        .getProfile(newProfileId);
-      if (currentProfile && result.profileFolder) {
-        const profiles = usePersistedStore.getState().profiles;
-        profiles[newProfileId] = {
-          ...currentProfile,
-          folderName: result.profileFolder,
-        };
-        usePersistedStore.setState({ profiles });
-      }
-
-      // Enable mods in the profile and add them to state
-      const store = usePersistedStore.getState();
-      const newMods: LocalMod[] = [];
-
-      for (const installedModInfo of result.installedMods) {
-        // Find the mod data from the original modsData
-        const modData = modsData.find(
-          (m) => m.remoteId === installedModInfo.modId,
-        );
-
-        if (modData) {
-          // Check if mod already exists in localMods
-          const existingMod = store.localMods.find(
-            (m) => m.remoteId === installedModInfo.modId,
-          );
-
-          const localMod: LocalMod = existingMod
-            ? {
-                ...existingMod,
-                installedVpks: installedModInfo.installedVpks,
-                installedFileTree: installedModInfo.fileTree,
-                status: ModStatus.Installed,
-              }
-            : {
-                ...modData,
-                status: ModStatus.Installed,
-                installedVpks: installedModInfo.installedVpks,
-                installedFileTree: installedModInfo.fileTree,
-                downloadedAt: new Date(),
-              };
-
-          if (!existingMod) {
-            // Add mod to localMods
-            addLocalMod(modData, {
-              status: ModStatus.Installed,
-              installedVpks: installedModInfo.installedVpks,
-              installedFileTree: installedModInfo.fileTree,
-              downloadedAt: new Date(),
-            });
-          } else {
-            // Update existing mod with installed VPKs
-            setInstalledVpks(
-              installedModInfo.modId,
-              installedModInfo.installedVpks,
-              installedModInfo.fileTree,
-            );
-          }
-
-          newMods.push(localMod);
-        }
-
-        // Enable mod in the profile
-        setModEnabledInProfile(newProfileId, installedModInfo.modId, true);
-      }
-
-      // Add mods to the new profile's mods array
-      if (newMods.length > 0) {
-        const profile = usePersistedStore.getState().getProfile(newProfileId);
-        if (profile) {
-          const profiles = usePersistedStore.getState().profiles;
-          profiles[newProfileId] = {
-            ...profile,
-            mods: [...profile.mods, ...newMods],
-          };
-          usePersistedStore.setState({ profiles });
-        }
-      }
-
-      // Clear progress
-      setImportProgress(null);
-
-      // Show results
-      if (result.failed.length > 0) {
-        logger
-          .withMetadata({
-            failed: result.failed.length,
-            succeeded: result.succeeded.length,
-          })
-          .warn("Some mods failed to import");
-        toast.warning(
-          t("profiles.createSuccess", { profileName: "Imported Profile" }) +
-            ` (${result.succeeded.length}/${importedMods.length} mods imported)`,
-        );
-      } else {
-        toast.success(
-          t("profiles.createSuccess", { profileName: "Imported Profile" }),
-        );
-      }
-    } catch (error) {
-      logger.withError(error).error("Profile import failed");
-      setImportProgress(null);
-      toast.error(t("profiles.createError"));
-      throw error;
-    }
-  };
-
-  const addToCurrentProfile = async (
-    importedMods: ImportedMod[],
-    modsData: ModDto[],
-  ): Promise<void> => {
-    const activeProfile = getActiveProfile();
-    if (!activeProfile) {
-      throw new Error("No active profile found");
-    }
-
-    // Initialize progress tracking
-    setImportProgress({
-      currentStep: t("profiles.updatingProfile"),
-      completedMods: 0,
-      totalMods: importedMods.length,
-      isDownloading: false,
-      isInstalling: false,
-    });
-
-    logger
-      .withMetadata({ profileId: activeProfile.id })
-      .info("Overriding current profile with imported mods");
-
-    // Prepare mods for batch import
-    const profileImportMods: ProfileImportMod[] = await Promise.all(
-      importedMods.map(async (importedMod) => {
-        const modData = modsData.find(
-          (m) => m.remoteId === importedMod.remoteId,
-        );
-
-        if (!modData) {
-          throw new Error(`Mod ${importedMod.remoteId} not available`);
-        }
-
-        const downloadsResponse = await getModDownloads(modData.remoteId);
-        const downloadFiles = downloadsResponse.downloads || [];
-
-        const selectedFileNames = resolveSelectedFileNames(
-          importedMod.selectedDownloads,
-          importedMod.selectedDownload,
-        );
-        const selectedFiles =
-          selectedFileNames && downloadFiles.length > 0
-            ? downloadFiles.filter((d) => selectedFileNames.includes(d.name))
-            : downloadFiles;
-
-        return {
-          modId: modData.remoteId,
-          modName: modData.name,
-          downloadFiles: selectedFiles.map((d) => ({
-            url: d.url,
-            name: d.name,
-            size: d.size || 0,
-          })),
-          fileTree: importedMod.fileTree
-            ? {
-                ...importedMod.fileTree,
-                files: importedMod.fileTree.files.some((f) => f.is_selected)
-                  ? importedMod.fileTree.files
-                  : importedMod.fileTree.files.map((f) => ({
-                      ...f,
-                      is_selected: true,
-                    })),
-              }
-            : undefined,
-          isMap: modData.isMap,
-        };
-      }),
-    );
-
-    try {
-      // Call Rust batch import command
-      const result = (await invoke("import_profile_batch", {
-        profileName: activeProfile.name,
-        profileDescription: activeProfile.description || "",
-        profileFolder: activeProfile.folderName || "",
-        mods: profileImportMods,
-        importType: "override",
-      })) as ProfileImportResult;
-
-      // Enable mods in the current profile and add them to state
-      for (const installedModInfo of result.installedMods) {
-        // Find the mod data from the original modsData
-        const modData = modsData.find(
-          (m) => m.remoteId === installedModInfo.modId,
-        );
-
-        if (modData) {
-          // Check if mod already exists in localMods
-          const existingMod = usePersistedStore
-            .getState()
-            .localMods.find((m) => m.remoteId === installedModInfo.modId);
-
-          if (!existingMod) {
-            // Add mod to localMods with installed status
-            addLocalMod(modData, {
-              status: ModStatus.Installed,
-              installedVpks: installedModInfo.installedVpks,
-              installedFileTree: installedModInfo.fileTree,
-              downloadedAt: new Date(),
-            });
-          } else {
-            // Update existing mod with installed VPKs
-            setInstalledVpks(
-              installedModInfo.modId,
-              installedModInfo.installedVpks,
-              installedModInfo.fileTree,
-            );
-          }
-        }
-
-        // Enable mod in the current profile
-        setModEnabledInCurrentProfile(installedModInfo.modId, true);
-      }
-
-      // Clear progress
-      setImportProgress(null);
-
-      // Show results
-      if (result.failed.length > 0) {
-        logger
-          .withMetadata({
-            failed: result.failed.length,
-            succeeded: result.succeeded.length,
-          })
-          .warn("Some mods failed to import to current profile");
-        toast.warning(
-          t("profiles.overrideSuccess") +
-            ` (${result.succeeded.length}/${importedMods.length} mods imported)`,
-        );
-      } else {
-        toast.success(t("profiles.overrideSuccess"));
-      }
-    } catch (error) {
-      logger.withError(error).error("Profile import failed");
-      setImportProgress(null);
-      toast.error(t("profiles.updateError"));
-      throw error;
-    }
-  };
+  }, [listenToProgress]);
 
   return {
     createProfileFromImport,

--- a/apps/desktop/src/lib/profiles/import-downloads.ts
+++ b/apps/desktop/src/lib/profiles/import-downloads.ts
@@ -1,0 +1,113 @@
+import type { ProfileModDownload } from "@deadlock-mods/shared";
+import type {
+  AvailableImportDownload,
+  ProfileImportDownloadFile,
+  ResolveProfileImportDownloadFilesArgs,
+  ResolvedProfileImportDownloadFiles,
+} from "@/lib/profiles/types";
+
+const isHttpOrHttpsUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const normalizeSelectedDownloads = (
+  selectedDownloads?: ProfileModDownload[],
+  selectedDownload?: ProfileModDownload,
+): ProfileModDownload[] => {
+  if (selectedDownloads?.length) {
+    return selectedDownloads;
+  }
+
+  return selectedDownload ? [selectedDownload] : [];
+};
+
+const toImportDownloadFile = (
+  download: AvailableImportDownload | ProfileModDownload,
+): ProfileImportDownloadFile => ({
+  url: download.url,
+  name: "file" in download ? download.file : download.name,
+  size: download.size ?? 0,
+});
+
+export const resolveProfileImportDownloadFiles = ({
+  availableDownloads,
+  selectedDownloads,
+  selectedDownload,
+}: ResolveProfileImportDownloadFilesArgs): ResolvedProfileImportDownloadFiles => {
+  const persistedSelections = normalizeSelectedDownloads(
+    selectedDownloads,
+    selectedDownload,
+  );
+
+  if (persistedSelections.length === 0) {
+    return {
+      downloadFiles: availableDownloads
+        .map(toImportDownloadFile)
+        .filter((file) => file.url.length > 0),
+      missingSelectionNames: [],
+      resolvedWithLiveFallbackNames: [],
+      resolvedWithPersistedFallbackNames: [],
+    };
+  }
+
+  const availableDownloadsByName = new Map(
+    availableDownloads.map((download) => [download.name, download]),
+  );
+  const missingSelectionNames: string[] = [];
+  const resolvedWithLiveFallbackNames: string[] = [];
+  const resolvedWithPersistedFallbackNames: string[] = [];
+  const exactlyMatchedSelectionNames = new Set(
+    persistedSelections
+      .filter((selection) => availableDownloadsByName.has(selection.file))
+      .map((selection) => selection.file),
+  );
+  const remainingAvailableDownloads = availableDownloads.filter(
+    (download) => !exactlyMatchedSelectionNames.has(download.name),
+  );
+  const unmatchedSelections = persistedSelections.filter(
+    (selection) => !availableDownloadsByName.has(selection.file),
+  );
+
+  const canResolveFromLiveDownloads =
+    unmatchedSelections.length > 0 &&
+    remainingAvailableDownloads.length === unmatchedSelections.length &&
+    (unmatchedSelections.length === 1 ||
+      persistedSelections.length === availableDownloads.length);
+  const liveFallbackQueue = canResolveFromLiveDownloads
+    ? [...remainingAvailableDownloads]
+    : [];
+
+  const downloadFiles = persistedSelections.flatMap((selection) => {
+    const matchedDownload = availableDownloadsByName.get(selection.file);
+
+    if (matchedDownload) {
+      return [toImportDownloadFile(matchedDownload)];
+    }
+
+    missingSelectionNames.push(selection.file);
+
+    const fallbackLiveDownload = liveFallbackQueue.shift();
+    if (fallbackLiveDownload) {
+      resolvedWithLiveFallbackNames.push(selection.file);
+      return [toImportDownloadFile(fallbackLiveDownload)];
+    }
+
+    resolvedWithPersistedFallbackNames.push(selection.file);
+    if (!isHttpOrHttpsUrl(selection.url)) {
+      return [];
+    }
+    return [toImportDownloadFile(selection)];
+  });
+
+  return {
+    downloadFiles,
+    missingSelectionNames,
+    resolvedWithLiveFallbackNames,
+    resolvedWithPersistedFallbackNames,
+  };
+};

--- a/apps/desktop/src/lib/profiles/import-profile-prep.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-prep.ts
@@ -1,0 +1,143 @@
+import { getMod, getModDownloads } from "@/lib/api";
+import logger from "@/lib/logger";
+import { resolveProfileImportDownloadFiles } from "@/lib/profiles/import-downloads";
+import type {
+  AvailableImportedMod,
+  FetchModsDataEntry,
+  FetchModsDataResult,
+  PrepareProfileImportEntry,
+  PreparedProfileImport,
+  PreparedProfileImportMod,
+} from "@/lib/profiles/types";
+
+export const fetchModsData = async (
+  remoteIds: string[],
+): Promise<FetchModsDataResult> => {
+  const results: FetchModsDataEntry[] = await Promise.all(
+    Array.from(new Set(remoteIds)).map(async (remoteId) => {
+      try {
+        return {
+          remoteId,
+          modData: await getMod(remoteId),
+        };
+      } catch (error) {
+        return {
+          remoteId,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+
+  return results.reduce<FetchModsDataResult>(
+    (accumulator, result) => {
+      if ("modData" in result) {
+        accumulator.modsData.push(result.modData);
+      } else {
+        accumulator.failed.push([result.remoteId, result.error]);
+      }
+
+      return accumulator;
+    },
+    { modsData: [], failed: [] },
+  );
+};
+
+export const prepareProfileImportMods = async (
+  availableImportedMods: AvailableImportedMod[],
+): Promise<PreparedProfileImport> => {
+  const results: PrepareProfileImportEntry[] = await Promise.all(
+    availableImportedMods.map(async ({ importedMod, modData }) => {
+      try {
+        const downloadsResponse = await getModDownloads(modData.remoteId);
+        const downloadFiles = downloadsResponse.downloads || [];
+
+        const resolvedDownloadFiles = resolveProfileImportDownloadFiles({
+          availableDownloads: downloadFiles,
+          selectedDownloads: importedMod.selectedDownloads,
+          selectedDownload: importedMod.selectedDownload,
+        });
+
+        if (resolvedDownloadFiles.downloadFiles.length === 0) {
+          throw new Error("No download files available for import");
+        }
+
+        if (resolvedDownloadFiles.resolvedWithLiveFallbackNames.length > 0) {
+          logger
+            .withMetadata({
+              modId: modData.remoteId,
+              modName: modData.name,
+              renamedSelectionNames:
+                resolvedDownloadFiles.resolvedWithLiveFallbackNames,
+              availableDownloadCount: downloadFiles.length,
+            })
+            .warn(
+              "Using current live download entries for renamed imported selections",
+            );
+        }
+
+        if (
+          resolvedDownloadFiles.resolvedWithPersistedFallbackNames.length > 0
+        ) {
+          logger
+            .withMetadata({
+              modId: modData.remoteId,
+              modName: modData.name,
+              missingSelectionNames:
+                resolvedDownloadFiles.resolvedWithPersistedFallbackNames,
+              availableDownloadCount: downloadFiles.length,
+            })
+            .warn("Falling back to persisted imported download selection");
+        }
+
+        return {
+          importedMod,
+          modData,
+          profileImportMod: {
+            modId: modData.remoteId,
+            modName: modData.name,
+            downloadFiles: resolvedDownloadFiles.downloadFiles.map(
+              (download) => ({
+                url: download.url,
+                name: download.name,
+                size: download.size,
+              }),
+            ),
+            fileTree: importedMod.fileTree
+              ? {
+                  ...importedMod.fileTree,
+                  files: importedMod.fileTree.files.some(
+                    (file) => file.is_selected,
+                  )
+                    ? importedMod.fileTree.files
+                    : importedMod.fileTree.files.map((file) => ({
+                        ...file,
+                        is_selected: true,
+                      })),
+                }
+              : undefined,
+            isMap: modData.isMap,
+          },
+        } satisfies PreparedProfileImportMod;
+      } catch (error) {
+        return {
+          importedMod,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+
+  return results.reduce<PreparedProfileImport>(
+    (accumulator, result) => {
+      if ("profileImportMod" in result) {
+        accumulator.preparedMods.push(result);
+      } else {
+        accumulator.failed.push([result.importedMod.remoteId, result.error]);
+      }
+
+      return accumulator;
+    },
+    { preparedMods: [], failed: [] },
+  );
+};

--- a/apps/desktop/src/lib/profiles/import-profile-shared.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-shared.ts
@@ -1,0 +1,33 @@
+import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import type { AvailableImportedMod } from "@/lib/profiles/types";
+import type { LocalMod } from "@/types/mods";
+
+export const sortModsByInstallOrder = (mods: LocalMod[]): LocalMod[] =>
+  [...mods].sort(
+    (left, right) =>
+      (left.installOrder ?? Number.MAX_SAFE_INTEGER) -
+      (right.installOrder ?? Number.MAX_SAFE_INTEGER),
+  );
+
+export const resolveImportContext = (
+  importedProfile: SharedProfile,
+  modsData: ModDto[],
+) => {
+  const importedMods = importedProfile.payload.mods;
+  const modsDataByRemoteId = new Map(
+    modsData.map((mod) => [mod.remoteId, mod]),
+  );
+  const availableImportedMods = importedMods
+    .map((importedMod) => {
+      const modData = modsDataByRemoteId.get(importedMod.remoteId);
+      return modData ? { importedMod, modData } : null;
+    })
+    .filter((entry): entry is AvailableImportedMod => entry !== null);
+
+  return {
+    importedMods,
+    availableImportedMods,
+    modsDataByRemoteId,
+    unavailableModsCount: importedMods.length - availableImportedMods.length,
+  };
+};

--- a/apps/desktop/src/lib/profiles/import-profile.ts
+++ b/apps/desktop/src/lib/profiles/import-profile.ts
@@ -1,0 +1,271 @@
+import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { invoke } from "@tauri-apps/api/core";
+import type { TFunction } from "i18next";
+import logger from "@/lib/logger";
+import { prepareProfileImportMods } from "@/lib/profiles/import-profile-prep";
+import { resolveImportContext } from "@/lib/profiles/import-profile-shared";
+import type {
+  ImportProgress,
+  ProfileImportOptions,
+} from "@/lib/profiles/types";
+import type { State } from "@/lib/store";
+import type { ProfileImportResult } from "@/types/mods";
+import type { ModProfile, ProfileId } from "@/types/profiles";
+import { createProfileId } from "@/types/profiles";
+
+export interface ProfileImportFlowDeps {
+  setImportProgress: (progress: ImportProgress | null) => void;
+  t: TFunction;
+  upsertProfile: State["upsertProfile"];
+  createImportProfileFolder: State["createImportProfileFolder"];
+  applyImportInstalledModsToProfile: State["applyImportInstalledModsToProfile"];
+  setProfileFolderName: State["setProfileFolderName"];
+  getProfile: State["getProfile"];
+  getActiveProfile: State["getActiveProfile"];
+}
+
+export const createProfileImportFlow = (deps: ProfileImportFlowDeps) => {
+  const {
+    setImportProgress,
+    t,
+    upsertProfile,
+    createImportProfileFolder,
+    applyImportInstalledModsToProfile,
+    setProfileFolderName,
+    getActiveProfile,
+  } = deps;
+
+  const createProfileFromImport = async (
+    importedProfile: SharedProfile,
+    modsData: ModDto[],
+    _options?: ProfileImportOptions,
+  ): Promise<void> => {
+    const {
+      importedMods,
+      availableImportedMods,
+      modsDataByRemoteId,
+      unavailableModsCount,
+    } = resolveImportContext(importedProfile, modsData);
+
+    const totalImportedMods = importedMods.length;
+    if (totalImportedMods === 0) {
+      throw new Error("No mods available in imported profile");
+    }
+
+    logger
+      .withMetadata({
+        importedModsCount: totalImportedMods,
+        availableModsCount: availableImportedMods.length,
+        unavailableModsCount,
+      })
+      .info("Starting profile import");
+
+    let newProfileId: ProfileId | null = null;
+
+    try {
+      setImportProgress({
+        currentStep: t("profiles.creatingProfile"),
+        completedMods: 0,
+        totalMods: totalImportedMods,
+        isDownloading: false,
+        isInstalling: false,
+      });
+
+      const profileId = `profile_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+      const createdProfileId = createProfileId(profileId);
+      newProfileId = createdProfileId;
+      const profileName = t("profiles.importedProfileName", {
+        date: new Date().toLocaleDateString(),
+      });
+      const folderName = await createImportProfileFolder(
+        createdProfileId,
+        profileName,
+      );
+
+      const newProfile: ModProfile = {
+        id: createdProfileId,
+        name: profileName,
+        description: t("profiles.importedProfileDescription"),
+        createdAt: new Date(),
+        lastUsed: new Date(),
+        enabledMods: {},
+        isDefault: false,
+        folderName,
+        mods: [],
+      };
+
+      upsertProfile(newProfile);
+
+      const { preparedMods, failed: preparationFailed } =
+        await prepareProfileImportMods(availableImportedMods);
+
+      let result: ProfileImportResult = {
+        profileFolder: folderName,
+        succeeded: [],
+        failed: [],
+        installedMods: [],
+      };
+
+      if (preparedMods.length > 0) {
+        result = await invoke<ProfileImportResult>("import_profile_batch", {
+          profileName,
+          profileDescription: t("profiles.importedProfileDescription"),
+          profileFolder: folderName,
+          mods: preparedMods.map((entry) => entry.profileImportMod),
+          importType: "override",
+        });
+
+        if (result.profileFolder && result.profileFolder !== folderName) {
+          setProfileFolderName(newProfileId, result.profileFolder);
+        }
+      }
+
+      if (result.installedMods.length > 0) {
+        applyImportInstalledModsToProfile(
+          newProfileId,
+          result.installedMods,
+          modsDataByRemoteId,
+        );
+      }
+
+      const missingCount =
+        totalImportedMods -
+        result.installedMods.length -
+        (totalImportedMods - preparedMods.length - unavailableModsCount);
+
+      setImportProgress(null);
+
+      if (
+        result.failed.length > 0 ||
+        preparationFailed.length > 0 ||
+        unavailableModsCount > 0
+      ) {
+        logger
+          .withMetadata({
+            failed: result.failed.length,
+            succeeded: result.succeeded.length,
+            unavailable: unavailableModsCount,
+            preparationFailed: preparationFailed.length,
+          })
+          .warn("Some mods failed to import");
+        const imported = result.installedMods.length;
+        toast.warning(
+          t("profiles.createSuccess", { profileName }) +
+            ` (${t("profiles.modsImportedCount", { imported, total: totalImportedMods })})`,
+        );
+      } else {
+        toast.success(t("profiles.createSuccess", { profileName }));
+      }
+
+      void missingCount;
+    } catch (error) {
+      logger.withError(error).error("Profile import failed");
+      setImportProgress(null);
+      toast.error(t("profiles.createError"));
+      throw error;
+    }
+  };
+
+  const addToCurrentProfile = async (
+    importedProfile: SharedProfile,
+    modsData: ModDto[],
+    _options?: ProfileImportOptions,
+  ): Promise<void> => {
+    const activeProfile = getActiveProfile();
+    if (!activeProfile) {
+      throw new Error("No active profile found");
+    }
+
+    const {
+      importedMods,
+      availableImportedMods,
+      modsDataByRemoteId,
+      unavailableModsCount,
+    } = resolveImportContext(importedProfile, modsData);
+
+    const totalImportedMods = importedMods.length;
+    if (totalImportedMods === 0) {
+      throw new Error("No mods available in imported profile");
+    }
+
+    logger
+      .withMetadata({
+        profileId: activeProfile.id,
+        importedModsCount: totalImportedMods,
+        availableModsCount: availableImportedMods.length,
+        unavailableModsCount,
+      })
+      .info("Overriding current profile with imported mods");
+
+    try {
+      setImportProgress({
+        currentStep: t("profiles.updatingProfile"),
+        completedMods: 0,
+        totalMods: totalImportedMods,
+        isDownloading: false,
+        isInstalling: false,
+      });
+
+      const { preparedMods, failed: preparationFailed } =
+        await prepareProfileImportMods(availableImportedMods);
+
+      let result: ProfileImportResult = {
+        profileFolder: activeProfile.folderName || "",
+        succeeded: [],
+        failed: [],
+        installedMods: [],
+      };
+
+      if (preparedMods.length > 0) {
+        result = await invoke<ProfileImportResult>("import_profile_batch", {
+          profileName: activeProfile.name,
+          profileDescription: activeProfile.description || "",
+          profileFolder: activeProfile.folderName || "",
+          mods: preparedMods.map((entry) => entry.profileImportMod),
+          importType: "override",
+        });
+
+        applyImportInstalledModsToProfile(
+          activeProfile.id,
+          result.installedMods,
+          modsDataByRemoteId,
+        );
+      }
+
+      setImportProgress(null);
+
+      if (
+        result.failed.length > 0 ||
+        preparationFailed.length > 0 ||
+        unavailableModsCount > 0
+      ) {
+        logger
+          .withMetadata({
+            failed: result.failed.length,
+            succeeded: result.succeeded.length,
+            unavailable: unavailableModsCount,
+            preparationFailed: preparationFailed.length,
+          })
+          .warn("Some mods failed to import to current profile");
+        const imported = result.installedMods.length;
+        toast.warning(
+          t("profiles.overrideSuccess") +
+            ` (${t("profiles.modsImportedCount", { imported, total: totalImportedMods })})`,
+        );
+      } else {
+        toast.success(t("profiles.overrideSuccess"));
+      }
+    } catch (error) {
+      logger.withError(error).error("Profile import failed");
+      setImportProgress(null);
+      toast.error(t("profiles.updateError"));
+      throw error;
+    }
+  };
+
+  return {
+    createProfileFromImport,
+    addToCurrentProfile,
+  };
+};

--- a/apps/desktop/src/lib/profiles/types.ts
+++ b/apps/desktop/src/lib/profiles/types.ts
@@ -1,0 +1,84 @@
+import type {
+  ModDto,
+  ProfileModDownload,
+  SharedProfile,
+} from "@deadlock-mods/shared";
+import type { ProfileImportMod } from "@/types/mods";
+
+export interface ImportProgress {
+  currentStep: string;
+  currentMod?: string;
+  completedMods: number;
+  totalMods: number;
+  isDownloading: boolean;
+  isInstalling: boolean;
+}
+
+export type OrderedImportedMod = SharedProfile["payload"]["mods"][number];
+
+export interface AvailableImportedMod {
+  importedMod: OrderedImportedMod;
+  modData: ModDto;
+}
+
+export interface PreparedProfileImportMod {
+  importedMod: OrderedImportedMod;
+  modData: ModDto;
+  profileImportMod: ProfileImportMod;
+}
+
+export interface PreparedProfileImport {
+  preparedMods: PreparedProfileImportMod[];
+  failed: Array<[string, string]>;
+}
+
+export interface FetchModsDataResult {
+  modsData: ModDto[];
+  failed: Array<[string, string]>;
+}
+
+export type FetchModsDataEntry =
+  | {
+      remoteId: string;
+      modData: ModDto;
+    }
+  | {
+      remoteId: string;
+      error: string;
+    };
+
+export type PrepareProfileImportEntry =
+  | PreparedProfileImportMod
+  | {
+      importedMod: OrderedImportedMod;
+      error: string;
+    };
+
+export interface ProfileImportOptions {
+  sourceProfileId?: string;
+}
+
+export interface ProfileImportDownloadFile {
+  url: string;
+  name: string;
+  size: number;
+}
+
+export interface AvailableImportDownload {
+  url: string;
+  name: string;
+  size?: number | null;
+}
+
+export interface ResolveProfileImportDownloadFilesArgs {
+  availableDownloads: AvailableImportDownload[];
+  selectedDownloads?: ProfileModDownload[];
+  selectedDownload?: ProfileModDownload;
+}
+
+export interface ResolvedProfileImportDownloadFiles {
+  downloadFiles: ProfileImportDownloadFile[];
+  missingSelectionNames: string[];
+  resolvedWithLiveFallbackNames: string[];
+  resolvedWithPersistedFallbackNames: string[];
+}

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -1,9 +1,11 @@
+import { type ModDto } from "@deadlock-mods/shared";
 import { invoke } from "@tauri-apps/api/core";
+import i18n from "i18next";
 import type { StateCreator } from "zustand";
 import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { isInstalledModWithVpks } from "@/lib/mods/installed-helpers";
-import { type LocalMod, ModStatus } from "@/types/mods";
+import { type LocalMod, ModStatus, type InstalledModInfo } from "@/types/mods";
 import {
   createProfileId,
   DEFAULT_PROFILE_ID,
@@ -13,7 +15,6 @@ import {
   type ProfileId,
   type ProfileSwitchResult,
 } from "@/types/profiles";
-import type { State } from "..";
 
 export interface ProfilesState {
   profiles: Record<ProfileId, ModProfile>;
@@ -29,6 +30,17 @@ export interface ProfilesState {
     profileId: ProfileId,
     updates: Partial<Pick<ModProfile, "name" | "description">>,
   ) => boolean;
+  setProfileFolderName: (profileId: ProfileId, folderName: string) => void;
+  upsertProfile: (profile: ModProfile) => void;
+  createImportProfileFolder: (
+    profileId: ProfileId,
+    profileName: string,
+  ) => Promise<string>;
+  applyImportInstalledModsToProfile: (
+    profileId: ProfileId,
+    installedMods: InstalledModInfo[],
+    modsDataByRemoteId: Map<string, ModDto>,
+  ) => void;
 
   switchToProfile: (profileId: ProfileId) => Promise<ProfileSwitchResult>;
   setModEnabledInProfile: (
@@ -66,10 +78,114 @@ const createDefaultProfile = (): ModProfile => ({
 export const profilesDeepMergeKeys =
   [] as const satisfies readonly (keyof ProfilesState)[];
 
-export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
-  set,
-  get,
-) => ({
+const RECOVERED_PROFILE_DESCRIPTION = "Profile detected from filesystem";
+const PROFILE_FOLDER_NAME_PATTERN = /^(profile_\d+_[^_]+)(?:_(.+))?$/;
+
+const toRecoveredProfileName = (value: string) => {
+  const displayName = value
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+  return (
+    displayName ||
+    i18n.t("profiles.unknownProfile", { defaultValue: "Unknown Profile" })
+  );
+};
+
+const getRecoveredProfileDetails = (folderName: string) => {
+  const match = folderName.match(PROFILE_FOLDER_NAME_PATTERN);
+
+  return {
+    profileId: createProfileId(match?.[1] ?? folderName),
+    displayName: toRecoveredProfileName(match?.[2] ?? folderName),
+  };
+};
+
+const shouldReplaceRecoveredProfileName = (profile: ModProfile) =>
+  profile.description === RECOVERED_PROFILE_DESCRIPTION || !profile.name.trim();
+
+const pickRecoveredProfileSource = (
+  existingProfile: ModProfile | undefined,
+  recoveredProfile: ModProfile,
+) => {
+  if (!existingProfile) {
+    return recoveredProfile;
+  }
+
+  if (existingProfile.mods.length !== recoveredProfile.mods.length) {
+    return existingProfile.mods.length > recoveredProfile.mods.length
+      ? existingProfile
+      : recoveredProfile;
+  }
+
+  return Object.keys(existingProfile.enabledMods).length >=
+    Object.keys(recoveredProfile.enabledMods).length
+    ? existingProfile
+    : recoveredProfile;
+};
+
+const normalizeRecoveredProfileIds = (
+  profiles: Record<ProfileId, ModProfile>,
+  activeProfileId: ProfileId,
+) => {
+  const nextProfiles = { ...profiles };
+  let nextActiveProfileId = activeProfileId;
+  let changed = false;
+
+  for (const profile of Object.values(profiles)) {
+    if (profile.isDefault || !profile.folderName) {
+      continue;
+    }
+
+    const { profileId, displayName } = getRecoveredProfileDetails(
+      profile.folderName,
+    );
+
+    if (profile.id === profileId) {
+      continue;
+    }
+
+    const sourceProfile = pickRecoveredProfileSource(
+      nextProfiles[profileId],
+      profile,
+    );
+
+    delete nextProfiles[profile.id];
+    nextProfiles[profileId] = {
+      ...sourceProfile,
+      id: profileId,
+      folderName: profile.folderName,
+      name: shouldReplaceRecoveredProfileName(sourceProfile)
+        ? displayName
+        : sourceProfile.name,
+    };
+
+    if (nextActiveProfileId === profile.id) {
+      nextActiveProfileId = profileId;
+    }
+
+    changed = true;
+  }
+
+  return {
+    profiles: changed ? nextProfiles : profiles,
+    activeProfileId: nextActiveProfileId,
+    changed,
+  };
+};
+
+type ProfilesSliceStore = ProfilesState & {
+  localMods: LocalMod[];
+};
+
+export const createProfilesSlice: StateCreator<
+  ProfilesSliceStore,
+  [],
+  [],
+  ProfilesState
+> = (set, get, _store): ProfilesState => ({
   profiles: {
     [DEFAULT_PROFILE_ID]: createDefaultProfile(),
   },
@@ -127,8 +243,29 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
       return false;
     }
 
-    if (profile.folderName) {
-      try {
+    const isDeletingActiveProfile = activeProfileId === profileId;
+    const fallbackProfile =
+      profiles[DEFAULT_PROFILE_ID] ?? createDefaultProfile();
+    let switchedToFallback = false;
+
+    try {
+      if (isDeletingActiveProfile) {
+        set({ isSwitching: true });
+
+        await invoke("switch_profile", {
+          profileFolder: fallbackProfile.folderName,
+        });
+        switchedToFallback = true;
+        logger
+          .withMetadata({
+            deletedProfileId: profileId,
+            fallbackProfileId: DEFAULT_PROFILE_ID,
+            fallbackFolderName: fallbackProfile.folderName,
+          })
+          .info("Switched to fallback profile before deletion");
+      }
+
+      if (profile.folderName) {
         await invoke("delete_profile_folder", {
           profileFolder: profile.folderName,
         });
@@ -138,29 +275,63 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
             folderName: profile.folderName,
           })
           .info("Deleted profile folder");
-      } catch (error) {
-        logger
-          .withMetadata({
-            profileId,
-            folderName: profile.folderName,
-          })
-          .withError(error)
-          .error("Failed to delete profile folder");
+      }
+
+      const deletedAt = new Date();
+
+      set((state) => {
+        const remainingProfiles = { ...state.profiles };
+
+        if (!remainingProfiles[DEFAULT_PROFILE_ID]) {
+          remainingProfiles[DEFAULT_PROFILE_ID] = fallbackProfile;
+        }
+
+        delete remainingProfiles[profileId];
+
+        if (!isDeletingActiveProfile) {
+          return {
+            profiles: remainingProfiles,
+          };
+        }
+
+        const nextActiveProfile = remainingProfiles[DEFAULT_PROFILE_ID];
+
+        return {
+          profiles: {
+            ...remainingProfiles,
+            [DEFAULT_PROFILE_ID]: {
+              ...nextActiveProfile,
+              lastUsed: deletedAt,
+            },
+          },
+          activeProfileId: DEFAULT_PROFILE_ID,
+          localMods: [...nextActiveProfile.mods],
+        };
+      });
+
+      return true;
+    } catch (error) {
+      if (switchedToFallback) {
+        set({
+          activeProfileId: DEFAULT_PROFILE_ID,
+          localMods: [...fallbackProfile.mods],
+        });
+      }
+      logger
+        .withMetadata({
+          profileId,
+          folderName: profile.folderName,
+          isDeletingActiveProfile,
+          switchedToFallback,
+        })
+        .withError(error)
+        .error("Failed to delete profile");
+      return false;
+    } finally {
+      if (isDeletingActiveProfile) {
+        set({ isSwitching: false });
       }
     }
-
-    const newProfiles = { ...profiles };
-    delete newProfiles[profileId];
-
-    set((state) => ({
-      profiles: newProfiles,
-      activeProfileId:
-        activeProfileId === profileId
-          ? DEFAULT_PROFILE_ID
-          : state.activeProfileId,
-    }));
-
-    return true;
   },
 
   updateProfile: (
@@ -189,6 +360,153 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
     }));
 
     return true;
+  },
+
+  setProfileFolderName: (profileId: ProfileId, folderName: string) => {
+    set((state) => {
+      const profile = state.profiles[profileId];
+
+      if (!profile) {
+        return state;
+      }
+
+      return {
+        profiles: {
+          ...state.profiles,
+          [profileId]: {
+            ...profile,
+            folderName,
+          },
+        },
+      };
+    });
+  },
+
+  upsertProfile: (profile: ModProfile) => {
+    set((state) => ({
+      profiles: {
+        ...state.profiles,
+        [profile.id]: profile,
+      },
+    }));
+  },
+
+  createImportProfileFolder: async (
+    profileId: ProfileId,
+    profileName: string,
+  ): Promise<string> => {
+    const folderName = await invoke<string>("create_profile_folder", {
+      profileId,
+      profileName,
+    });
+
+    get().setProfileFolderName(profileId, folderName);
+    return folderName;
+  },
+
+  applyImportInstalledModsToProfile: (
+    profileId: ProfileId,
+    installedMods: InstalledModInfo[],
+    modsDataByRemoteId: Map<string, ModDto>,
+  ) => {
+    set((state) => {
+      const profile = state.profiles[profileId];
+
+      if (!profile) {
+        return state;
+      }
+
+      const now = new Date();
+      const updateActiveLocalMods = state.activeProfileId === profileId;
+      const nextProfileMods = [...profile.mods];
+      const profileIndexesByRemoteId = new Map(
+        nextProfileMods.map((mod, index) => [mod.remoteId, index]),
+      );
+      const nextEnabledMods = { ...profile.enabledMods };
+      const nextLocalMods = updateActiveLocalMods
+        ? [...state.localMods]
+        : state.localMods;
+      const localIndexesByRemoteId = updateActiveLocalMods
+        ? new Map(nextLocalMods.map((mod, index) => [mod.remoteId, index]))
+        : null;
+
+      for (const installedMod of installedMods) {
+        const modData = modsDataByRemoteId.get(installedMod.modId);
+
+        if (!modData) {
+          continue;
+        }
+
+        const existingProfileIndex = profileIndexesByRemoteId.get(
+          installedMod.modId,
+        );
+        const existingProfileMod =
+          existingProfileIndex === undefined
+            ? undefined
+            : nextProfileMods[existingProfileIndex];
+        const existingLocalIndex = localIndexesByRemoteId?.get(
+          installedMod.modId,
+        );
+        const existingLocalMod =
+          existingLocalIndex === undefined
+            ? undefined
+            : nextLocalMods[existingLocalIndex];
+        const baseMod = existingProfileMod ?? existingLocalMod;
+
+        const nextMod: LocalMod = {
+          ...(baseMod ?? modData),
+          downloadedAt: baseMod?.downloadedAt ?? now,
+          status: ModStatus.Installed,
+          installedVpks: installedMod.installedVpks,
+          installedFileTree: installedMod.fileTree,
+        };
+
+        if (existingProfileIndex === undefined) {
+          profileIndexesByRemoteId.set(
+            installedMod.modId,
+            nextProfileMods.length,
+          );
+          nextProfileMods.push(nextMod);
+        } else {
+          nextProfileMods[existingProfileIndex] = nextMod;
+        }
+
+        nextEnabledMods[installedMod.modId] = {
+          remoteId: installedMod.modId,
+          enabled: true,
+          lastModified: now,
+        };
+
+        if (updateActiveLocalMods && localIndexesByRemoteId) {
+          if (existingLocalIndex === undefined) {
+            localIndexesByRemoteId.set(
+              installedMod.modId,
+              nextLocalMods.length,
+            );
+            nextLocalMods.push(nextMod);
+          } else {
+            nextLocalMods[existingLocalIndex] = nextMod;
+          }
+        }
+      }
+
+      const nextPartial: Partial<ProfilesSliceStore> = {
+        profiles: {
+          ...state.profiles,
+          [profileId]: {
+            ...profile,
+            enabledMods: nextEnabledMods,
+            mods: nextProfileMods,
+          },
+        },
+      };
+
+      if (updateActiveLocalMods) {
+        nextPartial.localMods = nextLocalMods;
+      }
+
+      return nextPartial;
+    });
   },
 
   switchToProfile: async (profileId: ProfileId) => {
@@ -362,11 +680,6 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
     return localMods.filter(isInstalledModWithVpks).length;
   },
 
-  activeProfile: () => {
-    const { activeProfileId, profiles } = get();
-    return profiles[activeProfileId];
-  },
-
   saveCurrentModsToProfile: () => {
     const { activeProfileId, profiles, localMods } = get();
     const profile = profiles[activeProfileId];
@@ -532,7 +845,22 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
   syncProfilesWithFilesystem: async () => {
     try {
       const filesystemFolders = await invoke<string[]>("list_profile_folders");
-      const { profiles, activeProfileId } = get();
+      const state = get();
+      const normalizedState = normalizeRecoveredProfileIds(
+        state.profiles,
+        state.activeProfileId,
+      );
+
+      if (normalizedState.changed) {
+        set({
+          profiles: normalizedState.profiles,
+          activeProfileId: normalizedState.activeProfileId,
+        });
+
+        logger.info("Normalized recovered profile IDs from filesystem folders");
+      }
+
+      const { profiles, activeProfileId } = normalizedState;
 
       const filesystemFoldersSet = new Set(filesystemFolders);
       const knownFolders = new Set(
@@ -599,28 +927,29 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
         const newProfiles: Record<ProfileId, ModProfile> = {};
 
         for (const folderName of unknownFolders) {
-          const parts = folderName.split("_");
-          const profileIdPart = parts[0];
-          const namePart = parts.slice(1).join("_") || "Unknown Profile";
+          const { profileId, displayName } =
+            getRecoveredProfileDetails(folderName);
+          const existingProfile = profiles[profileId];
 
-          const displayName = namePart
-            .split(/[-_]/)
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(" ");
-
-          const profileId = createProfileId(profileIdPart);
-
-          newProfiles[profileId] = {
-            id: profileId,
-            name: displayName,
-            description: "Profile detected from filesystem",
-            createdAt: new Date(),
-            lastUsed: new Date(),
-            enabledMods: {},
-            isDefault: false,
-            folderName: folderName,
-            mods: [],
-          };
+          newProfiles[profileId] = existingProfile
+            ? {
+                ...existingProfile,
+                folderName,
+                name: shouldReplaceRecoveredProfileName(existingProfile)
+                  ? displayName
+                  : existingProfile.name,
+              }
+            : {
+                id: profileId,
+                name: displayName,
+                description: RECOVERED_PROFILE_DESCRIPTION,
+                createdAt: new Date(),
+                lastUsed: new Date(),
+                enabledMods: {},
+                isDefault: false,
+                folderName,
+                mods: [],
+              };
         }
 
         set((state) => ({

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1625,7 +1625,8 @@
     "noUrlAvailable": "No URL available for this mod",
     "openedGameFolder": "Opened game folder",
     "openedModInGame": "Opened mod files in game folder",
-    "failedToOpenGameFolder": "Failed to open game folder"
+    "failedToOpenGameFolder": "Failed to open game folder",
+    "failedToOpenModInGame": "Failed to show mod in game"
   },
   "profiles": {
     "share": "Share Profile",
@@ -1699,7 +1700,18 @@
     "creatingProfile": "Creating new profile...",
     "updatingProfile": "Updating current profile...",
     "processingMods": "Processing mods...",
-    "modsProcessed": "Mods processed"
+    "modsProcessed": "Mods processed",
+    "importedProfileDescription": "Profile imported from shared profile ID",
+    "importedProfileName": "Imported Profile - {{date}}",
+    "modsImportedCount": "{{imported}}/{{total}} mods imported",
+    "activateProfileLabel": "Activate {{profileName}} profile",
+    "statusActive": "Active",
+    "statusInactive": "Inactive",
+    "hideModList": "Hide",
+    "showModList": "Show",
+    "modId": "ID: {{id}}",
+    "unknownProfile": "Unknown Profile",
+    "recoveredProfileDescription": "Profile detected from filesystem"
   },
   "mapInvite": {
     "title": "Invite Friends",


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Profile Import Logic Refactoring

This PR refactors the profile import workflow in the desktop app by extracting inline logic from `use-profile-import.ts` into a new set of specialized modules under `src/lib/profiles/`. The refactoring maintains existing behavior while improving code organization and separation of concerns.

### Affected Packages
- **desktop app** (only package affected)

### Functional Changes

**New modules created:**
- `types.ts`: Defines TypeScript interfaces for import progress tracking, prepared mod data, fetch results, and download file resolution
- `import-downloads.ts`: Handles resolving download file selections and applying live/persisted fallbacks when downloads are unavailable
- `import-profile-prep.ts`: Manages fetching mod metadata and preparing mods for import, including validation and error collection
- `import-profile-shared.ts`: Provides utility functions for sorting mods by install order and resolving available mods from an import context
- `import-profile.ts`: Implements the core profile import flow factory that handles both creating new profiles from imports and adding mods to the current profile

**Modified components:**
- `profile-import-dialog.tsx`: Refactored to use React Query mutations for fetching and creating profiles, with error handling delegated to the query layer
- `use-profile-import.ts`: Simplified to delegate implementation to `createProfileImportFlow` factory; now accepts optional `listenToProgress` flag
- `ProfilesState` store slice: Added import-specific actions (`createImportProfileFolder`, `applyImportInstalledModsToProfile`) and generic profile helpers (`setProfileFolderName`, `upsertProfile`); enhanced `deleteProfile` with active profile switching logic and improved `syncProfilesWithFilesystem` to handle filesystem-recovered profiles with i18n fallback

**Import type location change:**
- `ImportProgress` type now sourced from `@/lib/profiles/types` instead of `@/hooks/use-profile-import`

No database migrations, Tauri plugin changes, Rust FFI modifications, or cross-package dependency changes are involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->