### PR TITLE
docs(installation): add Gentoo overlay to package managers

### DIFF
--- a/apps/docs/content/docs/using-mod-manager/installation.mdx
+++ b/apps/docs/content/docs/using-mod-manager/installation.mdx
@@ -83,6 +83,22 @@ environment.systemPackages = with pkgs; [
 ];
 ```
 
+#### Gentoo
+
+Available via the third-party [`::deftera`](https://github.com/Deftera186/deftera-overlay) overlay.
+
+```bash
+# Enable the overlay
+sudo eselect repository add deftera git https://github.com/Deftera186/deftera-overlay.git
+sudo emaint sync --repo deftera
+
+# Prebuilt binary (recommended)
+sudo emerge -av games-util/deadlock-modmanager-bin
+
+# Or build from source
+sudo emerge -av games-util/deadlock-modmanager
+```
+
 More package managers will be added in the future. If you would like to maintain a package manager for Deadlock Mod Manager, please contact us on [Discord](https://deadlockmods.app/discord).
 
 ## Platform-Specific Installation


### PR DESCRIPTION
## Description

Adds the deftera third-party Gentoo overlay alongside the existing winget / AUR / nixpkgs entries, with both the prebuilt binary (games-util/deadlock-modmanager-bin) and the source build (games-util/deadlock-modmanager) variants.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues
None

## AI Disclosure

I use AI to help me maintain the overlay - but everything is manually checked by me and only pushed if I checked the code and also verified everything installs correctly. This PR is small part of docs so N/A here imo.

## Testing

- [X] I have tested these changes locally
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes 
(N/A)
- [X] I have tested the changes in both development and production-like environments
(N/A)

## Screenshots (if applicable)
<img width="1890" height="1007" alt="image" src="https://github.com/user-attachments/assets/661a99c6-21fa-4bd1-83b7-7d8c8845b2d6" />

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

I will try to maintain the stable releases, but in any case I also have a live (9999) ebuild, so users actually can just always install the most up-to-date from source.

## For Maintainers

- [ ] This PR requires a version bump
- [X] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Update: Gentoo Package Manager Installation

**Affected Package:** `docs`

Added Gentoo installation documentation to the "Option 3: Package Managers" section. The update documents installation via the community-maintained `::deftera` overlay with:

- Setup instructions: `sudo eselect repository add deftera` and `sudo emaint sync --repo deftera`
- Two installation options:
  - Prebuilt binary package: `games-util/deadlock-modmanager-bin` (recommended)
  - Source build variant: `games-util/deadlock-modmanager`

**Impact:** Documentation-only change. No functional code modifications, cross-package dependencies, database migrations, Tauri plugin changes, or Rust FFI boundary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->