### PR TITLE
fix: gpu compat for nvidia on x11

### DIFF
--- a/.changeset/dull-falcons-attack.md
+++ b/.changeset/dull-falcons-attack.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+fixed nvidia GPU compatability on x11

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,13 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 #[cfg(target_os = "linux")]
-fn is_nvidia_on_wayland() -> bool {
-  let session_type = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
-  if session_type != "wayland" {
-    eprintln!("[GPU Compat] Session type is '{session_type}', not wayland — skipping workaround");
-    return false;
-  }
-
+fn is_nvidia_gpu_present() -> bool {
   if std::path::Path::new("/proc/driver/nvidia/version").exists() {
     eprintln!("[GPU Compat] Detected NVIDIA driver via /proc/driver/nvidia/version");
     return true;
@@ -117,8 +111,9 @@ fn should_enable_gpu_compat_workaround() -> bool {
       false
     }
     _ => {
-      eprintln!("[GPU Compat] Auto-detecting NVIDIA + Wayland...");
-      is_nvidia_on_wayland()
+      let session_type = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
+      eprintln!("[GPU Compat] Auto-detecting NVIDIA on {session_type}...");
+      is_nvidia_gpu_present()
     }
   }
 }


### PR DESCRIPTION
## Description

Updated the nvidia GPU compatibility check to work for X11 as well. 

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [X] AI-assisted — Tool: Claude, Used for: Searching for the compatibility check function 

## Testing

- [X] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments


## Checklist

- [X] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [X] My code follows the style guidelines of this project (`pnpm lint` passes)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [X] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Noticed the UI was white screening when I tried to use your linux version so I thought I would help out. 

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Functional Impact

This PR fixes GPU compatibility detection for NVIDIA graphics on Linux X11 sessions in the **desktop** application.

### Changes Made

Modified the GPU compatibility check in `apps/desktop/src-tauri/src/main.rs` to detect NVIDIA hardware regardless of the session type (Wayland or X11), rather than exclusively for Wayland:

- Renamed `is_nvidia_on_wayland()` to `is_nvidia_gpu_present()` and removed the mandatory Wayland session type check
- Hardware detection logic remains unchanged: checks for NVIDIA driver via `/proc/driver/nvidia/version` and scans PCI devices for NVIDIA vendor ID (0x10de)
- The auto-detection path now reads `XDG_SESSION_TYPE` for logging purposes but no longer gates the workaround behind it
- Updated log strings to reflect "NVIDIA on {session_type}" instead of "NVIDIA + Wayland"

### Impact

The WebKit DMA-BUF renderer workaround (`WEBKIT_DISABLE_DMABUF_RENDERER` and `WEBKIT_DISABLE_COMPOSITING_MODE`) will now be applied when an NVIDIA GPU is detected on any Linux session type. This addresses UI white-screening issues previously limited to X11 with NVIDIA hardware.

**Scope**: Desktop app only. No cross-package dependencies, database migrations, Tauri plugin changes, or FFI boundary modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->