### PR TITLE
fix(alert-dialog): reset body between dialogs to prevent stale c…

### DIFF
--- a/apps/desktop/src/components/providers/alert-dialog.tsx
+++ b/apps/desktop/src/components/providers/alert-dialog.tsx
@@ -98,6 +98,7 @@ export function alertDialogReducer(
     case "prompt":
       return {
         ...state,
+        body: "",
         open: true,
         ...action,
         tone: ("tone" in action && action.tone) || "default",


### PR DESCRIPTION
## Description

The alertDialogReducer spread ...state before ...action, so any dialog opened without a body would inherit the body from the previous dialog's state. Added an explicit body: "" reset before the action spread so each dialog starts clean unless a specified body prop is sent in.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Fixes #419 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<img width="496" height="208" alt="image" src="https://github.com/user-attachments/assets/f14cd744-5a9b-459f-9fe5-cca8970a542c" />

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Functional Impact

**Affected Component:** Desktop app - Alert Dialog Provider

The `alertDialogReducer` function in `apps/desktop/src/components/providers/alert-dialog.tsx` now explicitly resets the dialog body to an empty string before applying new dialog properties. This prevents alert dialogs from inheriting body text from previously displayed dialogs when a new dialog is opened without specifying a body.

The fix ensures that when "alert", "confirm", or "prompt" actions are dispatched, the reducer initializes `body: ""` before spreading the action properties, guaranteeing that only dialogs with an explicitly provided `body` prop will display descriptive text. This resolves the issue where destructive action dialogs (such as "Clear All Mods", "Clear All Mod Data", "Clear Download Cache") were incorrectly displaying stale body messages from prior dialog interactions.

**Change Details:**
- Single-line addition of `body: ""` in the reducer's return statement for dialog open cases
- No API, database, or cross-package dependency changes
- No impact on other apps or packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->