### PR TITLE
refactor(desktop): modularize profile import with VPK reordering

### DIFF
--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -19,7 +19,7 @@ use crate::reports::{CreateReportRequest, CreateReportResponse, ReportCounts, Re
 use futures::future::join_all;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::time::Instant;
@@ -2430,6 +2430,39 @@ pub struct ProfileImportResult {
   pub installed_mods: Vec<InstalledModInfo>, // Mods that were successfully installed
 }
 
+fn build_profile_import_reorder_data(
+  installed_mods: &[InstalledModInfo],
+) -> Vec<(String, Vec<String>, u32)> {
+  installed_mods
+    .iter()
+    .filter(|installed_mod| !installed_mod.installed_vpks.is_empty())
+    .enumerate()
+    .map(|(index, installed_mod)| {
+      (
+        installed_mod.mod_id.clone(),
+        installed_mod.installed_vpks.clone(),
+        index as u32,
+      )
+    })
+    .collect()
+}
+
+fn apply_profile_import_reorder_mappings(
+  installed_mods: &mut [InstalledModInfo],
+  updated_mappings: &[(String, Vec<String>)],
+) {
+  let updated_vpks_by_mod_id: HashMap<&str, &Vec<String>> = updated_mappings
+    .iter()
+    .map(|(mod_id, installed_vpks)| (mod_id.as_str(), installed_vpks))
+    .collect();
+
+  for installed_mod in installed_mods {
+    if let Some(updated_vpks) = updated_vpks_by_mod_id.get(installed_mod.mod_id.as_str()) {
+      installed_mod.installed_vpks = (*updated_vpks).clone();
+    }
+  }
+}
+
 #[tauri::command]
 pub async fn import_profile_batch(
   app_handle: AppHandle,
@@ -2443,7 +2476,7 @@ pub async fn import_profile_batch(
     "Starting batch profile import: {} mods, type: {}, folder: {}",
     mods.len(),
     import_type,
-    profile_folder
+    profile_folder,
   );
 
   let total_mods = mods.len();
@@ -2533,12 +2566,13 @@ pub async fn import_profile_batch(
       tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
       match manager.get_download_status(&mod_data.mod_id).await {
-        Ok(Some(status)) => {
-          if status.status == "downloading" {
-            continue;
+        Ok(Some(status)) => match status.status.as_str() {
+          "downloading" | "paused" => continue,
+          _ => {
+            download_error = Some(format!("Unexpected download status: {}", status.status));
+            break;
           }
-          download_complete = true;
-        }
+        },
         Ok(None) => {
           download_complete = true;
         }
@@ -2681,6 +2715,32 @@ pub async fn import_profile_batch(
       Err(e) => {
         log::error!("Failed to install mod {}: {:?}", mod_data.mod_id, e);
         failed.push((mod_data.mod_id.clone(), format!("{:?}", e)));
+      }
+    }
+  }
+
+  let reorder_data = build_profile_import_reorder_data(&installed_mods);
+  if !reorder_data.is_empty() {
+    let profile_folder = if final_profile_folder.is_empty() {
+      None
+    } else {
+      Some(final_profile_folder.clone())
+    };
+
+    let res = {
+      let mut mod_manager = MANAGER.lock().unwrap();
+      mod_manager.reorder_mods_by_remote_id(reorder_data, profile_folder)
+    };
+
+    match res {
+      Ok(updated_mappings) => {
+        apply_profile_import_reorder_mappings(&mut installed_mods, &updated_mappings);
+      }
+      Err(error) => {
+        log::warn!(
+          "Failed to reorder imported profile mods in addons folder: {:?}",
+          error
+        );
       }
     }
   }
@@ -3041,12 +3101,13 @@ pub async fn batch_update_mods(
       tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
       match manager.get_download_status(&mod_data.mod_id).await {
-        Ok(Some(status)) => {
-          if status.status == "downloading" {
-            continue;
+        Ok(Some(status)) => match status.status.as_str() {
+          "downloading" | "paused" => continue,
+          _ => {
+            download_error = Some(format!("Unexpected download status: {}", status.status));
+            break;
           }
-          download_complete = true;
-        }
+        },
         Ok(None) => {
           download_complete = true;
         }
@@ -3669,5 +3730,99 @@ mod server_addons_tests {
     assert!(validate_custom_file_name("foo/bar.vpk").is_err());
     assert!(validate_custom_file_name("foo\\bar.vpk").is_err());
     assert!(validate_custom_file_name("").is_err());
+  }
+}
+
+#[cfg(test)]
+mod profile_import_tests {
+  use super::*;
+
+  #[test]
+  fn build_profile_import_reorder_data_preserves_install_sequence() {
+    let installed_mods = vec![
+      InstalledModInfo {
+        mod_id: "mod-b".to_string(),
+        mod_name: "Mod B".to_string(),
+        installed_vpks: vec!["pak03_dir.vpk".to_string()],
+        file_tree: None,
+      },
+      InstalledModInfo {
+        mod_id: "mod-a".to_string(),
+        mod_name: "Mod A".to_string(),
+        installed_vpks: vec!["pak07_dir.vpk".to_string(), "pak08_dir.vpk".to_string()],
+        file_tree: None,
+      },
+    ];
+
+    let reorder_data = build_profile_import_reorder_data(&installed_mods);
+
+    assert_eq!(
+      reorder_data,
+      vec![
+        ("mod-b".to_string(), vec!["pak03_dir.vpk".to_string()], 0),
+        (
+          "mod-a".to_string(),
+          vec!["pak07_dir.vpk".to_string(), "pak08_dir.vpk".to_string()],
+          1,
+        ),
+      ]
+    );
+  }
+
+  #[test]
+  fn build_profile_import_reorder_data_skips_mods_without_vpks() {
+    let installed_mods = vec![
+      InstalledModInfo {
+        mod_id: "mod-empty".to_string(),
+        mod_name: "Empty".to_string(),
+        installed_vpks: vec![],
+        file_tree: None,
+      },
+      InstalledModInfo {
+        mod_id: "mod-a".to_string(),
+        mod_name: "Mod A".to_string(),
+        installed_vpks: vec!["pak01_dir.vpk".to_string()],
+        file_tree: None,
+      },
+    ];
+
+    let reorder_data = build_profile_import_reorder_data(&installed_mods);
+
+    assert_eq!(
+      reorder_data,
+      vec![("mod-a".to_string(), vec!["pak01_dir.vpk".to_string()], 0)]
+    );
+  }
+
+  #[test]
+  fn apply_profile_import_reorder_mappings_updates_matching_mods() {
+    let mut installed_mods = vec![
+      InstalledModInfo {
+        mod_id: "mod-a".to_string(),
+        mod_name: "Mod A".to_string(),
+        installed_vpks: vec!["pak07_dir.vpk".to_string()],
+        file_tree: None,
+      },
+      InstalledModInfo {
+        mod_id: "mod-b".to_string(),
+        mod_name: "Mod B".to_string(),
+        installed_vpks: vec!["pak03_dir.vpk".to_string()],
+        file_tree: None,
+      },
+    ];
+
+    apply_profile_import_reorder_mappings(
+      &mut installed_mods,
+      &[("mod-b".to_string(), vec!["pak01_dir.vpk".to_string()])],
+    );
+
+    assert_eq!(
+      installed_mods[0].installed_vpks,
+      vec!["pak07_dir.vpk".to_string()]
+    );
+    assert_eq!(
+      installed_mods[1].installed_vpks,
+      vec!["pak01_dir.vpk".to_string()]
+    );
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/addon_analyzer.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/addon_analyzer.rs
@@ -547,16 +547,14 @@ impl AddonAnalyzer {
     })
   }
 
-  /// Recursively find all VPK file paths in a directory
+  /// Find VPK file paths in the active addons directory without recursing.
   fn find_vpk_file_paths(&self, dir: &PathBuf, vpk_paths: &mut Vec<PathBuf>) -> Result<(), Error> {
     if dir.is_dir() {
       for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
 
-        if path.is_dir() {
-          self.find_vpk_file_paths(&path, vpk_paths)?;
-        } else if path.extension().and_then(|e| e.to_str()) == Some("vpk") {
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "vpk") {
           vpk_paths.push(path);
         }
       }
@@ -624,5 +622,65 @@ impl AddonAnalyzer {
       remote_id: None,
       match_info: None,
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn find_vpk_file_paths_only_scans_top_level_directory() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let addons_path = temp_dir.path().to_path_buf();
+    let nested_profile_path = addons_path.join("profile_other");
+
+    std::fs::write(addons_path.join("pak01_dir.vpk"), b"root").expect("write root vpk");
+    std::fs::create_dir_all(&nested_profile_path).expect("create nested dir");
+    std::fs::write(nested_profile_path.join("pak02_dir.vpk"), b"nested").expect("write nested vpk");
+
+    let analyzer = AddonAnalyzer::new();
+    let mut vpk_paths = Vec::new();
+    analyzer
+      .find_vpk_file_paths(&addons_path, &mut vpk_paths)
+      .expect("scan addons path");
+
+    let file_names: Vec<String> = vpk_paths
+      .into_iter()
+      .map(|path| {
+        path
+          .file_name()
+          .expect("file name")
+          .to_string_lossy()
+          .to_string()
+      })
+      .collect();
+
+    assert_eq!(file_names, vec!["pak01_dir.vpk".to_string()]);
+  }
+
+  #[test]
+  fn find_vpk_file_paths_ignores_non_vpk_entries() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let addons_path = temp_dir.path().to_path_buf();
+
+    std::fs::write(addons_path.join("pak01_dir.vpk"), b"root").expect("write vpk");
+    std::fs::write(addons_path.join("notes.txt"), b"ignore").expect("write text file");
+    std::fs::create_dir_all(addons_path.join("replays")).expect("create replays dir");
+
+    let analyzer = AddonAnalyzer::new();
+    let mut vpk_paths = Vec::new();
+    analyzer
+      .find_vpk_file_paths(&addons_path, &mut vpk_paths)
+      .expect("scan addons path");
+
+    assert_eq!(vpk_paths.len(), 1);
+    assert_eq!(
+      vpk_paths[0]
+        .file_name()
+        .expect("file name")
+        .to_string_lossy(),
+      "pak01_dir.vpk"
+    );
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -48,6 +48,20 @@ impl VpkManager {
     Ok(next_number)
   }
 
+  fn find_next_free_vpk_name(&self, addons_path: &Path) -> Result<String, Error> {
+    let mut next_number = 1u32;
+
+    loop {
+      let candidate = format!("pak{next_number:02}_dir.vpk");
+
+      if !addons_path.join(&candidate).exists() {
+        return Ok(candidate);
+      }
+
+      next_number += 1;
+    }
+  }
+
   pub fn reorder_vpks(
     &self,
     mod_vpk_mapping: &[(String, Vec<String>)], // (mod_id, vpk_filenames)
@@ -427,9 +441,7 @@ impl VpkManager {
         continue;
       }
 
-      // Find next available number (fills gaps)
-      let next_number = self.find_next_available_vpk_number(addons_path)?;
-      let new_name = format!("pak{next_number:02}_dir.vpk");
+      let new_name = self.find_next_free_vpk_name(addons_path)?;
       let new_path = addons_path.join(&new_name);
 
       if let Err(e) = fs::rename(&old_path, &new_path) {
@@ -641,5 +653,102 @@ impl VpkManager {
 impl Default for VpkManager {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn enable_vpks_uses_next_free_slot_without_overwriting_existing_profile_vpks() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let addons_path = temp_dir.path();
+
+    for number in 1..=7 {
+      let file_name = format!("pak{number:02}_dir.vpk");
+      std::fs::write(addons_path.join(file_name), format!("existing-{number}").as_bytes())
+        .expect("write existing vpk");
+    }
+
+    std::fs::write(addons_path.join("669198_pak96_dir.vpk"), b"beginnings")
+      .expect("write prefixed retry vpk");
+
+    let vpk_manager = VpkManager::new();
+    let enabled_vpks = vpk_manager
+      .enable_vpks(
+        addons_path,
+        "669198",
+        &["669198_pak96_dir.vpk".to_string()],
+      )
+      .expect("enable vpk");
+
+    assert_eq!(enabled_vpks, vec!["pak08_dir.vpk".to_string()]);
+    assert!(addons_path.join("pak08_dir.vpk").exists());
+    assert!(addons_path.join("pak01_dir.vpk").exists());
+    assert!(!addons_path.join("669198_pak96_dir.vpk").exists());
+  }
+
+  #[test]
+  fn retry_insert_reorders_existing_profile_to_drop_recovered_mod_into_expected_slot() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let addons_path = temp_dir.path();
+
+    for number in 1..=7 {
+      let file_name = format!("pak{number:02}_dir.vpk");
+      std::fs::write(addons_path.join(file_name), format!("existing-{number}").as_bytes())
+        .expect("write existing vpk");
+    }
+
+    std::fs::write(addons_path.join("669198_pak96_dir.vpk"), b"beginnings")
+      .expect("write prefixed retry vpk");
+
+    let vpk_manager = VpkManager::new();
+    let enabled_vpks = vpk_manager
+      .enable_vpks(
+        addons_path,
+        "669198",
+        &["669198_pak96_dir.vpk".to_string()],
+      )
+      .expect("enable vpk");
+
+    assert_eq!(enabled_vpks, vec!["pak08_dir.vpk".to_string()]);
+
+    let updated_mappings = vpk_manager
+      .reorder_vpks(
+        &[
+          ("669781".to_string(), vec!["pak01_dir.vpk".to_string()]),
+          ("640378".to_string(), vec!["pak02_dir.vpk".to_string()]),
+          ("659570".to_string(), vec!["pak03_dir.vpk".to_string()]),
+          ("669521".to_string(), vec!["pak04_dir.vpk".to_string()]),
+          ("634638".to_string(), vec!["pak05_dir.vpk".to_string()]),
+          ("669198".to_string(), vec!["pak08_dir.vpk".to_string()]),
+          ("658931".to_string(), vec!["pak06_dir.vpk".to_string()]),
+          ("667277".to_string(), vec!["pak07_dir.vpk".to_string()]),
+        ],
+        addons_path,
+      )
+      .expect("reorder vpks");
+
+    assert_eq!(
+      updated_mappings,
+      vec![
+        ("669781".to_string(), vec!["pak01_dir.vpk".to_string()]),
+        ("640378".to_string(), vec!["pak02_dir.vpk".to_string()]),
+        ("659570".to_string(), vec!["pak03_dir.vpk".to_string()]),
+        ("669521".to_string(), vec!["pak04_dir.vpk".to_string()]),
+        ("634638".to_string(), vec!["pak05_dir.vpk".to_string()]),
+        ("669198".to_string(), vec!["pak06_dir.vpk".to_string()]),
+        ("658931".to_string(), vec!["pak07_dir.vpk".to_string()]),
+        ("667277".to_string(), vec!["pak08_dir.vpk".to_string()]),
+      ]
+    );
+
+    for number in 1..=8 {
+      assert!(
+        addons_path.join(format!("pak{number:02}_dir.vpk")).exists(),
+        "expected pak{number:02}_dir.vpk to exist after reorder"
+      );
+    }
   }
 }

--- a/apps/desktop/src/components/profiles/profile-import-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-import-dialog.tsx
@@ -26,11 +26,10 @@ export const ProfileImportDialog = () => {
   const [importedProfile, setImportedProfile] = useState<SharedProfile | null>(
     null,
   );
-  const [isImporting, setIsImporting] = useState(false);
   const { t } = useTranslation();
   const { createProfileFromImport, importProgress } = useProfileImport();
 
-  const { isPending, mutate } = useMutation({
+  const fetchProfileMutation = useMutation({
     mutationFn: (profileId: string) => getProfile(profileId.trim()),
     onSuccess: (data) => {
       setImportedProfile(data);
@@ -42,14 +41,33 @@ export const ProfileImportDialog = () => {
     },
   });
 
-  // Fetch mod details for each mod in the imported profile
+  const createProfileMutation = useMutation({
+    mutationFn: ({
+      profile,
+      availableMods,
+      sourceProfileId,
+    }: {
+      profile: SharedProfile;
+      availableMods: ModDto[];
+      sourceProfileId?: string;
+    }) =>
+      createProfileFromImport(profile, availableMods, {
+        sourceProfileId,
+      }),
+    onSuccess: () => {
+      handleCancel();
+    },
+  });
+
+  const orderedImportedMods = importedProfile
+    ? importedProfile.payload.mods
+    : [];
+
   const modQueries = useQueries({
-    queries:
-      importedProfile?.payload.mods.map((mod) => ({
-        queryKey: ["mod", mod.remoteId],
-        queryFn: () => getMod(mod.remoteId),
-        enabled: !!importedProfile,
-      })) || [],
+    queries: orderedImportedMods.map((mod) => ({
+      queryKey: ["mod", mod.remoteId],
+      queryFn: () => getMod(mod.remoteId),
+    })),
   });
 
   const modsLoading = modQueries.some((query) => query.isPending);
@@ -58,11 +76,14 @@ export const ProfileImportDialog = () => {
     .filter(Boolean) as ModDto[];
 
   const onSubmit = async (values: ProfileImportFormData) => {
-    if (!values.profileId?.trim()) {
+    const profileId = values.profileId?.trim();
+
+    if (!profileId) {
       toast.error(t("profiles.profileIdRequired"));
       return;
     }
-    return mutate(values.profileId);
+
+    await fetchProfileMutation.mutateAsync(profileId);
   };
 
   const handleCancel = () => {
@@ -70,20 +91,16 @@ export const ProfileImportDialog = () => {
     setOpen(false);
   };
 
-  const handleCreateNewProfile = async () => {
+  const handleCreateNewProfile = () => {
     if (!importedProfile) return;
 
-    setIsImporting(true);
+    const sourceProfileId = fetchProfileMutation.variables?.trim();
 
-    try {
-      await createProfileFromImport(importedProfile.payload.mods, modsData);
-      handleCancel();
-    } catch (error) {
-      console.error("Failed to create profile from import:", error);
-      toast.error(t("profiles.createError"));
-    } finally {
-      setIsImporting(false);
-    }
+    createProfileMutation.mutate({
+      profile: importedProfile,
+      availableMods: modsData,
+      sourceProfileId,
+    });
   };
 
   return (
@@ -114,14 +131,14 @@ export const ProfileImportDialog = () => {
             modsData={modsData}
             onCreateNew={handleCreateNewProfile}
             onCancel={handleCancel}
-            isImporting={isImporting}
+            isImporting={createProfileMutation.isPending}
             importProgress={importProgress}
           />
         ) : (
           <ProfileImportForm
             onSubmit={onSubmit}
             onCancel={handleCancel}
-            isLoading={isPending}
+            isLoading={fetchProfileMutation.isPending}
           />
         )}
       </DialogContent>

--- a/apps/desktop/src/components/profiles/profile-import-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-import-dialog.tsx
@@ -1,4 +1,8 @@
-import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import {
+  getOrderedSharedProfileMods,
+  type ModDto,
+  type SharedProfile,
+} from "@deadlock-mods/shared";
 import { Button } from "@deadlock-mods/ui/components/button";
 import {
   Dialog,
@@ -60,7 +64,7 @@ export const ProfileImportDialog = () => {
   });
 
   const orderedImportedMods = importedProfile
-    ? importedProfile.payload.mods
+    ? getOrderedSharedProfileMods(importedProfile)
     : [];
 
   const modQueries = useQueries({

--- a/apps/desktop/src/components/profiles/profile-manager-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-manager-dialog.tsx
@@ -24,13 +24,15 @@ import {
   Trash2,
   Users,
 } from "@deadlock-mods/ui/icons";
-import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useConfirm } from "@/components/providers/alert-dialog";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { useSyncProfiles } from "@/hooks/use-sync-profiles";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
+import type { LocalMod } from "@/types/mods";
 import type { ModProfile, ModProfileEntry, ProfileId } from "@/types/profiles";
 import { ProfileCreateDialog } from "./profile-create-dialog";
 import { ProfileEditDialog } from "./profile-edit-dialog";
@@ -64,8 +66,6 @@ export const ProfileManagerDialog = ({
   const [expandedProfiles, setExpandedProfiles] = useState<Set<ProfileId>>(
     new Set(),
   );
-  const [isSyncing, setIsSyncing] = useState(false);
-
   useSyncProfiles(open);
 
   const {
@@ -78,6 +78,22 @@ export const ProfileManagerDialog = ({
 
   const profiles = getAllProfiles();
   const activeProfile = getActiveProfile();
+
+  const localModsByRemoteId = useMemo(
+    () => new Map(localMods.map((mod) => [mod.remoteId, mod] as const)),
+    [localMods],
+  );
+
+  const syncProfilesMutation = useMutation({
+    mutationFn: () => syncProfilesWithFilesystem(),
+    onSuccess: () => {
+      toast.success(t("profiles.syncSuccess"));
+    },
+    onError: (error) => {
+      logger.withError(error).error("Failed to sync profiles");
+      toast.error(t("profiles.syncError"));
+    },
+  });
 
   const handleDeleteProfile = async (
     profileId: ProfileId,
@@ -159,16 +175,17 @@ export const ProfileManagerDialog = ({
     });
   };
 
-  const getEnabledModsInfo = (profile: ModProfile): EnabledModsInfo => {
+  const getEnabledModsInfo = (
+    profile: ModProfile,
+    modsByRemoteId: Map<string, LocalMod>,
+  ): EnabledModsInfo => {
     const enabledEntries = Object.values(profile.enabledMods || {}).filter(
       (entry: ModProfileEntry) => entry.enabled,
     );
 
     const enabledMods: ModInfo[] = enabledEntries
       .map((entry) => {
-        const localMod = localMods.find(
-          (mod) => mod.remoteId === entry.remoteId,
-        );
+        const localMod = modsByRemoteId.get(entry.remoteId);
         return localMod
           ? { name: localMod.name, remoteId: entry.remoteId }
           : null;
@@ -179,19 +196,6 @@ export const ProfileManagerDialog = ({
       count: enabledEntries.length,
       mods: enabledMods,
     };
-  };
-
-  const handleSyncProfiles = async () => {
-    setIsSyncing(true);
-    try {
-      await syncProfilesWithFilesystem();
-      toast.success(t("profiles.syncSuccess"));
-    } catch (error) {
-      logger.withError(error).error("Failed to sync profiles");
-      toast.error(t("profiles.syncError"));
-    } finally {
-      setIsSyncing(false);
-    }
   };
 
   return (
@@ -211,116 +215,128 @@ export const ProfileManagerDialog = ({
           </div>
           <div className='flex-1 overflow-auto'>
             <div className='grid gap-4 pb-4'>
-              {profiles.map((profile) => (
-                <Card key={profile.id}>
-                  <CardHeader className='pb-3'>
-                    <div className='flex items-start justify-between'>
-                      <div className='flex-1 min-w-0'>
-                        <div className='flex items-center gap-2 mb-1'>
-                          <h3 className='font-semibold text-lg truncate'>
-                            {profile.name}
-                          </h3>
-                          {profile.id === activeProfile?.id && (
-                            <Badge variant='default' className='shrink-0'>
-                              {t("profiles.active")}
-                            </Badge>
+              {profiles.map((profile) => {
+                const enabledModsInfo = getEnabledModsInfo(
+                  profile,
+                  localModsByRemoteId,
+                );
+
+                return (
+                  <Card key={profile.id}>
+                    <CardHeader className='pb-3'>
+                      <div className='flex items-start justify-between'>
+                        <div className='flex-1 min-w-0'>
+                          <div className='flex items-center gap-2 mb-1'>
+                            <h3 className='font-semibold text-lg truncate'>
+                              {profile.name}
+                            </h3>
+                            {profile.id === activeProfile?.id && (
+                              <Badge variant='default' className='shrink-0'>
+                                {t("profiles.active")}
+                              </Badge>
+                            )}
+                            {profile.isDefault && (
+                              <Badge variant='secondary' className='shrink-0'>
+                                {t("profiles.default")}
+                              </Badge>
+                            )}
+                            <Button
+                              variant='transparent'
+                              size='sm'
+                              onClick={() => setEditingProfile(profile.id)}>
+                              <Edit className='w-4 h-4' />
+                            </Button>
+                          </div>
+                          {profile.description && (
+                            <p className='text-sm text-muted-foreground line-clamp-2'>
+                              {profile.description}
+                            </p>
                           )}
-                          {profile.isDefault && (
-                            <Badge variant='secondary' className='shrink-0'>
-                              {t("profiles.default")}
-                            </Badge>
-                          )}
-                          <Button
-                            variant='transparent'
-                            size='sm'
-                            onClick={() => setEditingProfile(profile.id)}>
-                            <Edit className='w-4 h-4' />
-                          </Button>
                         </div>
-                        {profile.description && (
-                          <p className='text-sm text-muted-foreground line-clamp-2'>
-                            {profile.description}
-                          </p>
+                        <div className='flex items-center gap-2 ml-4'>
+                          <div className='flex items-center gap-2'>
+                            <Switch
+                              checked={profile.id === activeProfile?.id}
+                              onCheckedChange={(checked) => {
+                                if (
+                                  checked &&
+                                  profile.id !== activeProfile?.id
+                                ) {
+                                  handleSetActive(profile.id);
+                                }
+                              }}
+                              aria-label={t("profiles.activateProfileLabel", {
+                                profileName: profile.name,
+                              })}
+                            />
+                            <span className='text-sm font-medium'>
+                              {profile.id === activeProfile?.id
+                                ? t("profiles.statusActive")
+                                : t("profiles.statusInactive")}
+                            </span>
+                          </div>
+                          {!profile.isDefault && (
+                            <Button
+                              variant='outline'
+                              size='sm'
+                              onClick={() =>
+                                handleDeleteProfile(profile.id, profile.name)
+                              }>
+                              <Trash2 className='w-4 h-4' />
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    </CardHeader>
+                    <CardContent className='space-y-4'>
+                      <div className='grid grid-cols-3 gap-4 text-sm'>
+                        <div>
+                          <div className='font-medium text-muted-foreground mb-1'>
+                            {t("profiles.lastUsed")}
+                          </div>
+                          <div className='text-foreground'>
+                            {formatDate(profile.lastUsed)}
+                          </div>
+                        </div>
+                        <div>
+                          <div className='font-medium text-muted-foreground mb-1'>
+                            {t("profiles.created")}
+                          </div>
+                          <div className='text-foreground'>
+                            {formatDate(profile.createdAt)}
+                          </div>
+                        </div>
+                      </div>
+                      <div className='flex items-center justify-between'>
+                        <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+                          {t("profiles.enabledMods")}:{" "}
+                          <Badge variant='secondary'>
+                            {enabledModsInfo.count}
+                          </Badge>
+                        </div>
+                        {enabledModsInfo.count > 0 && (
+                          <button
+                            onClick={() => toggleProfileExpanded(profile.id)}
+                            className='flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors cursor-pointer'>
+                            <span>
+                              {expandedProfiles.has(profile.id)
+                                ? t("profiles.hideModList")
+                                : t("profiles.showModList")}
+                            </span>
+                            {expandedProfiles.has(profile.id) ? (
+                              <ChevronUp className='w-3 h-3' />
+                            ) : (
+                              <ChevronDown className='w-3 h-3' />
+                            )}
+                          </button>
                         )}
                       </div>
-                      <div className='flex items-center gap-2 ml-4'>
-                        <div className='flex items-center gap-2'>
-                          <Switch
-                            checked={profile.id === activeProfile?.id}
-                            onCheckedChange={(checked) => {
-                              if (checked && profile.id !== activeProfile?.id) {
-                                handleSetActive(profile.id);
-                              }
-                            }}
-                            aria-label={`Activate ${profile.name} profile`}
-                          />
-                          <span className='text-sm font-medium'>
-                            {profile.id === activeProfile?.id
-                              ? "Active"
-                              : "Inactive"}
-                          </span>
-                        </div>
-                        {!profile.isDefault && (
-                          <Button
-                            variant='outline'
-                            size='sm'
-                            onClick={() =>
-                              handleDeleteProfile(profile.id, profile.name)
-                            }>
-                            <Trash2 className='w-4 h-4' />
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className='space-y-4'>
-                    <div className='grid grid-cols-3 gap-4 text-sm'>
-                      <div>
-                        <div className='font-medium text-muted-foreground mb-1'>
-                          {t("profiles.lastUsed")}
-                        </div>
-                        <div className='text-foreground'>
-                          {formatDate(profile.lastUsed)}
-                        </div>
-                      </div>
-                      <div>
-                        <div className='font-medium text-muted-foreground mb-1'>
-                          {t("profiles.created")}
-                        </div>
-                        <div className='text-foreground'>
-                          {formatDate(profile.createdAt)}
-                        </div>
-                      </div>
-                    </div>
-                    <div className='flex items-center justify-between'>
-                      <div className='flex items-center gap-2 text-sm text-muted-foreground'>
-                        {t("profiles.enabledMods")}:{" "}
-                        <Badge variant='secondary'>
-                          {getEnabledModsInfo(profile).count}
-                        </Badge>
-                      </div>
-                      {getEnabledModsInfo(profile).count > 0 && (
-                        <button
-                          onClick={() => toggleProfileExpanded(profile.id)}
-                          className='flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors cursor-pointer'>
-                          <span>
-                            {expandedProfiles.has(profile.id) ? "Hide" : "Show"}
-                          </span>
-                          {expandedProfiles.has(profile.id) ? (
-                            <ChevronUp className='w-3 h-3' />
-                          ) : (
-                            <ChevronDown className='w-3 h-3' />
-                          )}
-                        </button>
-                      )}
-                    </div>
-                  </CardContent>
-                  {expandedProfiles.has(profile.id) && (
-                    <div className='px-6 pb-6'>
-                      {getEnabledModsInfo(profile).mods.length > 0 && (
-                        <div className='grid gap-2'>
-                          {getEnabledModsInfo(profile).mods.map(
-                            (mod, index) => (
+                    </CardContent>
+                    {expandedProfiles.has(profile.id) && (
+                      <div className='px-6 pb-6'>
+                        {enabledModsInfo.mods.length > 0 && (
+                          <div className='grid gap-2'>
+                            {enabledModsInfo.mods.map((mod, index) => (
                               <div
                                 key={mod.remoteId}
                                 className='flex items-center gap-3 p-3 rounded-lg border bg-card hover:bg-muted/30 transition-colors'>
@@ -334,28 +350,28 @@ export const ProfileManagerDialog = ({
                                     {mod.name}
                                   </p>
                                   <p className='text-xs text-muted-foreground'>
-                                    ID: {mod.remoteId}
+                                    {t("profiles.modId", { id: mod.remoteId })}
                                   </p>
                                 </div>
                               </div>
-                            ),
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </Card>
-              ))}
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </Card>
+                );
+              })}
             </div>
           </div>
           <DialogFooter>
             <Button
-              onClick={handleSyncProfiles}
-              disabled={isSyncing}
+              onClick={() => syncProfilesMutation.mutate()}
+              disabled={syncProfilesMutation.isPending}
               variant='outline'
               icon={
                 <RefreshCw
-                  className={`w-4 h-4 ${isSyncing ? "animate-spin" : ""}`}
+                  className={`w-4 h-4 ${syncProfilesMutation.isPending ? "animate-spin" : ""}`}
                 />
               }>
               {t("profiles.sync")}

--- a/apps/desktop/src/components/profiles/profile-preview.tsx
+++ b/apps/desktop/src/components/profiles/profile-preview.tsx
@@ -4,7 +4,7 @@ import { DialogFooter } from "@deadlock-mods/ui/components/dialog";
 import { Progress } from "@deadlock-mods/ui/components/progress";
 import { Download, Package, UserPlus } from "@deadlock-mods/ui/icons";
 import { useTranslation } from "react-i18next";
-import type { ImportProgress } from "@/hooks/use-profile-import";
+import type { ImportProgress } from "@/lib/profiles/types";
 import { ProfileModsList } from "./profile-mods-list";
 
 interface ProfilePreviewProps {

--- a/apps/desktop/src/components/profiles/profile-share-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-share-dialog.tsx
@@ -36,58 +36,71 @@ export const ProfileShareDialog = () => {
   const { version } = useAbout();
   const { t } = useTranslation();
   const { analytics } = useAnalyticsContext();
-  const { getActiveProfile, localMods } = usePersistedStore();
+  const { getActiveProfile, getOrderedMods, localMods } = usePersistedStore();
   const [profileId, setProfileId] = useState<string | null>(null);
 
   const activeProfile = getActiveProfile();
-  const enabledMods = Object.values(activeProfile?.enabledMods ?? {})
-    .filter((mod) => mod.enabled)
-    .map((mod) => {
-      // Find the local mod to get installation details
-      const localMod = localMods.find((m) => m.remoteId === mod.remoteId);
+  const enabledModIds = new Set(
+    Object.values(activeProfile?.enabledMods ?? {})
+      .filter((mod) => mod.enabled)
+      .map((mod) => mod.remoteId),
+  );
+  const localModsByRemoteId = new Map(
+    localMods.map((mod) => [mod.remoteId, mod]),
+  );
 
-      const baseModData: {
-        remoteId: string;
-        fileTree?: ModFileTree;
-        selectedDownloads?: ProfileModDownload[];
-      } = {
-        remoteId: mod.remoteId,
-      };
+  const toSharedProfileMod = (remoteId: string) => {
+    const localMod = localModsByRemoteId.get(remoteId);
+    const baseModData: {
+      remoteId: string;
+      fileTree?: ModFileTree;
+      selectedDownloads?: ProfileModDownload[];
+    } = {
+      remoteId,
+    };
 
-      // Add file tree information if available (for any mod that has file tree data)
-      if (localMod?.installedFileTree) {
-        // Ensure at least one file is selected in the file tree
-        // (fix for older mods that may not have proper selection info)
-        const hasAnySelected = localMod.installedFileTree.files.some(
-          (f) => f.is_selected,
-        );
+    if (localMod?.installedFileTree) {
+      const hasAnySelected = localMod.installedFileTree.files.some(
+        (file) => file.is_selected,
+      );
 
-        baseModData.fileTree = hasAnySelected
-          ? localMod.installedFileTree
-          : {
-              ...localMod.installedFileTree,
-              files: localMod.installedFileTree.files.map((f) => ({
-                ...f,
-                is_selected: true, // Select all if none selected
-              })),
-            };
-      }
+      baseModData.fileTree = hasAnySelected
+        ? localMod.installedFileTree
+        : {
+            ...localMod.installedFileTree,
+            files: localMod.installedFileTree.files.map((file) => ({
+              ...file,
+              is_selected: true,
+            })),
+          };
+    }
 
-      // Add selected download information if available
-      if (localMod?.downloads && localMod.downloads.length > 0) {
-        const selected = localMod.selectedDownloads?.length
-          ? localMod.selectedDownloads
-          : [localMod.downloads[0]];
-        baseModData.selectedDownloads = selected.map((d) => ({
-          remoteId: mod.remoteId,
-          file: d.name,
-          url: d.url,
-          size: d.size,
-        }));
-      }
+    if (localMod?.downloads && localMod.downloads.length > 0) {
+      const selectedDownloads = localMod.selectedDownloads?.length
+        ? localMod.selectedDownloads
+        : [localMod.downloads[0]];
+      baseModData.selectedDownloads = selectedDownloads.map((download) => ({
+        remoteId,
+        file: download.name,
+        url: download.url,
+        size: download.size,
+      }));
+    }
 
-      return baseModData;
-    });
+    return baseModData;
+  };
+
+  const orderedEnabledMods = getOrderedMods()
+    .filter((mod) => enabledModIds.has(mod.remoteId))
+    .map((mod) => toSharedProfileMod(mod.remoteId));
+  const orderedEnabledModIds = new Set(
+    orderedEnabledMods.map((mod) => mod.remoteId),
+  );
+  const missingEnabledMods = [...enabledModIds]
+    .filter((remoteId) => !orderedEnabledModIds.has(remoteId))
+    .map((remoteId) => toSharedProfileMod(remoteId));
+  const sharedMods = [...orderedEnabledMods, ...missingEnabledMods];
+  const sharedLoadOrder = sharedMods.map((mod) => mod.remoteId);
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (params: {
@@ -118,27 +131,17 @@ export const ProfileShareDialog = () => {
       setProfileId(data?.id ?? null);
 
       if (data?.id) {
-        analytics.trackProfileShared(data.id, enabledMods.length, "link");
+        analytics.trackProfileShared(data.id, sharedMods.length, "link");
       }
     },
   });
 
   const onSubmit = () => {
-    logger
-      .withMetadata({
-        enabledModsCount: enabledMods.length,
-        enabledMods: enabledMods.map((mod) => ({
-          remoteId: mod.remoteId,
-          hasFileTree: !!mod.fileTree,
-          hasSelectedDownloads: !!mod.selectedDownloads?.length,
-        })),
-      })
-      .info("Creating profile with enhanced mod data");
-
     const validatedProfile = profileSchema.safeParse({
-      version: "1",
+      version: "2",
       payload: {
-        mods: enabledMods,
+        mods: sharedMods,
+        loadOrder: sharedLoadOrder,
       },
     });
 
@@ -146,22 +149,14 @@ export const ProfileShareDialog = () => {
       logger
         .withMetadata({
           profile: validatedProfile.error,
-          enabledMods,
+          enabledMods: sharedMods,
         })
         .error("Invalid profile");
       toast.error(t("profiles.shareError"));
       return;
     }
 
-    logger
-      .withMetadata({
-        validatedProfile: validatedProfile.data,
-        originalEnabledMods: enabledMods,
-        validatedMods: validatedProfile.data.payload.mods,
-      })
-      .info("Profile validation successful");
-
-    if (!validatedProfile || !hardwareId || !version) {
+    if (!hardwareId || !version) {
       logger.error("Hardware ID or version is missing");
       toast.error(t("profiles.noHardwareIdOrVersion"));
       return;
@@ -181,8 +176,9 @@ export const ProfileShareDialog = () => {
 
     logger
       .withMetadata({
-        payload: JSON.stringify(payload, null, 2),
-        profileMods: validatedProfile.data.payload.mods,
+        profileName: payload.name,
+        profileVersion: validatedProfile.data.version,
+        modsCount: validatedProfile.data.payload.mods.length,
       })
       .info("Sharing profile");
 

--- a/apps/desktop/src/hooks/use-profile-import.ts
+++ b/apps/desktop/src/hooks/use-profile-import.ts
@@ -1,63 +1,57 @@
-import type { ModDto, ProfileModDownload } from "@deadlock-mods/shared";
-import { toast } from "@deadlock-mods/ui/components/sonner";
-import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getModDownloads } from "@/lib/api";
-import logger from "@/lib/logger";
+import { createProfileImportFlow } from "@/lib/profiles/import-profile";
+import type { ImportProgress } from "@/lib/profiles/types";
 import { usePersistedStore } from "@/lib/store";
-import type {
-  LocalMod,
-  ModFileTree,
-  ProfileImportMod,
-  ProfileImportProgressEvent,
-  ProfileImportResult,
-} from "@/types/mods";
-import { ModStatus } from "@/types/mods";
-import type { ModProfile, ProfileId } from "@/types/profiles";
-import { createProfileId } from "@/types/profiles";
+import type { ProfileImportProgressEvent } from "@/types/mods";
 
-export interface ImportProgress {
-  currentStep: string;
-  currentMod?: string;
-  completedMods: number;
-  totalMods: number;
-  isDownloading: boolean;
-  isInstalling: boolean;
-}
-
-interface ImportedMod {
-  remoteId: string;
-  fileTree?: ModFileTree;
-  selectedDownload?: ProfileModDownload;
-  selectedDownloads?: ProfileModDownload[];
-}
-
-const resolveSelectedFileNames = (
-  selectedDownloads?: ProfileModDownload[],
-  selectedDownload?: ProfileModDownload,
-): string[] | null =>
-  selectedDownloads?.length
-    ? selectedDownloads.map((d) => d.file)
-    : selectedDownload
-      ? [selectedDownload.file]
-      : null;
-
-export const useProfileImport = () => {
+export const useProfileImport = (options?: { listenToProgress?: boolean }) => {
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(
     null,
   );
   const { t } = useTranslation();
-  const {
-    getActiveProfile,
-    setModEnabledInProfile,
-    setModEnabledInCurrentProfile,
-  } = usePersistedStore();
-  const { addLocalMod, setInstalledVpks } = usePersistedStore();
+  const listenToProgress = options?.listenToProgress ?? true;
 
-  // Listen to profile import progress events
+  const upsertProfile = usePersistedStore((s) => s.upsertProfile);
+  const createImportProfileFolder = usePersistedStore(
+    (s) => s.createImportProfileFolder,
+  );
+  const applyImportInstalledModsToProfile = usePersistedStore(
+    (s) => s.applyImportInstalledModsToProfile,
+  );
+  const setProfileFolderName = usePersistedStore((s) => s.setProfileFolderName);
+  const getProfile = usePersistedStore((s) => s.getProfile);
+  const getActiveProfile = usePersistedStore((s) => s.getActiveProfile);
+
+  const { createProfileFromImport, addToCurrentProfile } = useMemo(
+    () =>
+      createProfileImportFlow({
+        setImportProgress,
+        t,
+        upsertProfile,
+        createImportProfileFolder,
+        applyImportInstalledModsToProfile,
+        setProfileFolderName,
+        getProfile,
+        getActiveProfile,
+      }),
+    [
+      t,
+      upsertProfile,
+      createImportProfileFolder,
+      applyImportInstalledModsToProfile,
+      setProfileFolderName,
+      getProfile,
+      getActiveProfile,
+    ],
+  );
+
   useEffect(() => {
+    if (!listenToProgress) {
+      return;
+    }
+
     const unlistenPromise = listen<ProfileImportProgressEvent>(
       "profile-import-progress",
       (event) => {
@@ -76,356 +70,7 @@ export const useProfileImport = () => {
     return () => {
       unlistenPromise.then((unlisten) => unlisten());
     };
-  }, []);
-
-  const createProfileFromImport = async (
-    importedMods: ImportedMod[],
-    modsData: ModDto[],
-  ): Promise<void> => {
-    logger
-      .withMetadata({
-        importedModsCount: importedMods.length,
-        modsDataCount: modsData.length,
-      })
-      .info("Starting profile import");
-
-    // Initialize progress tracking
-    setImportProgress({
-      currentStep: t("profiles.creatingProfile"),
-      completedMods: 0,
-      totalMods: importedMods.length,
-      isDownloading: false,
-      isInstalling: false,
-    });
-
-    // Create new profile in store without creating folder (batch import will create it)
-    const profileId = `profile_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-    const newProfileId = createProfileId(profileId) as ProfileId;
-
-    const newProfile: ModProfile = {
-      id: newProfileId,
-      name: `Imported Profile - ${new Date().toLocaleDateString()}`,
-      description: "Profile imported from shared profile ID",
-      createdAt: new Date(),
-      lastUsed: new Date(),
-      enabledMods: {},
-      isDefault: false,
-      folderName: null, // Will be set after batch import creates the folder
-      mods: [],
-    };
-
-    usePersistedStore.setState((state) => ({
-      profiles: {
-        ...state.profiles,
-        [newProfileId]: newProfile,
-      },
-    }));
-
-    // Prepare mods for batch import
-    const profileImportMods: ProfileImportMod[] = await Promise.all(
-      importedMods.map(async (importedMod) => {
-        const modData = modsData.find(
-          (m) => m.remoteId === importedMod.remoteId,
-        );
-
-        if (!modData) {
-          throw new Error(`Mod ${importedMod.remoteId} not available`);
-        }
-
-        const downloadsResponse = await getModDownloads(modData.remoteId);
-        const downloadFiles = downloadsResponse.downloads || [];
-
-        const selectedFileNames = resolveSelectedFileNames(
-          importedMod.selectedDownloads,
-          importedMod.selectedDownload,
-        );
-        const selectedFiles =
-          selectedFileNames && downloadFiles.length > 0
-            ? downloadFiles.filter((d) => selectedFileNames.includes(d.name))
-            : downloadFiles;
-
-        return {
-          modId: modData.remoteId,
-          modName: modData.name,
-          downloadFiles: selectedFiles.map((d) => ({
-            url: d.url,
-            name: d.name,
-            size: d.size || 0,
-          })),
-          fileTree: importedMod.fileTree
-            ? {
-                ...importedMod.fileTree,
-                files: importedMod.fileTree.files.some((f) => f.is_selected)
-                  ? importedMod.fileTree.files
-                  : importedMod.fileTree.files.map((f) => ({
-                      ...f,
-                      is_selected: true,
-                    })),
-              }
-            : undefined,
-          isMap: modData.isMap,
-        };
-      }),
-    );
-
-    try {
-      // Call Rust batch import command - it will create the profile folder
-      const result = (await invoke("import_profile_batch", {
-        profileName: `Imported Profile - ${new Date().toLocaleDateString()}`,
-        profileDescription: "Profile imported from shared profile ID",
-        profileFolder: "", // Empty - batch import will create it
-        mods: profileImportMods,
-        importType: "create", // Batch import will create the folder
-      })) as ProfileImportResult;
-
-      // Update profile folder name with the one created by batch import
-      const currentProfile = usePersistedStore
-        .getState()
-        .getProfile(newProfileId);
-      if (currentProfile && result.profileFolder) {
-        const profiles = usePersistedStore.getState().profiles;
-        profiles[newProfileId] = {
-          ...currentProfile,
-          folderName: result.profileFolder,
-        };
-        usePersistedStore.setState({ profiles });
-      }
-
-      // Enable mods in the profile and add them to state
-      const store = usePersistedStore.getState();
-      const newMods: LocalMod[] = [];
-
-      for (const installedModInfo of result.installedMods) {
-        // Find the mod data from the original modsData
-        const modData = modsData.find(
-          (m) => m.remoteId === installedModInfo.modId,
-        );
-
-        if (modData) {
-          // Check if mod already exists in localMods
-          const existingMod = store.localMods.find(
-            (m) => m.remoteId === installedModInfo.modId,
-          );
-
-          const localMod: LocalMod = existingMod
-            ? {
-                ...existingMod,
-                installedVpks: installedModInfo.installedVpks,
-                installedFileTree: installedModInfo.fileTree,
-                status: ModStatus.Installed,
-              }
-            : {
-                ...modData,
-                status: ModStatus.Installed,
-                installedVpks: installedModInfo.installedVpks,
-                installedFileTree: installedModInfo.fileTree,
-                downloadedAt: new Date(),
-              };
-
-          if (!existingMod) {
-            // Add mod to localMods
-            addLocalMod(modData, {
-              status: ModStatus.Installed,
-              installedVpks: installedModInfo.installedVpks,
-              installedFileTree: installedModInfo.fileTree,
-              downloadedAt: new Date(),
-            });
-          } else {
-            // Update existing mod with installed VPKs
-            setInstalledVpks(
-              installedModInfo.modId,
-              installedModInfo.installedVpks,
-              installedModInfo.fileTree,
-            );
-          }
-
-          newMods.push(localMod);
-        }
-
-        // Enable mod in the profile
-        setModEnabledInProfile(newProfileId, installedModInfo.modId, true);
-      }
-
-      // Add mods to the new profile's mods array
-      if (newMods.length > 0) {
-        const profile = usePersistedStore.getState().getProfile(newProfileId);
-        if (profile) {
-          const profiles = usePersistedStore.getState().profiles;
-          profiles[newProfileId] = {
-            ...profile,
-            mods: [...profile.mods, ...newMods],
-          };
-          usePersistedStore.setState({ profiles });
-        }
-      }
-
-      // Clear progress
-      setImportProgress(null);
-
-      // Show results
-      if (result.failed.length > 0) {
-        logger
-          .withMetadata({
-            failed: result.failed.length,
-            succeeded: result.succeeded.length,
-          })
-          .warn("Some mods failed to import");
-        toast.warning(
-          t("profiles.createSuccess", { profileName: "Imported Profile" }) +
-            ` (${result.succeeded.length}/${importedMods.length} mods imported)`,
-        );
-      } else {
-        toast.success(
-          t("profiles.createSuccess", { profileName: "Imported Profile" }),
-        );
-      }
-    } catch (error) {
-      logger.withError(error).error("Profile import failed");
-      setImportProgress(null);
-      toast.error(t("profiles.createError"));
-      throw error;
-    }
-  };
-
-  const addToCurrentProfile = async (
-    importedMods: ImportedMod[],
-    modsData: ModDto[],
-  ): Promise<void> => {
-    const activeProfile = getActiveProfile();
-    if (!activeProfile) {
-      throw new Error("No active profile found");
-    }
-
-    // Initialize progress tracking
-    setImportProgress({
-      currentStep: t("profiles.updatingProfile"),
-      completedMods: 0,
-      totalMods: importedMods.length,
-      isDownloading: false,
-      isInstalling: false,
-    });
-
-    logger
-      .withMetadata({ profileId: activeProfile.id })
-      .info("Overriding current profile with imported mods");
-
-    // Prepare mods for batch import
-    const profileImportMods: ProfileImportMod[] = await Promise.all(
-      importedMods.map(async (importedMod) => {
-        const modData = modsData.find(
-          (m) => m.remoteId === importedMod.remoteId,
-        );
-
-        if (!modData) {
-          throw new Error(`Mod ${importedMod.remoteId} not available`);
-        }
-
-        const downloadsResponse = await getModDownloads(modData.remoteId);
-        const downloadFiles = downloadsResponse.downloads || [];
-
-        const selectedFileNames = resolveSelectedFileNames(
-          importedMod.selectedDownloads,
-          importedMod.selectedDownload,
-        );
-        const selectedFiles =
-          selectedFileNames && downloadFiles.length > 0
-            ? downloadFiles.filter((d) => selectedFileNames.includes(d.name))
-            : downloadFiles;
-
-        return {
-          modId: modData.remoteId,
-          modName: modData.name,
-          downloadFiles: selectedFiles.map((d) => ({
-            url: d.url,
-            name: d.name,
-            size: d.size || 0,
-          })),
-          fileTree: importedMod.fileTree
-            ? {
-                ...importedMod.fileTree,
-                files: importedMod.fileTree.files.some((f) => f.is_selected)
-                  ? importedMod.fileTree.files
-                  : importedMod.fileTree.files.map((f) => ({
-                      ...f,
-                      is_selected: true,
-                    })),
-              }
-            : undefined,
-          isMap: modData.isMap,
-        };
-      }),
-    );
-
-    try {
-      // Call Rust batch import command
-      const result = (await invoke("import_profile_batch", {
-        profileName: activeProfile.name,
-        profileDescription: activeProfile.description || "",
-        profileFolder: activeProfile.folderName || "",
-        mods: profileImportMods,
-        importType: "override",
-      })) as ProfileImportResult;
-
-      // Enable mods in the current profile and add them to state
-      for (const installedModInfo of result.installedMods) {
-        // Find the mod data from the original modsData
-        const modData = modsData.find(
-          (m) => m.remoteId === installedModInfo.modId,
-        );
-
-        if (modData) {
-          // Check if mod already exists in localMods
-          const existingMod = usePersistedStore
-            .getState()
-            .localMods.find((m) => m.remoteId === installedModInfo.modId);
-
-          if (!existingMod) {
-            // Add mod to localMods with installed status
-            addLocalMod(modData, {
-              status: ModStatus.Installed,
-              installedVpks: installedModInfo.installedVpks,
-              installedFileTree: installedModInfo.fileTree,
-              downloadedAt: new Date(),
-            });
-          } else {
-            // Update existing mod with installed VPKs
-            setInstalledVpks(
-              installedModInfo.modId,
-              installedModInfo.installedVpks,
-              installedModInfo.fileTree,
-            );
-          }
-        }
-
-        // Enable mod in the current profile
-        setModEnabledInCurrentProfile(installedModInfo.modId, true);
-      }
-
-      // Clear progress
-      setImportProgress(null);
-
-      // Show results
-      if (result.failed.length > 0) {
-        logger
-          .withMetadata({
-            failed: result.failed.length,
-            succeeded: result.succeeded.length,
-          })
-          .warn("Some mods failed to import to current profile");
-        toast.warning(
-          t("profiles.overrideSuccess") +
-            ` (${result.succeeded.length}/${importedMods.length} mods imported)`,
-        );
-      } else {
-        toast.success(t("profiles.overrideSuccess"));
-      }
-    } catch (error) {
-      logger.withError(error).error("Profile import failed");
-      setImportProgress(null);
-      toast.error(t("profiles.updateError"));
-      throw error;
-    }
-  };
+  }, [listenToProgress]);
 
   return {
     createProfileFromImport,

--- a/apps/desktop/src/lib/profiles/import-downloads.ts
+++ b/apps/desktop/src/lib/profiles/import-downloads.ts
@@ -1,0 +1,113 @@
+import type { ProfileModDownload } from "@deadlock-mods/shared";
+import type {
+  AvailableImportDownload,
+  ProfileImportDownloadFile,
+  ResolveProfileImportDownloadFilesArgs,
+  ResolvedProfileImportDownloadFiles,
+} from "@/lib/profiles/types";
+
+const isHttpOrHttpsUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
+const normalizeSelectedDownloads = (
+  selectedDownloads?: ProfileModDownload[],
+  selectedDownload?: ProfileModDownload,
+): ProfileModDownload[] => {
+  if (selectedDownloads?.length) {
+    return selectedDownloads;
+  }
+
+  return selectedDownload ? [selectedDownload] : [];
+};
+
+const toImportDownloadFile = (
+  download: AvailableImportDownload | ProfileModDownload,
+): ProfileImportDownloadFile => ({
+  url: download.url,
+  name: "file" in download ? download.file : download.name,
+  size: download.size ?? 0,
+});
+
+export const resolveProfileImportDownloadFiles = ({
+  availableDownloads,
+  selectedDownloads,
+  selectedDownload,
+}: ResolveProfileImportDownloadFilesArgs): ResolvedProfileImportDownloadFiles => {
+  const persistedSelections = normalizeSelectedDownloads(
+    selectedDownloads,
+    selectedDownload,
+  );
+
+  if (persistedSelections.length === 0) {
+    return {
+      downloadFiles: availableDownloads
+        .map(toImportDownloadFile)
+        .filter((file) => file.url.length > 0),
+      missingSelectionNames: [],
+      resolvedWithLiveFallbackNames: [],
+      resolvedWithPersistedFallbackNames: [],
+    };
+  }
+
+  const availableDownloadsByName = new Map(
+    availableDownloads.map((download) => [download.name, download]),
+  );
+  const missingSelectionNames: string[] = [];
+  const resolvedWithLiveFallbackNames: string[] = [];
+  const resolvedWithPersistedFallbackNames: string[] = [];
+  const exactlyMatchedSelectionNames = new Set(
+    persistedSelections
+      .filter((selection) => availableDownloadsByName.has(selection.file))
+      .map((selection) => selection.file),
+  );
+  const remainingAvailableDownloads = availableDownloads.filter(
+    (download) => !exactlyMatchedSelectionNames.has(download.name),
+  );
+  const unmatchedSelections = persistedSelections.filter(
+    (selection) => !availableDownloadsByName.has(selection.file),
+  );
+
+  const canResolveFromLiveDownloads =
+    unmatchedSelections.length > 0 &&
+    remainingAvailableDownloads.length === unmatchedSelections.length &&
+    (unmatchedSelections.length === 1 ||
+      persistedSelections.length === availableDownloads.length);
+  const liveFallbackQueue = canResolveFromLiveDownloads
+    ? [...remainingAvailableDownloads]
+    : [];
+
+  const downloadFiles = persistedSelections.flatMap((selection) => {
+    const matchedDownload = availableDownloadsByName.get(selection.file);
+
+    if (matchedDownload) {
+      return [toImportDownloadFile(matchedDownload)];
+    }
+
+    missingSelectionNames.push(selection.file);
+
+    const fallbackLiveDownload = liveFallbackQueue.shift();
+    if (fallbackLiveDownload) {
+      resolvedWithLiveFallbackNames.push(selection.file);
+      return [toImportDownloadFile(fallbackLiveDownload)];
+    }
+
+    resolvedWithPersistedFallbackNames.push(selection.file);
+    if (!isHttpOrHttpsUrl(selection.url)) {
+      return [];
+    }
+    return [toImportDownloadFile(selection)];
+  });
+
+  return {
+    downloadFiles,
+    missingSelectionNames,
+    resolvedWithLiveFallbackNames,
+    resolvedWithPersistedFallbackNames,
+  };
+};

--- a/apps/desktop/src/lib/profiles/import-profile-prep.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-prep.ts
@@ -1,0 +1,143 @@
+import { getMod, getModDownloads } from "@/lib/api";
+import logger from "@/lib/logger";
+import { resolveProfileImportDownloadFiles } from "@/lib/profiles/import-downloads";
+import type {
+  AvailableImportedMod,
+  FetchModsDataEntry,
+  FetchModsDataResult,
+  PrepareProfileImportEntry,
+  PreparedProfileImport,
+  PreparedProfileImportMod,
+} from "@/lib/profiles/types";
+
+export const fetchModsData = async (
+  remoteIds: string[],
+): Promise<FetchModsDataResult> => {
+  const results: FetchModsDataEntry[] = await Promise.all(
+    Array.from(new Set(remoteIds)).map(async (remoteId) => {
+      try {
+        return {
+          remoteId,
+          modData: await getMod(remoteId),
+        };
+      } catch (error) {
+        return {
+          remoteId,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+
+  return results.reduce<FetchModsDataResult>(
+    (accumulator, result) => {
+      if ("modData" in result) {
+        accumulator.modsData.push(result.modData);
+      } else {
+        accumulator.failed.push([result.remoteId, result.error]);
+      }
+
+      return accumulator;
+    },
+    { modsData: [], failed: [] },
+  );
+};
+
+export const prepareProfileImportMods = async (
+  availableImportedMods: AvailableImportedMod[],
+): Promise<PreparedProfileImport> => {
+  const results: PrepareProfileImportEntry[] = await Promise.all(
+    availableImportedMods.map(async ({ importedMod, modData }) => {
+      try {
+        const downloadsResponse = await getModDownloads(modData.remoteId);
+        const downloadFiles = downloadsResponse.downloads || [];
+
+        const resolvedDownloadFiles = resolveProfileImportDownloadFiles({
+          availableDownloads: downloadFiles,
+          selectedDownloads: importedMod.selectedDownloads,
+          selectedDownload: importedMod.selectedDownload,
+        });
+
+        if (resolvedDownloadFiles.downloadFiles.length === 0) {
+          throw new Error("No download files available for import");
+        }
+
+        if (resolvedDownloadFiles.resolvedWithLiveFallbackNames.length > 0) {
+          logger
+            .withMetadata({
+              modId: modData.remoteId,
+              modName: modData.name,
+              renamedSelectionNames:
+                resolvedDownloadFiles.resolvedWithLiveFallbackNames,
+              availableDownloadCount: downloadFiles.length,
+            })
+            .warn(
+              "Using current live download entries for renamed imported selections",
+            );
+        }
+
+        if (
+          resolvedDownloadFiles.resolvedWithPersistedFallbackNames.length > 0
+        ) {
+          logger
+            .withMetadata({
+              modId: modData.remoteId,
+              modName: modData.name,
+              missingSelectionNames:
+                resolvedDownloadFiles.resolvedWithPersistedFallbackNames,
+              availableDownloadCount: downloadFiles.length,
+            })
+            .warn("Falling back to persisted imported download selection");
+        }
+
+        return {
+          importedMod,
+          modData,
+          profileImportMod: {
+            modId: modData.remoteId,
+            modName: modData.name,
+            downloadFiles: resolvedDownloadFiles.downloadFiles.map(
+              (download) => ({
+                url: download.url,
+                name: download.name,
+                size: download.size,
+              }),
+            ),
+            fileTree: importedMod.fileTree
+              ? {
+                  ...importedMod.fileTree,
+                  files: importedMod.fileTree.files.some(
+                    (file) => file.is_selected,
+                  )
+                    ? importedMod.fileTree.files
+                    : importedMod.fileTree.files.map((file) => ({
+                        ...file,
+                        is_selected: true,
+                      })),
+                }
+              : undefined,
+            isMap: modData.isMap,
+          },
+        } satisfies PreparedProfileImportMod;
+      } catch (error) {
+        return {
+          importedMod,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+
+  return results.reduce<PreparedProfileImport>(
+    (accumulator, result) => {
+      if ("profileImportMod" in result) {
+        accumulator.preparedMods.push(result);
+      } else {
+        accumulator.failed.push([result.importedMod.remoteId, result.error]);
+      }
+
+      return accumulator;
+    },
+    { preparedMods: [], failed: [] },
+  );
+};

--- a/apps/desktop/src/lib/profiles/import-profile-shared.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-shared.ts
@@ -1,4 +1,8 @@
-import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import {
+  getOrderedSharedProfileMods,
+  type ModDto,
+  type SharedProfile,
+} from "@deadlock-mods/shared";
 import type { AvailableImportedMod } from "@/lib/profiles/types";
 import type { LocalMod } from "@/types/mods";
 
@@ -13,7 +17,10 @@ export const resolveImportContext = (
   importedProfile: SharedProfile,
   modsData: ModDto[],
 ) => {
-  const importedMods = importedProfile.payload.mods;
+  const importedMods = getOrderedSharedProfileMods(importedProfile);
+  const installOrderByRemoteId = new Map(
+    importedMods.map((mod, index) => [mod.remoteId, index]),
+  );
   const modsDataByRemoteId = new Map(
     modsData.map((mod) => [mod.remoteId, mod]),
   );
@@ -27,6 +34,7 @@ export const resolveImportContext = (
   return {
     importedMods,
     availableImportedMods,
+    installOrderByRemoteId,
     modsDataByRemoteId,
     unavailableModsCount: importedMods.length - availableImportedMods.length,
   };

--- a/apps/desktop/src/lib/profiles/import-profile-shared.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-shared.ts
@@ -1,0 +1,33 @@
+import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import type { AvailableImportedMod } from "@/lib/profiles/types";
+import type { LocalMod } from "@/types/mods";
+
+export const sortModsByInstallOrder = (mods: LocalMod[]): LocalMod[] =>
+  [...mods].sort(
+    (left, right) =>
+      (left.installOrder ?? Number.MAX_SAFE_INTEGER) -
+      (right.installOrder ?? Number.MAX_SAFE_INTEGER),
+  );
+
+export const resolveImportContext = (
+  importedProfile: SharedProfile,
+  modsData: ModDto[],
+) => {
+  const importedMods = importedProfile.payload.mods;
+  const modsDataByRemoteId = new Map(
+    modsData.map((mod) => [mod.remoteId, mod]),
+  );
+  const availableImportedMods = importedMods
+    .map((importedMod) => {
+      const modData = modsDataByRemoteId.get(importedMod.remoteId);
+      return modData ? { importedMod, modData } : null;
+    })
+    .filter((entry): entry is AvailableImportedMod => entry !== null);
+
+  return {
+    importedMods,
+    availableImportedMods,
+    modsDataByRemoteId,
+    unavailableModsCount: importedMods.length - availableImportedMods.length,
+  };
+};

--- a/apps/desktop/src/lib/profiles/import-profile.ts
+++ b/apps/desktop/src/lib/profiles/import-profile.ts
@@ -44,6 +44,7 @@ export const createProfileImportFlow = (deps: ProfileImportFlowDeps) => {
     const {
       importedMods,
       availableImportedMods,
+      installOrderByRemoteId,
       modsDataByRemoteId,
       unavailableModsCount,
     } = resolveImportContext(importedProfile, modsData);
@@ -126,6 +127,7 @@ export const createProfileImportFlow = (deps: ProfileImportFlowDeps) => {
           newProfileId,
           result.installedMods,
           modsDataByRemoteId,
+          installOrderByRemoteId,
         );
       }
 
@@ -180,6 +182,7 @@ export const createProfileImportFlow = (deps: ProfileImportFlowDeps) => {
     const {
       importedMods,
       availableImportedMods,
+      installOrderByRemoteId,
       modsDataByRemoteId,
       unavailableModsCount,
     } = resolveImportContext(importedProfile, modsData);
@@ -230,6 +233,7 @@ export const createProfileImportFlow = (deps: ProfileImportFlowDeps) => {
           activeProfile.id,
           result.installedMods,
           modsDataByRemoteId,
+          installOrderByRemoteId,
         );
       }
 

--- a/apps/desktop/src/lib/profiles/import-profile.ts
+++ b/apps/desktop/src/lib/profiles/import-profile.ts
@@ -1,0 +1,271 @@
+import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { invoke } from "@tauri-apps/api/core";
+import type { TFunction } from "i18next";
+import logger from "@/lib/logger";
+import { prepareProfileImportMods } from "@/lib/profiles/import-profile-prep";
+import { resolveImportContext } from "@/lib/profiles/import-profile-shared";
+import type {
+  ImportProgress,
+  ProfileImportOptions,
+} from "@/lib/profiles/types";
+import type { State } from "@/lib/store";
+import type { ProfileImportResult } from "@/types/mods";
+import type { ModProfile, ProfileId } from "@/types/profiles";
+import { createProfileId } from "@/types/profiles";
+
+export interface ProfileImportFlowDeps {
+  setImportProgress: (progress: ImportProgress | null) => void;
+  t: TFunction;
+  upsertProfile: State["upsertProfile"];
+  createImportProfileFolder: State["createImportProfileFolder"];
+  applyImportInstalledModsToProfile: State["applyImportInstalledModsToProfile"];
+  setProfileFolderName: State["setProfileFolderName"];
+  getProfile: State["getProfile"];
+  getActiveProfile: State["getActiveProfile"];
+}
+
+export const createProfileImportFlow = (deps: ProfileImportFlowDeps) => {
+  const {
+    setImportProgress,
+    t,
+    upsertProfile,
+    createImportProfileFolder,
+    applyImportInstalledModsToProfile,
+    setProfileFolderName,
+    getActiveProfile,
+  } = deps;
+
+  const createProfileFromImport = async (
+    importedProfile: SharedProfile,
+    modsData: ModDto[],
+    _options?: ProfileImportOptions,
+  ): Promise<void> => {
+    const {
+      importedMods,
+      availableImportedMods,
+      modsDataByRemoteId,
+      unavailableModsCount,
+    } = resolveImportContext(importedProfile, modsData);
+
+    const totalImportedMods = importedMods.length;
+    if (totalImportedMods === 0) {
+      throw new Error("No mods available in imported profile");
+    }
+
+    logger
+      .withMetadata({
+        importedModsCount: totalImportedMods,
+        availableModsCount: availableImportedMods.length,
+        unavailableModsCount,
+      })
+      .info("Starting profile import");
+
+    let newProfileId: ProfileId | null = null;
+
+    try {
+      setImportProgress({
+        currentStep: t("profiles.creatingProfile"),
+        completedMods: 0,
+        totalMods: totalImportedMods,
+        isDownloading: false,
+        isInstalling: false,
+      });
+
+      const profileId = `profile_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+      const createdProfileId = createProfileId(profileId);
+      newProfileId = createdProfileId;
+      const profileName = t("profiles.importedProfileName", {
+        date: new Date().toLocaleDateString(),
+      });
+      const folderName = await createImportProfileFolder(
+        createdProfileId,
+        profileName,
+      );
+
+      const newProfile: ModProfile = {
+        id: createdProfileId,
+        name: profileName,
+        description: t("profiles.importedProfileDescription"),
+        createdAt: new Date(),
+        lastUsed: new Date(),
+        enabledMods: {},
+        isDefault: false,
+        folderName,
+        mods: [],
+      };
+
+      upsertProfile(newProfile);
+
+      const { preparedMods, failed: preparationFailed } =
+        await prepareProfileImportMods(availableImportedMods);
+
+      let result: ProfileImportResult = {
+        profileFolder: folderName,
+        succeeded: [],
+        failed: [],
+        installedMods: [],
+      };
+
+      if (preparedMods.length > 0) {
+        result = await invoke<ProfileImportResult>("import_profile_batch", {
+          profileName,
+          profileDescription: t("profiles.importedProfileDescription"),
+          profileFolder: folderName,
+          mods: preparedMods.map((entry) => entry.profileImportMod),
+          importType: "override",
+        });
+
+        if (result.profileFolder && result.profileFolder !== folderName) {
+          setProfileFolderName(newProfileId, result.profileFolder);
+        }
+      }
+
+      if (result.installedMods.length > 0) {
+        applyImportInstalledModsToProfile(
+          newProfileId,
+          result.installedMods,
+          modsDataByRemoteId,
+        );
+      }
+
+      const missingCount =
+        totalImportedMods -
+        result.installedMods.length -
+        (totalImportedMods - preparedMods.length - unavailableModsCount);
+
+      setImportProgress(null);
+
+      if (
+        result.failed.length > 0 ||
+        preparationFailed.length > 0 ||
+        unavailableModsCount > 0
+      ) {
+        logger
+          .withMetadata({
+            failed: result.failed.length,
+            succeeded: result.succeeded.length,
+            unavailable: unavailableModsCount,
+            preparationFailed: preparationFailed.length,
+          })
+          .warn("Some mods failed to import");
+        const imported = result.installedMods.length;
+        toast.warning(
+          t("profiles.createSuccess", { profileName }) +
+            ` (${t("profiles.modsImportedCount", { imported, total: totalImportedMods })})`,
+        );
+      } else {
+        toast.success(t("profiles.createSuccess", { profileName }));
+      }
+
+      void missingCount;
+    } catch (error) {
+      logger.withError(error).error("Profile import failed");
+      setImportProgress(null);
+      toast.error(t("profiles.createError"));
+      throw error;
+    }
+  };
+
+  const addToCurrentProfile = async (
+    importedProfile: SharedProfile,
+    modsData: ModDto[],
+    _options?: ProfileImportOptions,
+  ): Promise<void> => {
+    const activeProfile = getActiveProfile();
+    if (!activeProfile) {
+      throw new Error("No active profile found");
+    }
+
+    const {
+      importedMods,
+      availableImportedMods,
+      modsDataByRemoteId,
+      unavailableModsCount,
+    } = resolveImportContext(importedProfile, modsData);
+
+    const totalImportedMods = importedMods.length;
+    if (totalImportedMods === 0) {
+      throw new Error("No mods available in imported profile");
+    }
+
+    logger
+      .withMetadata({
+        profileId: activeProfile.id,
+        importedModsCount: totalImportedMods,
+        availableModsCount: availableImportedMods.length,
+        unavailableModsCount,
+      })
+      .info("Overriding current profile with imported mods");
+
+    try {
+      setImportProgress({
+        currentStep: t("profiles.updatingProfile"),
+        completedMods: 0,
+        totalMods: totalImportedMods,
+        isDownloading: false,
+        isInstalling: false,
+      });
+
+      const { preparedMods, failed: preparationFailed } =
+        await prepareProfileImportMods(availableImportedMods);
+
+      let result: ProfileImportResult = {
+        profileFolder: activeProfile.folderName || "",
+        succeeded: [],
+        failed: [],
+        installedMods: [],
+      };
+
+      if (preparedMods.length > 0) {
+        result = await invoke<ProfileImportResult>("import_profile_batch", {
+          profileName: activeProfile.name,
+          profileDescription: activeProfile.description || "",
+          profileFolder: activeProfile.folderName || "",
+          mods: preparedMods.map((entry) => entry.profileImportMod),
+          importType: "override",
+        });
+
+        applyImportInstalledModsToProfile(
+          activeProfile.id,
+          result.installedMods,
+          modsDataByRemoteId,
+        );
+      }
+
+      setImportProgress(null);
+
+      if (
+        result.failed.length > 0 ||
+        preparationFailed.length > 0 ||
+        unavailableModsCount > 0
+      ) {
+        logger
+          .withMetadata({
+            failed: result.failed.length,
+            succeeded: result.succeeded.length,
+            unavailable: unavailableModsCount,
+            preparationFailed: preparationFailed.length,
+          })
+          .warn("Some mods failed to import to current profile");
+        const imported = result.installedMods.length;
+        toast.warning(
+          t("profiles.overrideSuccess") +
+            ` (${t("profiles.modsImportedCount", { imported, total: totalImportedMods })})`,
+        );
+      } else {
+        toast.success(t("profiles.overrideSuccess"));
+      }
+    } catch (error) {
+      logger.withError(error).error("Profile import failed");
+      setImportProgress(null);
+      toast.error(t("profiles.updateError"));
+      throw error;
+    }
+  };
+
+  return {
+    createProfileFromImport,
+    addToCurrentProfile,
+  };
+};

--- a/apps/desktop/src/lib/profiles/profile-reorder.ts
+++ b/apps/desktop/src/lib/profiles/profile-reorder.ts
@@ -1,0 +1,51 @@
+import type { LocalMod } from "@/types/mods";
+
+export type ProfileReorderData = [string, string[], number];
+export type UpdatedVpkMappings = Array<[string, string[]]>;
+
+type ReorderableMod = Pick<
+  LocalMod,
+  "remoteId" | "installedVpks" | "installOrder"
+>;
+
+export const buildProfileReorderData = (
+  mods: ReorderableMod[],
+): ProfileReorderData[] =>
+  mods
+    .map((mod, index) => ({ mod, index }))
+    .filter(
+      ({ mod }) =>
+        Array.isArray(mod.installedVpks) && mod.installedVpks.length > 0,
+    )
+    .sort((left, right) => {
+      const orderDifference =
+        (left.mod.installOrder ?? Number.MAX_SAFE_INTEGER) -
+        (right.mod.installOrder ?? Number.MAX_SAFE_INTEGER);
+
+      if (orderDifference !== 0) {
+        return orderDifference;
+      }
+
+      return left.index - right.index;
+    })
+    .map(({ mod }, index) => [mod.remoteId, mod.installedVpks ?? [], index]);
+
+export const applyUpdatedVpkMappings = <T extends ReorderableMod>(
+  mods: T[],
+  updatedVpkMappings: UpdatedVpkMappings,
+): T[] => {
+  const updatedVpksByRemoteId = new Map(updatedVpkMappings);
+
+  return mods.map((mod) => {
+    const updatedVpks = updatedVpksByRemoteId.get(mod.remoteId);
+
+    if (!updatedVpks) {
+      return mod;
+    }
+
+    return {
+      ...mod,
+      installedVpks: updatedVpks,
+    };
+  });
+};

--- a/apps/desktop/src/lib/profiles/types.ts
+++ b/apps/desktop/src/lib/profiles/types.ts
@@ -1,7 +1,7 @@
-import type {
-  ModDto,
-  ProfileModDownload,
-  SharedProfile,
+import {
+  getOrderedSharedProfileMods,
+  type ModDto,
+  type ProfileModDownload,
 } from "@deadlock-mods/shared";
 import type { ProfileImportMod } from "@/types/mods";
 
@@ -14,7 +14,9 @@ export interface ImportProgress {
   isInstalling: boolean;
 }
 
-export type OrderedImportedMod = SharedProfile["payload"]["mods"][number];
+export type OrderedImportedMod = ReturnType<
+  typeof getOrderedSharedProfileMods
+>[number];
 
 export interface AvailableImportedMod {
   importedMod: OrderedImportedMod;

--- a/apps/desktop/src/lib/profiles/types.ts
+++ b/apps/desktop/src/lib/profiles/types.ts
@@ -1,0 +1,84 @@
+import type {
+  ModDto,
+  ProfileModDownload,
+  SharedProfile,
+} from "@deadlock-mods/shared";
+import type { ProfileImportMod } from "@/types/mods";
+
+export interface ImportProgress {
+  currentStep: string;
+  currentMod?: string;
+  completedMods: number;
+  totalMods: number;
+  isDownloading: boolean;
+  isInstalling: boolean;
+}
+
+export type OrderedImportedMod = SharedProfile["payload"]["mods"][number];
+
+export interface AvailableImportedMod {
+  importedMod: OrderedImportedMod;
+  modData: ModDto;
+}
+
+export interface PreparedProfileImportMod {
+  importedMod: OrderedImportedMod;
+  modData: ModDto;
+  profileImportMod: ProfileImportMod;
+}
+
+export interface PreparedProfileImport {
+  preparedMods: PreparedProfileImportMod[];
+  failed: Array<[string, string]>;
+}
+
+export interface FetchModsDataResult {
+  modsData: ModDto[];
+  failed: Array<[string, string]>;
+}
+
+export type FetchModsDataEntry =
+  | {
+      remoteId: string;
+      modData: ModDto;
+    }
+  | {
+      remoteId: string;
+      error: string;
+    };
+
+export type PrepareProfileImportEntry =
+  | PreparedProfileImportMod
+  | {
+      importedMod: OrderedImportedMod;
+      error: string;
+    };
+
+export interface ProfileImportOptions {
+  sourceProfileId?: string;
+}
+
+export interface ProfileImportDownloadFile {
+  url: string;
+  name: string;
+  size: number;
+}
+
+export interface AvailableImportDownload {
+  url: string;
+  name: string;
+  size?: number | null;
+}
+
+export interface ResolveProfileImportDownloadFilesArgs {
+  availableDownloads: AvailableImportDownload[];
+  selectedDownloads?: ProfileModDownload[];
+  selectedDownload?: ProfileModDownload;
+}
+
+export interface ResolvedProfileImportDownloadFiles {
+  downloadFiles: ProfileImportDownloadFile[];
+  missingSelectionNames: string[];
+  resolvedWithLiveFallbackNames: string[];
+  resolvedWithPersistedFallbackNames: string[];
+}

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -1,8 +1,10 @@
+import { type ModDto } from "@deadlock-mods/shared";
 import { invoke } from "@tauri-apps/api/core";
+import i18n from "i18next";
 import type { StateCreator } from "zustand";
 import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
-import { type LocalMod, ModStatus } from "@/types/mods";
+import { type LocalMod, ModStatus, type InstalledModInfo } from "@/types/mods";
 import {
   createProfileId,
   DEFAULT_PROFILE_ID,
@@ -12,7 +14,6 @@ import {
   type ProfileId,
   type ProfileSwitchResult,
 } from "@/types/profiles";
-import type { State } from "..";
 
 export interface ProfilesState {
   profiles: Record<ProfileId, ModProfile>;
@@ -28,6 +29,17 @@ export interface ProfilesState {
     profileId: ProfileId,
     updates: Partial<Pick<ModProfile, "name" | "description">>,
   ) => boolean;
+  setProfileFolderName: (profileId: ProfileId, folderName: string) => void;
+  upsertProfile: (profile: ModProfile) => void;
+  createImportProfileFolder: (
+    profileId: ProfileId,
+    profileName: string,
+  ) => Promise<string>;
+  applyImportInstalledModsToProfile: (
+    profileId: ProfileId,
+    installedMods: InstalledModInfo[],
+    modsDataByRemoteId: Map<string, ModDto>,
+  ) => void;
 
   switchToProfile: (profileId: ProfileId) => Promise<ProfileSwitchResult>;
   setModEnabledInProfile: (
@@ -65,10 +77,114 @@ const createDefaultProfile = (): ModProfile => ({
 export const profilesDeepMergeKeys =
   [] as const satisfies readonly (keyof ProfilesState)[];
 
-export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
-  set,
-  get,
-) => ({
+const RECOVERED_PROFILE_DESCRIPTION = "Profile detected from filesystem";
+const PROFILE_FOLDER_NAME_PATTERN = /^(profile_\d+_[^_]+)(?:_(.+))?$/;
+
+const toRecoveredProfileName = (value: string) => {
+  const displayName = value
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+  return (
+    displayName ||
+    i18n.t("profiles.unknownProfile", { defaultValue: "Unknown Profile" })
+  );
+};
+
+const getRecoveredProfileDetails = (folderName: string) => {
+  const match = folderName.match(PROFILE_FOLDER_NAME_PATTERN);
+
+  return {
+    profileId: createProfileId(match?.[1] ?? folderName),
+    displayName: toRecoveredProfileName(match?.[2] ?? folderName),
+  };
+};
+
+const shouldReplaceRecoveredProfileName = (profile: ModProfile) =>
+  profile.description === RECOVERED_PROFILE_DESCRIPTION || !profile.name.trim();
+
+const pickRecoveredProfileSource = (
+  existingProfile: ModProfile | undefined,
+  recoveredProfile: ModProfile,
+) => {
+  if (!existingProfile) {
+    return recoveredProfile;
+  }
+
+  if (existingProfile.mods.length !== recoveredProfile.mods.length) {
+    return existingProfile.mods.length > recoveredProfile.mods.length
+      ? existingProfile
+      : recoveredProfile;
+  }
+
+  return Object.keys(existingProfile.enabledMods).length >=
+    Object.keys(recoveredProfile.enabledMods).length
+    ? existingProfile
+    : recoveredProfile;
+};
+
+const normalizeRecoveredProfileIds = (
+  profiles: Record<ProfileId, ModProfile>,
+  activeProfileId: ProfileId,
+) => {
+  const nextProfiles = { ...profiles };
+  let nextActiveProfileId = activeProfileId;
+  let changed = false;
+
+  for (const profile of Object.values(profiles)) {
+    if (profile.isDefault || !profile.folderName) {
+      continue;
+    }
+
+    const { profileId, displayName } = getRecoveredProfileDetails(
+      profile.folderName,
+    );
+
+    if (profile.id === profileId) {
+      continue;
+    }
+
+    const sourceProfile = pickRecoveredProfileSource(
+      nextProfiles[profileId],
+      profile,
+    );
+
+    delete nextProfiles[profile.id];
+    nextProfiles[profileId] = {
+      ...sourceProfile,
+      id: profileId,
+      folderName: profile.folderName,
+      name: shouldReplaceRecoveredProfileName(sourceProfile)
+        ? displayName
+        : sourceProfile.name,
+    };
+
+    if (nextActiveProfileId === profile.id) {
+      nextActiveProfileId = profileId;
+    }
+
+    changed = true;
+  }
+
+  return {
+    profiles: changed ? nextProfiles : profiles,
+    activeProfileId: nextActiveProfileId,
+    changed,
+  };
+};
+
+type ProfilesSliceStore = ProfilesState & {
+  localMods: LocalMod[];
+};
+
+export const createProfilesSlice: StateCreator<
+  ProfilesSliceStore,
+  [],
+  [],
+  ProfilesState
+> = (set, get, _store): ProfilesState => ({
   profiles: {
     [DEFAULT_PROFILE_ID]: createDefaultProfile(),
   },
@@ -126,8 +242,29 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
       return false;
     }
 
-    if (profile.folderName) {
-      try {
+    const isDeletingActiveProfile = activeProfileId === profileId;
+    const fallbackProfile =
+      profiles[DEFAULT_PROFILE_ID] ?? createDefaultProfile();
+    let switchedToFallback = false;
+
+    try {
+      if (isDeletingActiveProfile) {
+        set({ isSwitching: true });
+
+        await invoke("switch_profile", {
+          profileFolder: fallbackProfile.folderName,
+        });
+        switchedToFallback = true;
+        logger
+          .withMetadata({
+            deletedProfileId: profileId,
+            fallbackProfileId: DEFAULT_PROFILE_ID,
+            fallbackFolderName: fallbackProfile.folderName,
+          })
+          .info("Switched to fallback profile before deletion");
+      }
+
+      if (profile.folderName) {
         await invoke("delete_profile_folder", {
           profileFolder: profile.folderName,
         });
@@ -137,29 +274,63 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
             folderName: profile.folderName,
           })
           .info("Deleted profile folder");
-      } catch (error) {
-        logger
-          .withMetadata({
-            profileId,
-            folderName: profile.folderName,
-          })
-          .withError(error)
-          .error("Failed to delete profile folder");
+      }
+
+      const deletedAt = new Date();
+
+      set((state) => {
+        const remainingProfiles = { ...state.profiles };
+
+        if (!remainingProfiles[DEFAULT_PROFILE_ID]) {
+          remainingProfiles[DEFAULT_PROFILE_ID] = fallbackProfile;
+        }
+
+        delete remainingProfiles[profileId];
+
+        if (!isDeletingActiveProfile) {
+          return {
+            profiles: remainingProfiles,
+          };
+        }
+
+        const nextActiveProfile = remainingProfiles[DEFAULT_PROFILE_ID];
+
+        return {
+          profiles: {
+            ...remainingProfiles,
+            [DEFAULT_PROFILE_ID]: {
+              ...nextActiveProfile,
+              lastUsed: deletedAt,
+            },
+          },
+          activeProfileId: DEFAULT_PROFILE_ID,
+          localMods: [...nextActiveProfile.mods],
+        };
+      });
+
+      return true;
+    } catch (error) {
+      if (switchedToFallback) {
+        set({
+          activeProfileId: DEFAULT_PROFILE_ID,
+          localMods: [...fallbackProfile.mods],
+        });
+      }
+      logger
+        .withMetadata({
+          profileId,
+          folderName: profile.folderName,
+          isDeletingActiveProfile,
+          switchedToFallback,
+        })
+        .withError(error)
+        .error("Failed to delete profile");
+      return false;
+    } finally {
+      if (isDeletingActiveProfile) {
+        set({ isSwitching: false });
       }
     }
-
-    const newProfiles = { ...profiles };
-    delete newProfiles[profileId];
-
-    set((state) => ({
-      profiles: newProfiles,
-      activeProfileId:
-        activeProfileId === profileId
-          ? DEFAULT_PROFILE_ID
-          : state.activeProfileId,
-    }));
-
-    return true;
   },
 
   updateProfile: (
@@ -188,6 +359,153 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
     }));
 
     return true;
+  },
+
+  setProfileFolderName: (profileId: ProfileId, folderName: string) => {
+    set((state) => {
+      const profile = state.profiles[profileId];
+
+      if (!profile) {
+        return state;
+      }
+
+      return {
+        profiles: {
+          ...state.profiles,
+          [profileId]: {
+            ...profile,
+            folderName,
+          },
+        },
+      };
+    });
+  },
+
+  upsertProfile: (profile: ModProfile) => {
+    set((state) => ({
+      profiles: {
+        ...state.profiles,
+        [profile.id]: profile,
+      },
+    }));
+  },
+
+  createImportProfileFolder: async (
+    profileId: ProfileId,
+    profileName: string,
+  ): Promise<string> => {
+    const folderName = await invoke<string>("create_profile_folder", {
+      profileId,
+      profileName,
+    });
+
+    get().setProfileFolderName(profileId, folderName);
+    return folderName;
+  },
+
+  applyImportInstalledModsToProfile: (
+    profileId: ProfileId,
+    installedMods: InstalledModInfo[],
+    modsDataByRemoteId: Map<string, ModDto>,
+  ) => {
+    set((state) => {
+      const profile = state.profiles[profileId];
+
+      if (!profile) {
+        return state;
+      }
+
+      const now = new Date();
+      const updateActiveLocalMods = state.activeProfileId === profileId;
+      const nextProfileMods = [...profile.mods];
+      const profileIndexesByRemoteId = new Map(
+        nextProfileMods.map((mod, index) => [mod.remoteId, index]),
+      );
+      const nextEnabledMods = { ...profile.enabledMods };
+      const nextLocalMods = updateActiveLocalMods
+        ? [...state.localMods]
+        : state.localMods;
+      const localIndexesByRemoteId = updateActiveLocalMods
+        ? new Map(nextLocalMods.map((mod, index) => [mod.remoteId, index]))
+        : null;
+
+      for (const installedMod of installedMods) {
+        const modData = modsDataByRemoteId.get(installedMod.modId);
+
+        if (!modData) {
+          continue;
+        }
+
+        const existingProfileIndex = profileIndexesByRemoteId.get(
+          installedMod.modId,
+        );
+        const existingProfileMod =
+          existingProfileIndex === undefined
+            ? undefined
+            : nextProfileMods[existingProfileIndex];
+        const existingLocalIndex = localIndexesByRemoteId?.get(
+          installedMod.modId,
+        );
+        const existingLocalMod =
+          existingLocalIndex === undefined
+            ? undefined
+            : nextLocalMods[existingLocalIndex];
+        const baseMod = existingProfileMod ?? existingLocalMod;
+
+        const nextMod: LocalMod = {
+          ...(baseMod ?? modData),
+          downloadedAt: baseMod?.downloadedAt ?? now,
+          status: ModStatus.Installed,
+          installedVpks: installedMod.installedVpks,
+          installedFileTree: installedMod.fileTree,
+        };
+
+        if (existingProfileIndex === undefined) {
+          profileIndexesByRemoteId.set(
+            installedMod.modId,
+            nextProfileMods.length,
+          );
+          nextProfileMods.push(nextMod);
+        } else {
+          nextProfileMods[existingProfileIndex] = nextMod;
+        }
+
+        nextEnabledMods[installedMod.modId] = {
+          remoteId: installedMod.modId,
+          enabled: true,
+          lastModified: now,
+        };
+
+        if (updateActiveLocalMods && localIndexesByRemoteId) {
+          if (existingLocalIndex === undefined) {
+            localIndexesByRemoteId.set(
+              installedMod.modId,
+              nextLocalMods.length,
+            );
+            nextLocalMods.push(nextMod);
+          } else {
+            nextLocalMods[existingLocalIndex] = nextMod;
+          }
+        }
+      }
+
+      const nextPartial: Partial<ProfilesSliceStore> = {
+        profiles: {
+          ...state.profiles,
+          [profileId]: {
+            ...profile,
+            enabledMods: nextEnabledMods,
+            mods: nextProfileMods,
+          },
+        },
+      };
+
+      if (updateActiveLocalMods) {
+        nextPartial.localMods = nextLocalMods;
+      }
+
+      return nextPartial;
+    });
   },
 
   switchToProfile: async (profileId: ProfileId) => {
@@ -369,11 +687,6 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
       .length;
   },
 
-  activeProfile: () => {
-    const { activeProfileId, profiles } = get();
-    return profiles[activeProfileId];
-  },
-
   saveCurrentModsToProfile: () => {
     const { activeProfileId, profiles, localMods } = get();
     const profile = profiles[activeProfileId];
@@ -539,7 +852,22 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
   syncProfilesWithFilesystem: async () => {
     try {
       const filesystemFolders = await invoke<string[]>("list_profile_folders");
-      const { profiles, activeProfileId } = get();
+      const state = get();
+      const normalizedState = normalizeRecoveredProfileIds(
+        state.profiles,
+        state.activeProfileId,
+      );
+
+      if (normalizedState.changed) {
+        set({
+          profiles: normalizedState.profiles,
+          activeProfileId: normalizedState.activeProfileId,
+        });
+
+        logger.info("Normalized recovered profile IDs from filesystem folders");
+      }
+
+      const { profiles, activeProfileId } = normalizedState;
 
       const filesystemFoldersSet = new Set(filesystemFolders);
       const knownFolders = new Set(
@@ -606,28 +934,29 @@ export const createProfilesSlice: StateCreator<State, [], [], ProfilesState> = (
         const newProfiles: Record<ProfileId, ModProfile> = {};
 
         for (const folderName of unknownFolders) {
-          const parts = folderName.split("_");
-          const profileIdPart = parts[0];
-          const namePart = parts.slice(1).join("_") || "Unknown Profile";
+          const { profileId, displayName } =
+            getRecoveredProfileDetails(folderName);
+          const existingProfile = profiles[profileId];
 
-          const displayName = namePart
-            .split(/[-_]/)
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(" ");
-
-          const profileId = createProfileId(profileIdPart);
-
-          newProfiles[profileId] = {
-            id: profileId,
-            name: displayName,
-            description: "Profile detected from filesystem",
-            createdAt: new Date(),
-            lastUsed: new Date(),
-            enabledMods: {},
-            isDefault: false,
-            folderName: folderName,
-            mods: [],
-          };
+          newProfiles[profileId] = existingProfile
+            ? {
+                ...existingProfile,
+                folderName,
+                name: shouldReplaceRecoveredProfileName(existingProfile)
+                  ? displayName
+                  : existingProfile.name,
+              }
+            : {
+                id: profileId,
+                name: displayName,
+                description: RECOVERED_PROFILE_DESCRIPTION,
+                createdAt: new Date(),
+                lastUsed: new Date(),
+                enabledMods: {},
+                isDefault: false,
+                folderName,
+                mods: [],
+              };
         }
 
         set((state) => ({

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -4,6 +4,8 @@ import i18n from "i18next";
 import type { StateCreator } from "zustand";
 import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
+import { sortModsByInstallOrder } from "@/lib/profiles/import-profile-shared";
+import { applyUpdatedVpkMappings } from "@/lib/profiles/profile-reorder";
 import { type LocalMod, ModStatus, type InstalledModInfo } from "@/types/mods";
 import {
   createProfileId,
@@ -39,6 +41,11 @@ export interface ProfilesState {
     profileId: ProfileId,
     installedMods: InstalledModInfo[],
     modsDataByRemoteId: Map<string, ModDto>,
+    installOrderByRemoteId: Map<string, number>,
+  ) => void;
+  applyImportReorderVpksToProfile: (
+    profileId: ProfileId,
+    updatedVpkMappings: Array<[string, string[]]>,
   ) => void;
 
   switchToProfile: (profileId: ProfileId) => Promise<ProfileSwitchResult>;
@@ -407,6 +414,7 @@ export const createProfilesSlice: StateCreator<
     profileId: ProfileId,
     installedMods: InstalledModInfo[],
     modsDataByRemoteId: Map<string, ModDto>,
+    installOrderByRemoteId: Map<string, number>,
   ) => {
     set((state) => {
       const profile = state.profiles[profileId];
@@ -436,6 +444,7 @@ export const createProfilesSlice: StateCreator<
           continue;
         }
 
+        const installOrder = installOrderByRemoteId.get(installedMod.modId);
         const existingProfileIndex = profileIndexesByRemoteId.get(
           installedMod.modId,
         );
@@ -458,6 +467,7 @@ export const createProfilesSlice: StateCreator<
           status: ModStatus.Installed,
           installedVpks: installedMod.installedVpks,
           installedFileTree: installedMod.fileTree,
+          installOrder: installOrder ?? baseMod?.installOrder,
         };
 
         if (existingProfileIndex === undefined) {
@@ -495,13 +505,49 @@ export const createProfilesSlice: StateCreator<
           [profileId]: {
             ...profile,
             enabledMods: nextEnabledMods,
-            mods: nextProfileMods,
+            mods: sortModsByInstallOrder(nextProfileMods),
           },
         },
       };
 
       if (updateActiveLocalMods) {
-        nextPartial.localMods = nextLocalMods;
+        nextPartial.localMods = sortModsByInstallOrder(nextLocalMods);
+      }
+
+      return nextPartial;
+    });
+  },
+
+  applyImportReorderVpksToProfile: (
+    profileId: ProfileId,
+    updatedVpkMappings: Array<[string, string[]]>,
+  ) => {
+    if (updatedVpkMappings.length === 0) {
+      return;
+    }
+
+    set((state) => {
+      const profile = state.profiles[profileId];
+
+      if (!profile) {
+        return state;
+      }
+
+      const nextPartial: Partial<ProfilesSliceStore> = {
+        profiles: {
+          ...state.profiles,
+          [profileId]: {
+            ...profile,
+            mods: applyUpdatedVpkMappings(profile.mods, updatedVpkMappings),
+          },
+        },
+      };
+
+      if (state.activeProfileId === profileId) {
+        nextPartial.localMods = applyUpdatedVpkMappings(
+          state.localMods,
+          updatedVpkMappings,
+        );
       }
 
       return nextPartial;

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1605,7 +1605,8 @@
     "noUrlAvailable": "No URL available for this mod",
     "openedGameFolder": "Opened game folder",
     "openedModInGame": "Opened mod files in game folder",
-    "failedToOpenGameFolder": "Failed to open game folder"
+    "failedToOpenGameFolder": "Failed to open game folder",
+    "failedToOpenModInGame": "Failed to show mod in game"
   },
   "profiles": {
     "share": "Share Profile",
@@ -1679,7 +1680,18 @@
     "creatingProfile": "Creating new profile...",
     "updatingProfile": "Updating current profile...",
     "processingMods": "Processing mods...",
-    "modsProcessed": "Mods processed"
+    "modsProcessed": "Mods processed",
+    "importedProfileDescription": "Profile imported from shared profile ID",
+    "importedProfileName": "Imported Profile - {{date}}",
+    "modsImportedCount": "{{imported}}/{{total}} mods imported",
+    "activateProfileLabel": "Activate {{profileName}} profile",
+    "statusActive": "Active",
+    "statusInactive": "Inactive",
+    "hideModList": "Hide",
+    "showModList": "Show",
+    "modId": "ID: {{id}}",
+    "unknownProfile": "Unknown Profile",
+    "recoveredProfileDescription": "Profile detected from filesystem"
   },
   "mapInvite": {
     "title": "Invite Friends",

--- a/packages/shared/src/schemas/profile.schemas.ts
+++ b/packages/shared/src/schemas/profile.schemas.ts
@@ -49,4 +49,47 @@ export const v2ProfileSchema = z.object({
 export const profileSchema = z.union([v1ProfileSchema, v2ProfileSchema]);
 
 export type SharedProfile = z.infer<typeof profileSchema>;
+type SharedProfileMod = z.infer<typeof profileModSchema>;
 export type ProfileModDownload = z.infer<typeof profileModDownloadSchema>;
+
+export const getSharedProfileLoadOrder = (profile: SharedProfile): string[] => {
+  const availableModIds = new Set(
+    profile.payload.mods.map((mod) => mod.remoteId),
+  );
+  const explicitLoadOrder =
+    profile.version === "2" ? profile.payload.loadOrder : [];
+  const normalizedLoadOrder: string[] = [];
+  const seenModIds = new Set<string>();
+
+  for (const remoteId of explicitLoadOrder) {
+    if (!availableModIds.has(remoteId) || seenModIds.has(remoteId)) {
+      continue;
+    }
+
+    normalizedLoadOrder.push(remoteId);
+    seenModIds.add(remoteId);
+  }
+
+  for (const mod of profile.payload.mods) {
+    if (seenModIds.has(mod.remoteId)) {
+      continue;
+    }
+
+    normalizedLoadOrder.push(mod.remoteId);
+    seenModIds.add(mod.remoteId);
+  }
+
+  return normalizedLoadOrder;
+};
+
+export const getOrderedSharedProfileMods = (
+  profile: SharedProfile,
+): SharedProfileMod[] => {
+  const modsByRemoteId = new Map(
+    profile.payload.mods.map((mod) => [mod.remoteId, mod]),
+  );
+
+  return getSharedProfileLoadOrder(profile)
+    .map((remoteId) => modsByRemoteId.get(remoteId))
+    .filter((mod): mod is SharedProfileMod => mod !== undefined);
+};

--- a/packages/shared/src/tests/profile.schemas.spec.ts
+++ b/packages/shared/src/tests/profile.schemas.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { profileSchema } from "../schemas/profile.schemas";
+import {
+  getOrderedSharedProfileMods,
+  getSharedProfileLoadOrder,
+  profileSchema,
+  type SharedProfile,
+} from "../schemas/profile.schemas";
 
 describe("profileSchema", () => {
   it("parses v1 profiles", () => {
@@ -30,5 +35,124 @@ describe("profileSchema", () => {
     expect(profile.version).toBe("2");
     expect(profile.payload.mods).toHaveLength(3);
     expect(profile.payload.loadOrder).toEqual(["mod-a", "mod-b", "mod-c"]);
+  });
+});
+
+describe("getSharedProfileLoadOrder", () => {
+  it("returns v2 load order with unknown and duplicate IDs removed", () => {
+    const profile: SharedProfile = {
+      version: "2",
+      payload: {
+        mods: [{ remoteId: "mod-a" }, { remoteId: "mod-b" }],
+        loadOrder: [
+          "mod-b",
+          "unknown-mod",
+          "mod-a",
+          "mod-b",
+          "another-unknown",
+        ],
+      },
+    };
+
+    expect(getSharedProfileLoadOrder(profile)).toEqual(["mod-b", "mod-a"]);
+  });
+
+  it("appends mods missing from v2 load order", () => {
+    const profile: SharedProfile = {
+      version: "2",
+      payload: {
+        mods: [
+          { remoteId: "mod-a" },
+          { remoteId: "mod-b" },
+          { remoteId: "mod-c" },
+        ],
+        loadOrder: ["mod-b"],
+      },
+    };
+
+    expect(getSharedProfileLoadOrder(profile)).toEqual([
+      "mod-b",
+      "mod-a",
+      "mod-c",
+    ]);
+  });
+
+  it("returns mods in payload order for v1 profiles", () => {
+    const profile: SharedProfile = {
+      version: "1",
+      payload: {
+        mods: [
+          { remoteId: "mod-c" },
+          { remoteId: "mod-a" },
+          { remoteId: "mod-b" },
+        ],
+      },
+    };
+
+    expect(getSharedProfileLoadOrder(profile)).toEqual([
+      "mod-c",
+      "mod-a",
+      "mod-b",
+    ]);
+  });
+});
+
+describe("getOrderedSharedProfileMods", () => {
+  it("returns mods ordered by v2 load order", () => {
+    const profile: SharedProfile = {
+      version: "2",
+      payload: {
+        mods: [
+          { remoteId: "mod-c" },
+          { remoteId: "mod-a" },
+          { remoteId: "mod-b" },
+        ],
+        loadOrder: ["mod-b", "mod-a", "mod-c"],
+      },
+    };
+
+    const ordered = getOrderedSharedProfileMods(profile);
+
+    expect(ordered.map((m) => m.remoteId)).toEqual(["mod-b", "mod-a", "mod-c"]);
+  });
+
+  it("returns mods in payload order for v1 profiles", () => {
+    const profile: SharedProfile = {
+      version: "1",
+      payload: {
+        mods: [{ remoteId: "mod-b" }, { remoteId: "mod-a" }],
+      },
+    };
+
+    const ordered = getOrderedSharedProfileMods(profile);
+
+    expect(ordered.map((m) => m.remoteId)).toEqual(["mod-b", "mod-a"]);
+  });
+
+  it("preserves mod data when reordering", () => {
+    const profile: SharedProfile = {
+      version: "2",
+      payload: {
+        mods: [
+          {
+            remoteId: "mod-a",
+            selectedDownload: {
+              remoteId: "mod-a",
+              file: "file-a.zip",
+              url: "https://example.com/a",
+              size: 100,
+            },
+          },
+          { remoteId: "mod-b" },
+        ],
+        loadOrder: ["mod-b", "mod-a"],
+      },
+    };
+
+    const ordered = getOrderedSharedProfileMods(profile);
+
+    expect(ordered[0]?.remoteId).toBe("mod-b");
+    expect(ordered[1]?.remoteId).toBe("mod-a");
+    expect(ordered[1]?.selectedDownload?.file).toBe("file-a.zip");
   });
 });


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Profile Load Order and Import Flow Refactoring

### Overview
Introduces V2 profile schema with explicit load order support and comprehensively refactors the profile import flow into dedicated, composable modules. Integrates load-order preservation from remote sources through profile export and applies it during import operations. Modifies Rust-side VPK handling to support shallow-scan lookup and dynamic VPK slot allocation.

### Affected Packages & Apps
- **apps/desktop** (frontend): Components, hooks, new profile import/reorder library modules, store
- **apps/desktop/src-tauri** (Rust backend): Import batch operations, VPK management, addon analysis
- **packages/shared**: Profile schema definitions and validation helpers

### Key Functional Changes

#### Profile Schema & Load Order (packages/shared)
- Added V2 profile schema with `loadOrder` field alongside existing `mods` array
- New utilities: `getSharedProfileLoadOrder` (extracts and normalizes load order from v2 profiles, falls back to v1 mod sequence) and `getOrderedSharedProfileMods` (returns mods reordered by computed load order)
- Load order generation deduplicates remote IDs, removes unknown entries, and appends unmapped mods in original order

#### Desktop Frontend - Profile Management
- **profile-share-dialog.tsx**: Updated to emit V2 profiles with `version: "2"` including both `mods` and `loadOrder` fields; derives shared mods and load order using new helpers
- **profile-import-dialog.tsx**: Split mutation logic; uses `getOrderedSharedProfileMods` to derive ordered import list for mod detail fetching
- **profile-manager-dialog.tsx**: Migrated sync flow to React Query mutation; optimized mod enablement rendering via precomputed `remoteId` map
- **use-profile-import.ts**: Refactored from direct import logic to delegating to `createProfileImportFlow`; introduces `listenToProgress` option

#### New Desktop Library Modules (apps/desktop/src/lib/profiles/)
- **types.ts**: Core TypeScript definitions for import flow (`ImportProgress`, `OrderedImportedMod`, `PreparedProfileImport`, etc.) and download resolution
- **import-downloads.ts**: Download file resolution logic with fallback handling for persisted selections vs live downloads
- **import-profile-prep.ts**: Mod data fetching and import preparation; handles download file resolution and error tracking
- **import-profile-shared.ts**: Shared utilities for mod ordering by `installOrder` and import context resolution
- **import-profile.ts**: Main flow orchestration (`createProfileImportFlow`) wiring UI progress, profile state mutations, and backend operations
- **profile-reorder.ts**: VPK reorder data construction and application; builds reorder input from installed mods and applies returned VPK mappings

#### Store Updates (apps/desktop/src/lib/store/slices/profiles.ts)
- New actions: `setProfileFolderName`, `upsertProfile`, `createImportProfileFolder`, `applyImportInstalledModsToProfile`, `applyImportReorderVpksToProfile`
- `applyImportInstalledModsToProfile`: Updates installed mod metadata and applies sorted/ordered mods to profiles
- `applyImportReorderVpksToProfile`: Applies VPK reorder mappings from backend to profile mod state
- `deleteProfile`: Refactored to safely switch away from active profile before deletion

#### Rust Backend Changes (apps/desktop/src-tauri)
- **commands.rs**: 
  - New helpers to build reorder input from profile mods (preserving installation sequence)
  - `import_profile_batch`: Now treats both `"downloading"` and `"paused"` as in-progress; conditionally invokes `reorder_mods_by_remote_id` post-import and updates in-memory VPK lists on success
  - `batch_update_mods`: Added `"paused"` status handling
- **addon_analyzer.rs**: `find_vpk_file_paths` converted from recursive to shallow (top-level only) directory scan
- **vpk_manager.rs**: Replaced `find_next_available_vpk_number` with `find_next_free_vpk_name` for linear probing of free VPK slots

### Cross-Package Dependencies
- Desktop components and hooks import from new `@/lib/profiles` modules
- Desktop import flow depends on shared `getOrderedSharedProfileMods` and profile schema types
- Rust import operations integrated with new VPK shallow-scan and reorder logic; VPK reorder results propagated back to desktop via store mutations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->