### PR TITLE
fix(profile): fix VPK state drift

### DIFF
--- a/.changeset/brave-wolves-howl.md
+++ b/.changeset/brave-wolves-howl.md
@@ -1,5 +1,0 @@
----
-"@deadlock-mods/desktop": minor
----
-
-Improve mod deletion feedback when VPK files are locked by the game. Users now see an actionable error message suggesting to close Deadlock, and metadata is preserved so deletion can be retried.

--- a/.changeset/brisk-wolves-track.md
+++ b/.changeset/brisk-wolves-track.md
@@ -1,5 +1,0 @@
----
-"@deadlock-mods/desktop": patch
----
-
-Fix Discord game presence detection for hero variants, party sizes, and match modes

--- a/.changeset/calm-lions-persist.md
+++ b/.changeset/calm-lions-persist.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix manifest sync: persist analyzed mods to .dmm.json and hydrate mod repository from manifest on profile load

--- a/.changeset/dull-falcons-attack.md
+++ b/.changeset/dull-falcons-attack.md
@@ -1,5 +1,0 @@
----
-"@deadlock-mods/desktop": patch
----
-
-fixed nvidia GPU compatability on x11

--- a/.changeset/fix-profile-vpk-state.md
+++ b/.changeset/fix-profile-vpk-state.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix profile VPK manifest state drift and audio preview playback clicks.

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::errors::Error;
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use crate::mod_manager::{Mod, ModFileTree};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
@@ -575,21 +576,22 @@ pub async fn register_analyzed_mod(
   mod_id: String,
   mod_name: String,
   installed_vpks: Vec<String>,
+  profile_folder: Option<String>,
 ) -> Result<(), Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
 
   if mod_manager.get_mod_repository().get_mod(&mod_id).is_none() {
     log::info!(
-      "Registering analyzed mod in repository: {} ({}) with {} VPKs",
+      "Registering analyzed mod in repository: {} ({}) with {} VPKs (profile: {profile_folder:?})",
       mod_name,
       mod_id,
       installed_vpks.len()
     );
     let deadlock_mod = Mod {
-      id: mod_id,
+      id: mod_id.clone(),
       name: mod_name,
       is_map: false,
-      installed_vpks,
+      installed_vpks: installed_vpks.clone(),
       file_tree: None,
       install_order: None,
       original_vpk_names: Vec::new(),
@@ -597,6 +599,14 @@ pub async fn register_analyzed_mod(
     mod_manager.get_mod_repository_mut().add_mod(deadlock_mod);
   } else {
     log::debug!("Mod {} already registered in repository, skipping", mod_id);
+  }
+
+  let addons_path = mod_manager.get_addons_path(profile_folder.as_deref())?;
+  let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+  if !manifest.mods.contains_key(&mod_id) {
+    manifest.mark_enabled(&mod_id, installed_vpks, Vec::new(), None);
+    manifest.save(&addons_path)?;
+    log::info!("Persisted analyzed mod {mod_id} to profile manifest");
   }
 
   Ok(())

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -1,6 +1,8 @@
 use crate::download_manager::DownloadTask;
 use crate::errors::Error;
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use crate::mod_manager::Mod;
+use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager};
 
 use super::downloads::get_download_manager;
@@ -555,4 +557,68 @@ pub async fn import_profile_batch(
     failed,
     installed_mods,
   })
+}
+
+#[tauri::command]
+pub async fn get_profile_vpk_manifest(
+  profile_folder: Option<String>,
+) -> Result<ProfileVpkManifest, Error> {
+  log::info!("Getting VPK manifest for profile: {profile_folder:?}");
+
+  let mod_manager = MANAGER.lock().unwrap();
+  mod_manager.get_profile_vpk_manifest(profile_folder)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedManifestEntry {
+  pub mod_id: String,
+  pub enabled: bool,
+  #[serde(default)]
+  pub current_vpks: Vec<String>,
+  #[serde(default)]
+  pub disabled_vpks: Vec<String>,
+  #[serde(default)]
+  pub original_vpk_names: Vec<String>,
+  #[serde(default)]
+  pub order: Option<u32>,
+}
+
+#[tauri::command]
+pub async fn seed_profile_vpk_manifest_entries(
+  profile_folder: Option<String>,
+  entries: Vec<SeedManifestEntry>,
+) -> Result<(), Error> {
+  log::info!(
+    "Seeding VPK manifest for profile {profile_folder:?} with {} entries",
+    entries.len()
+  );
+
+  let mod_manager = MANAGER.lock().unwrap();
+  let addons_path = mod_manager.get_addons_path(profile_folder.as_deref())?;
+  let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+  let mut changed = false;
+
+  for entry in entries {
+    if manifest.mods.contains_key(&entry.mod_id) {
+      continue;
+    }
+    if entry.enabled {
+      manifest.mark_enabled(
+        &entry.mod_id,
+        entry.current_vpks,
+        entry.original_vpk_names,
+        entry.order,
+      );
+    } else {
+      manifest.mark_disabled(&entry.mod_id, entry.disabled_vpks, entry.original_vpk_names);
+    }
+    changed = true;
+  }
+
+  if changed {
+    manifest.save(&addons_path)?;
+  }
+
+  Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -565,8 +565,17 @@ pub async fn get_profile_vpk_manifest(
 ) -> Result<ProfileVpkManifest, Error> {
   log::info!("Getting VPK manifest for profile: {profile_folder:?}");
 
-  let mod_manager = MANAGER.lock().unwrap();
+  let mut mod_manager = MANAGER.lock().unwrap();
+  mod_manager.hydrate_mods_from_manifest(profile_folder.clone())?;
   mod_manager.get_profile_vpk_manifest(profile_folder)
+}
+
+#[tauri::command]
+pub async fn hydrate_mods_from_manifest(
+  profile_folder: Option<String>,
+) -> Result<usize, Error> {
+  let mut mod_manager = MANAGER.lock().unwrap();
+  mod_manager.hydrate_mods_from_manifest(profile_folder)
 }
 
 #[derive(Debug, Deserialize)]

--- a/apps/desktop/src-tauri/src/errors.rs
+++ b/apps/desktop/src-tauri/src/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
   Rar(#[from] unrar::error::UnrarError),
   #[error(transparent)]
   Zip(#[from] zip::result::ZipError),
-  #[error("Mod is invalid")]
+  #[error("Mod is invalid: {0}")]
   ModInvalid(String),
   #[error("Game is running")]
   GameRunning,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -188,6 +188,7 @@ pub fn run() {
       commands::downloads::download_custom_provider_mod,
       commands::profiles::get_profile_installed_vpks,
       commands::profiles::get_profile_vpk_manifest,
+      commands::profiles::hydrate_mods_from_manifest,
       commands::profiles::seed_profile_vpk_manifest_entries,
       commands::profiles::delete_profile_vpk,
       commands::profiles::show_profile_vpk_in_folder,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -187,6 +187,8 @@ pub fn run() {
       commands::server_profiles::cleanup_stale_server_gameinfo,
       commands::downloads::download_custom_provider_mod,
       commands::profiles::get_profile_installed_vpks,
+      commands::profiles::get_profile_vpk_manifest,
+      commands::profiles::seed_profile_vpk_manifest_entries,
       commands::profiles::delete_profile_vpk,
       commands::profiles::show_profile_vpk_in_folder,
       commands::profiles::import_profile_batch,

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -768,6 +768,47 @@ impl ModManager {
     ProfileVpkManifest::load(&addons_path)
   }
 
+  pub fn hydrate_mods_from_manifest(
+    &mut self,
+    profile_folder: Option<String>,
+  ) -> Result<usize, Error> {
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
+    let manifest = ProfileVpkManifest::load(&addons_path)?;
+
+    let mut hydrated = 0usize;
+    for (mod_id, entry) in &manifest.mods {
+      if self.mod_repository.get_mod(mod_id).is_some() {
+        continue;
+      }
+
+      let installed_vpks = if entry.enabled {
+        entry.current_vpks.clone()
+      } else {
+        Vec::new()
+      };
+
+      let deadlock_mod = Mod {
+        id: mod_id.clone(),
+        name: mod_id.clone(),
+        is_map: false,
+        installed_vpks,
+        file_tree: None,
+        install_order: entry.order,
+        original_vpk_names: entry.original_vpk_names.clone(),
+      };
+      self.mod_repository.add_mod(deadlock_mod);
+      hydrated += 1;
+    }
+
+    if hydrated > 0 {
+      log::info!(
+        "Hydrated {hydrated} mods from manifest for profile {profile_folder:?}"
+      );
+    }
+
+    Ok(hydrated)
+  }
+
   /// Replace VPK files for a mod
   pub fn replace_mod_vpks(
     &mut self,
@@ -821,10 +862,15 @@ impl ModManager {
       .collect();
 
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-    if manifest.mods.contains_key(&mod_id) {
+    if installed_vpks.is_empty() {
+      let prefixed_vpks = self
+        .vpk_manager
+        .find_prefixed_vpks(&addons_path, &mod_id)?;
+      manifest.mark_disabled(&mod_id, prefixed_vpks, new_original_names);
+    } else {
       manifest.mark_enabled(&mod_id, installed_vpks, new_original_names, None);
-      manifest.save(&addons_path)?;
     }
+    manifest.save(&addons_path)?;
 
     log::info!("Successfully replaced VPK files for mod: {mod_id}");
     Ok(())

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -9,10 +9,16 @@ use crate::mod_manager::{
   mod_repository::{Mod, ModRepository},
   steam_manager::SteamManager,
   vpk_manager::VpkManager,
+  vpk_manifest::ProfileVpkManifest,
 };
 use log;
-use std::path::PathBuf;
+use std::{
+  collections::HashSet,
+  path::{Component, Path, PathBuf},
+};
 use tauri::Manager;
+
+const UNORDERED_FALLBACK_ORDER: u32 = u32::MAX;
 
 pub struct ModManager {
   steam_manager: SteamManager,
@@ -68,6 +74,45 @@ impl ModManager {
 
   pub fn is_game_running(&mut self) -> Result<bool, Error> {
     self.process_manager.is_game_running()
+  }
+
+  pub(crate) fn get_addons_path(&self, profile_folder: Option<&str>) -> Result<PathBuf, Error> {
+    let game_path = self
+      .steam_manager
+      .get_game_path()
+      .ok_or(Error::GamePathNotSet)?;
+
+    let addons_path = game_path.join("game").join("citadel").join("addons");
+    Ok(match profile_folder {
+      Some(folder) => {
+        if !Self::is_safe_profile_folder(folder) {
+          return Err(Error::InvalidInput(format!(
+            "Invalid profile folder path: {folder}"
+          )));
+        }
+        addons_path.join(folder)
+      }
+      None => addons_path,
+    })
+  }
+
+  fn is_safe_profile_folder(folder: &str) -> bool {
+    !folder.is_empty()
+      && Path::new(folder)
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+  }
+
+  fn vpk_filenames(vpks: &[String]) -> Vec<String> {
+    vpks
+      .iter()
+      .map(|vpk| {
+        std::path::Path::new(vpk)
+          .file_name()
+          .map(|f| f.to_string_lossy().to_string())
+          .unwrap_or_else(|| vpk.clone())
+      })
+      .collect()
   }
 
   pub fn stop_game(&mut self) -> Result<(), Error> {
@@ -147,20 +192,7 @@ impl ModManager {
       self.setup_game_for_mods()?;
     }
 
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     // Find prefixed VPKs in addons (mod is downloaded but not enabled)
     let mut prefixed_vpks = self
@@ -236,6 +268,15 @@ impl ModManager {
     log::info!("Adding mod to managed mods list");
     self.mod_repository.add_mod(deadlock_mod.clone());
 
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    manifest.mark_enabled(
+      &deadlock_mod.id,
+      deadlock_mod.installed_vpks.clone(),
+      deadlock_mod.original_vpk_names.clone(),
+      deadlock_mod.install_order,
+    );
+    manifest.save(&addons_path)?;
+
     // If the mod has an install order, trigger a reorder to maintain correct sequence
     if deadlock_mod.install_order.is_some() {
       log::info!("Mod has install order, triggering reorder to maintain sequence");
@@ -254,62 +295,72 @@ impl ModManager {
   ) -> Result<(), Error> {
     log::info!("Uninstalling (disabling) mod: {mod_id} (profile: {profile_folder:?})");
 
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     if !addons_path.exists() {
       return Err(Error::GamePathNotSet);
     }
 
-    if let Some(mut local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
-      log::info!("Mod found in memory: {}", local_mod.name);
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    let manifest_entry = manifest.mods.get(&mod_id).cloned();
 
-      let prefixed_vpks = self.vpk_manager.disable_vpks(
-        &addons_path,
-        &mod_id,
-        &local_mod.installed_vpks,
-        &local_mod.original_vpk_names,
-      )?;
-
-      // Update mod state to track prefixed VPKs
-      local_mod.installed_vpks = Vec::new();
-      self.mod_repository.add_mod(local_mod);
-
-      log::info!(
-        "Disabled mod {mod_id} with {} prefixed VPKs",
-        prefixed_vpks.len()
-      );
+    let (installed_vpks, original_vpk_names) = if let Some(entry) = manifest_entry.as_ref()
+      && !entry.current_vpks.is_empty()
+    {
+      log::info!("Using manifest VPK state for mod {mod_id}");
+      (
+        entry.current_vpks.clone(),
+        if entry.original_vpk_names.is_empty() {
+          entry.current_vpks.clone()
+        } else {
+          entry.original_vpk_names.clone()
+        },
+      )
     } else if !vpks.is_empty() {
-      log::warn!("Mod not found in repository, disabling VPKs directly");
-      // VPKs from local analysis may be full paths; extract just filenames for disable_vpks
-      let vpk_filenames: Vec<String> = vpks
-        .iter()
-        .map(|v| {
-          std::path::Path::new(v)
-            .file_name()
-            .map(|f| f.to_string_lossy().to_string())
-            .unwrap_or_else(|| v.clone())
-        })
-        .collect();
+      log::warn!("Manifest has no enabled VPKs for {mod_id}, using frontend VPK state");
+      let vpk_filenames = Self::vpk_filenames(&vpks);
+      (vpk_filenames.clone(), vpk_filenames)
+    } else if let Some(local_mod) = self.mod_repository.get_mod(&mod_id)
+      && !local_mod.installed_vpks.is_empty()
+    {
+      log::warn!("Manifest has no enabled VPKs for {mod_id}, using in-memory repository state");
+      (
+        local_mod.installed_vpks.clone(),
+        if local_mod.original_vpk_names.is_empty() {
+          local_mod.installed_vpks.clone()
+        } else {
+          local_mod.original_vpk_names.clone()
+        },
+      )
+    } else if manifest_entry
+      .as_ref()
+      .is_some_and(|entry| !entry.enabled && !entry.disabled_vpks.is_empty())
+    {
+      log::info!("Mod {mod_id} is already disabled according to the profile manifest");
+      return Ok(());
+    } else {
+      return Err(Error::ModInvalid(format!(
+        "Cannot disable mod {mod_id}: no enabled VPK files are recorded for this profile"
+      )));
+    };
+
+    let prefixed_vpks =
       self
         .vpk_manager
-        .disable_vpks(&addons_path, &mod_id, &vpk_filenames, &vpk_filenames)?;
-      log::info!("Disabled {} VPKs for mod {mod_id}", vpk_filenames.len());
-    } else {
-      log::warn!("Mod not found in repository and no VPKs provided");
+        .disable_vpks(&addons_path, &mod_id, &installed_vpks, &original_vpk_names)?;
+
+    manifest.mark_disabled(&mod_id, prefixed_vpks.clone(), original_vpk_names);
+    manifest.save(&addons_path)?;
+
+    if let Some(mut local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
+      local_mod.installed_vpks = Vec::new();
+      self.mod_repository.add_mod(local_mod);
     }
+
+    log::info!(
+      "Disabled mod {mod_id} with {} prefixed VPKs",
+      prefixed_vpks.len()
+    );
 
     Ok(())
   }
@@ -322,20 +373,13 @@ impl ModManager {
   ) -> Result<(), Error> {
     log::info!("Purging mod: {mod_id} (profile: {profile_folder:?})");
 
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    let mut vpks_to_remove = manifest
+      .mods
+      .get(&mod_id)
+      .map(|entry| entry.current_vpks.clone())
+      .unwrap_or_default();
 
     if !addons_path.exists() {
       return Err(Error::GamePathNotSet);
@@ -343,22 +387,25 @@ impl ModManager {
 
     if let Some(local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
       log::info!("Mod found in memory: {}", local_mod.name);
-
-      if !local_mod.installed_vpks.is_empty() {
-        self
-          .vpk_manager
-          .remove_vpks(&local_mod.installed_vpks, addons_path.as_path())?;
-      }
-
-      self
-        .vpk_manager
-        .remove_vpks_by_mod_id(addons_path.as_path(), &mod_id)?;
+      vpks_to_remove.extend(local_mod.installed_vpks);
     } else {
-      self.vpk_manager.remove_vpks(&vpks, &addons_path)?;
+      vpks_to_remove.extend(vpks);
+    }
+
+    let mut seen_vpks = HashSet::new();
+    vpks_to_remove.retain(|vpk| seen_vpks.insert(vpk.clone()));
+
+    if !vpks_to_remove.is_empty() {
       self
         .vpk_manager
-        .remove_vpks_by_mod_id(&addons_path, &mod_id)?;
+        .remove_vpks(&vpks_to_remove, &addons_path)?;
     }
+    self
+      .vpk_manager
+      .remove_vpks_by_mod_id(&addons_path, &mod_id)?;
+
+    manifest.remove_mod(&mod_id);
+    manifest.save(&addons_path)?;
 
     self.mod_repository.remove_mod(&mod_id);
 
@@ -377,42 +424,53 @@ impl ModManager {
 
   /// Reorder all mods based on their current install_order for a specific profile
   fn reorder_all_mods_for_profile(&mut self, profile_folder: Option<String>) -> Result<(), Error> {
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     log::info!("Reordering all mods based on install order for profile: {profile_folder:?}");
 
-    let mut ordered_mods: Vec<Mod> = self.mod_repository.get_all_mods().cloned().collect();
-    ordered_mods.sort_by_key(|mod_entry| mod_entry.install_order.unwrap_or(999));
-
-    // Create mapping for reordering
-    let mod_vpk_mapping: Vec<(String, Vec<String>)> = ordered_mods
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    let mut ordered_manifest_entries: Vec<(String, u32, Vec<String>)> = manifest
+      .mods
       .iter()
-      .map(|mod_entry| (mod_entry.id.clone(), mod_entry.installed_vpks.clone()))
+      .filter(|(_, entry)| entry.enabled && !entry.current_vpks.is_empty())
+      .map(|(mod_id, entry)| {
+        (
+          mod_id.clone(),
+          entry.order.unwrap_or(UNORDERED_FALLBACK_ORDER),
+          entry.current_vpks.clone(),
+        )
+      })
+      .collect();
+    ordered_manifest_entries.sort_by_key(|(_, order, _)| *order);
+
+    let mod_vpk_mapping: Vec<(String, Vec<String>)> = ordered_manifest_entries
+      .into_iter()
+      .map(|(mod_id, _, vpks)| (mod_id, vpks))
       .collect();
 
-    // Reorder the VPK files
+    if mod_vpk_mapping.is_empty() {
+      log::info!("No enabled manifest VPKs need reordering");
+      return Ok(());
+    }
+
     let updated_vpk_mappings = self
       .vpk_manager
       .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
 
-    // Update mod data with new VPK names
-    for (mut mod_entry, (_, new_vpk_names)) in ordered_mods.into_iter().zip(updated_vpk_mappings) {
-      mod_entry.installed_vpks = new_vpk_names;
-      self.mod_repository.add_mod(mod_entry); // This will replace the existing mod
+    for (mod_id, new_vpk_names) in updated_vpk_mappings {
+      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
+        entry.enabled = true;
+        entry.current_vpks = new_vpk_names.clone();
+        entry.disabled_vpks.clear();
+      }
+
+      if let Some(mut mod_entry) = self.mod_repository.remove_mod(&mod_id) {
+        mod_entry.installed_vpks = new_vpk_names;
+        self.mod_repository.add_mod(mod_entry);
+      }
     }
+
+    manifest.save(&addons_path)?;
 
     log::info!("All mods reordered successfully");
     Ok(())
@@ -424,20 +482,7 @@ impl ModManager {
     mod_order_data: Vec<(String, Vec<String>, u32)>, // (remote_id, current_vpks, order)
     profile_folder: Option<String>,
   ) -> Result<Vec<(String, Vec<String>)>, Error> {
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     log::info!(
       "Reordering mods by remote ID for {} mods in profile: {:?}",
@@ -454,7 +499,7 @@ impl ModManager {
     let mut sorted_data = mod_order_data;
     sorted_data.sort_by_key(|(_, _, order)| *order);
 
-    sorted_data.retain(|(remote_id, _, _)| self.mod_repository.get_mod(remote_id).is_some());
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
 
     // Log the sorted data
     log::info!("Sorted order:");
@@ -462,11 +507,35 @@ impl ModManager {
       log::info!("Position {i}: mod {remote_id} (order {order}) with VPKs: {vpks:?}");
     }
 
-    // Create mapping for VPK reordering: (identifier, vpk_files)
-    let mod_vpk_mapping: Vec<(String, Vec<String>)> = sorted_data
-      .into_iter()
-      .map(|(remote_id, vpk_files, _)| (remote_id, vpk_files))
-      .collect();
+    let mut mod_vpk_mapping = Vec::new();
+    let mut manifest_changed = false;
+    for (remote_id, vpk_files, order) in sorted_data {
+      let vpk_files = Self::vpk_filenames(&vpk_files);
+      let was_known = manifest.mods.contains_key(&remote_id);
+      let entry = manifest.mods.entry(remote_id.clone()).or_default();
+      if entry.order != Some(order) {
+        entry.order = Some(order);
+        manifest_changed = true;
+      }
+
+      if !was_known && !vpk_files.is_empty() {
+        entry.enabled = true;
+        entry.current_vpks = vpk_files;
+        manifest_changed = true;
+      }
+
+      if entry.enabled && !entry.current_vpks.is_empty() {
+        mod_vpk_mapping.push((remote_id, entry.current_vpks.clone()));
+      }
+    }
+
+    if mod_vpk_mapping.is_empty() {
+      if manifest_changed {
+        manifest.save(&addons_path)?;
+      }
+      log::warn!("No enabled VPK mappings available to reorder");
+      return Ok(Vec::new());
+    }
 
     // Reorder the VPK files and get the updated mappings
     let updated_mappings = self
@@ -474,11 +543,19 @@ impl ModManager {
       .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
 
     for (remote_id, new_vpks) in &updated_mappings {
+      if let Some(entry) = manifest.mods.get_mut(remote_id) {
+        entry.enabled = true;
+        entry.current_vpks = new_vpks.clone();
+        entry.disabled_vpks.clear();
+      }
+
       if let Some(mut mod_entry) = self.mod_repository.remove_mod(remote_id) {
         mod_entry.installed_vpks = new_vpks.clone();
         self.mod_repository.add_mod(mod_entry);
       }
     }
+
+    manifest.save(&addons_path)?;
 
     log::info!("Mod reordering by remote ID completed successfully");
     Ok(updated_mappings)
@@ -490,20 +567,7 @@ impl ModManager {
     mod_order_data: Vec<(String, u32)>,
     profile_folder: Option<String>,
   ) -> Result<Vec<Mod>, Error> {
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     log::info!(
       "Reordering {} mods for profile: {profile_folder:?}",
@@ -514,21 +578,39 @@ impl ModManager {
     let mut sorted_order = mod_order_data;
     sorted_order.sort_by_key(|(_, order)| *order);
 
-    // Create mapping of mod_id -> vpk_files for reordering
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     let mut mod_vpk_mapping = Vec::new();
     let mut updated_mods = Vec::new();
+    let mut manifest_changed = false;
 
     for (mod_id, new_order) in sorted_order {
-      if let Some(mut deadlock_mod) = self.mod_repository.remove_mod(&mod_id) {
-        // Update the install order
-        deadlock_mod.install_order = Some(new_order);
+      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
+        if entry.order != Some(new_order) {
+          entry.order = Some(new_order);
+          manifest_changed = true;
+        }
+        if entry.enabled && !entry.current_vpks.is_empty() {
+          mod_vpk_mapping.push((mod_id.clone(), entry.current_vpks.clone()));
+        }
+      }
 
-        // Add to mapping for VPK reordering
-        mod_vpk_mapping.push((mod_id.clone(), deadlock_mod.installed_vpks.clone()));
+      if let Some(mut deadlock_mod) = self.mod_repository.remove_mod(&mod_id) {
+        deadlock_mod.install_order = Some(new_order);
         updated_mods.push(deadlock_mod);
       } else {
-        log::warn!("Mod not found in repository: {mod_id}");
+        log::debug!("Mod {mod_id} not found in in-memory repository while reordering");
       }
+    }
+
+    if mod_vpk_mapping.is_empty() {
+      if manifest_changed {
+        manifest.save(&addons_path)?;
+      }
+      for deadlock_mod in updated_mods {
+        self.mod_repository.add_mod(deadlock_mod);
+      }
+      log::warn!("No enabled manifest VPKs available to reorder");
+      return Ok(Vec::new());
     }
 
     // Reorder the VPK files
@@ -538,52 +620,44 @@ impl ModManager {
 
     // Update mod data with new VPK names and re-add to repository
     let mut result_mods = Vec::new();
-    for (mut deadlock_mod, (_, new_vpk_names)) in updated_mods.into_iter().zip(updated_vpk_mappings)
-    {
-      deadlock_mod.installed_vpks = new_vpk_names;
-      self.mod_repository.add_mod(deadlock_mod.clone());
-      result_mods.push(deadlock_mod);
+    for (mod_id, new_vpk_names) in updated_vpk_mappings {
+      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
+        entry.enabled = true;
+        entry.current_vpks = new_vpk_names.clone();
+        entry.disabled_vpks.clear();
+      }
+
+      if let Some(index) = updated_mods
+        .iter()
+        .position(|mod_entry| mod_entry.id == mod_id)
+      {
+        let mut deadlock_mod = updated_mods.remove(index);
+        deadlock_mod.installed_vpks = new_vpk_names;
+        self.mod_repository.add_mod(deadlock_mod.clone());
+        result_mods.push(deadlock_mod);
+      }
     }
+
+    for deadlock_mod in updated_mods {
+      self.mod_repository.add_mod(deadlock_mod);
+    }
+
+    manifest.save(&addons_path)?;
 
     log::info!("Successfully reordered {} mods", result_mods.len());
     Ok(result_mods)
   }
 
   pub fn clear_mods(&mut self, profile_folder: Option<String>) -> Result<(), Error> {
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     self.vpk_manager.clear_all_vpks(&addons_path)?;
+    ProfileVpkManifest::default().save(&addons_path)?;
     Ok(())
   }
 
   pub fn open_mods_folder(&self, profile_folder: Option<String>) -> Result<(), Error> {
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     self
       .filesystem
@@ -686,6 +760,14 @@ impl ModManager {
     Ok(app_local_data_dir.join("mods"))
   }
 
+  pub fn get_profile_vpk_manifest(
+    &self,
+    profile_folder: Option<String>,
+  ) -> Result<ProfileVpkManifest, Error> {
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
+    ProfileVpkManifest::load(&addons_path)
+  }
+
   /// Replace VPK files for a mod
   pub fn replace_mod_vpks(
     &mut self,
@@ -697,23 +779,16 @@ impl ModManager {
     log::info!("Replacing VPK files for mod: {mod_id} (profile: {profile_folder:?})");
     log::info!("Installed VPKs from frontend: {installed_vpks_from_frontend:?}");
 
-    let game_path = self
-      .steam_manager
-      .get_game_path()
-      .ok_or(Error::GamePathNotSet)?;
-
-    let addons_path = if let Some(ref folder) = profile_folder {
-      game_path
-        .join("game")
-        .join("citadel")
-        .join("addons")
-        .join(folder)
-    } else {
-      game_path.join("game").join("citadel").join("addons")
-    };
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
 
     // Use VPK info from frontend first, then try repository, then look for prefixed VPKs
-    let (installed_vpks, original_names) = if !installed_vpks_from_frontend.is_empty() {
+    let manifest = ProfileVpkManifest::load(&addons_path)?;
+    let (installed_vpks, original_names) = if let Some(entry) = manifest.mods.get(&mod_id)
+      && !entry.current_vpks.is_empty()
+    {
+      log::info!("Using manifest VPKs for replacement");
+      (entry.current_vpks.clone(), entry.original_vpk_names.clone())
+    } else if !installed_vpks_from_frontend.is_empty() {
       log::info!("Using installed VPKs from frontend");
       (installed_vpks_from_frontend, Vec::new())
     } else if let Some(mod_info) = self.mod_repository.get_mod(&mod_id) {
@@ -739,6 +814,17 @@ impl ModManager {
       &installed_vpks,
       &original_names,
     )?;
+
+    let new_original_names: Vec<String> = source_vpk_paths
+      .iter()
+      .filter_map(|p| p.file_name().map(|f| f.to_string_lossy().to_string()))
+      .collect();
+
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    if manifest.mods.contains_key(&mod_id) {
+      manifest.mark_enabled(&mod_id, installed_vpks, new_original_names, None);
+      manifest.save(&addons_path)?;
+    }
 
     log::info!("Successfully replaced VPK files for mod: {mod_id}");
     Ok(())
@@ -868,4 +954,24 @@ fn dir_size(path: &std::path::Path) -> u64 {
         .sum()
     })
     .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::ModManager;
+
+  #[test]
+  fn profile_folder_validation_rejects_path_escape_components() {
+    assert!(ModManager::is_safe_profile_folder("profile_123"));
+    assert!(ModManager::is_safe_profile_folder("server_abc"));
+    assert!(ModManager::is_safe_profile_folder("profiles/imported"));
+
+    assert!(!ModManager::is_safe_profile_folder(""));
+    assert!(!ModManager::is_safe_profile_folder("."));
+    assert!(!ModManager::is_safe_profile_folder("../profile_123"));
+    assert!(!ModManager::is_safe_profile_folder("/tmp/profile_123"));
+
+    #[cfg(windows)]
+    assert!(!ModManager::is_safe_profile_folder("C:\\tmp\\profile_123"));
+  }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod.rs
@@ -21,4 +21,3 @@ pub use file_tree::ModFileTree;
 pub use font_manager::{FontInfo, FontManager};
 pub use manager::ModManager;
 pub use mod_repository::Mod;
-pub use vpk_manifest::ProfileVpkManifest;

--- a/apps/desktop/src-tauri/src/mod_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod.rs
@@ -12,6 +12,7 @@ pub mod manager;
 pub mod mod_repository;
 pub mod steam_manager;
 pub mod vpk_manager;
+pub mod vpk_manifest;
 
 pub use addon_analyzer::{AddonAnalyzer, AnalyzeAddonsResult};
 pub use addons_backup_manager::AddonsBackup;
@@ -20,3 +21,4 @@ pub use file_tree::ModFileTree;
 pub use font_manager::{FontInfo, FontManager};
 pub use manager::ModManager;
 pub use mod_repository::Mod;
+pub use vpk_manifest::ProfileVpkManifest;

--- a/apps/desktop/src-tauri/src/mod_manager/mod_repository.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod_repository.rs
@@ -45,11 +45,6 @@ impl ModRepository {
   pub fn get_mod(&self, mod_id: &str) -> Option<&Mod> {
     self.mods.get(mod_id)
   }
-
-  /// Get all mods as an iterator
-  pub fn get_all_mods(&self) -> impl Iterator<Item = &Mod> {
-    self.mods.values()
-  }
 }
 
 impl Default for ModRepository {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -4,6 +4,7 @@ use log;
 use regex::Regex;
 use std::fs;
 use std::path::Path;
+use std::sync::LazyLock;
 
 /// Manages VPK file operations and installation
 pub struct VpkManager {
@@ -22,7 +23,6 @@ impl VpkManager {
       return Ok(1);
     }
 
-    let vpk_pattern = Regex::new(r"pak(\d+)_dir\.vpk").unwrap();
     let mut used_numbers = std::collections::HashSet::new();
 
     for entry in fs::read_dir(addons_path)? {
@@ -32,8 +32,7 @@ impl VpkManager {
       if path.is_file()
         && path.extension().is_some_and(|ext| ext == "vpk")
         && let Some(name) = path.file_name().and_then(|n| n.to_str())
-        && let Some(captures) = vpk_pattern.captures(name)
-        && let Ok(num) = captures[1].parse::<u32>()
+        && let Some(num) = Self::enabled_vpk_number(name)
       {
         used_numbers.insert(num);
       }
@@ -62,6 +61,23 @@ impl VpkManager {
 
     log::info!("Starting VPK reordering for {} mods", mod_vpk_mapping.len());
 
+    let mut missing_vpks = Vec::new();
+    for (mod_id, old_vpk_names) in mod_vpk_mapping {
+      for old_vpk_name in old_vpk_names {
+        let filename = Self::vpk_filename(old_vpk_name);
+        if !addons_path.join(&filename).exists() {
+          missing_vpks.push(format!("{mod_id}:{filename}"));
+        }
+      }
+    }
+
+    if !missing_vpks.is_empty() {
+      return Err(Error::ModInvalid(format!(
+        "Cannot reorder mods because enabled VPK files are missing: {}",
+        missing_vpks.join(", ")
+      )));
+    }
+
     // Create a temporary directory for safe reordering
     let temp_dir = addons_path.join("temp_reorder");
     if temp_dir.exists() {
@@ -73,8 +89,8 @@ impl VpkManager {
 
     let mut updated_mappings = Vec::new();
 
-    // Step 1: Move enabled VPK files to temporary directory, skip disabled (prefixed) VPKs
-    // Disabled VPKs use the format `{mod_id}_{original_name}.vpk` and should not be touched
+    // Step 1: Move enabled pak##_dir.vpk files to the temporary directory.
+    // Disabled prefixed VPKs and unmanaged files should not be touched.
     if addons_path.exists() {
       for entry in std::fs::read_dir(addons_path)? {
         let entry = entry?;
@@ -84,8 +100,8 @@ impl VpkManager {
           && path.extension().is_some_and(|ext| ext == "vpk")
           && let Some(filename) = path.file_name().and_then(|n| n.to_str())
         {
-          if Self::extract_mod_id_from_prefix(filename).is_some() {
-            log::debug!("Skipping disabled (prefixed) VPK during reorder: {filename}");
+          if !Self::is_enabled_vpk_name(filename) {
+            log::debug!("Skipping non-enabled VPK during reorder: {filename}");
             continue;
           }
 
@@ -105,11 +121,7 @@ impl VpkManager {
       // For each VPK this mod should have, find the specific VPK file in temp
       for old_vpk_name in old_vpk_names {
         // Extract just the filename from the full path
-        let filename = if let Some(filename) = std::path::Path::new(&old_vpk_name).file_name() {
-          filename.to_string_lossy().to_string()
-        } else {
-          old_vpk_name.clone()
-        };
+        let filename = Self::vpk_filename(old_vpk_name);
 
         let temp_vpk_path = temp_dir.join(&filename);
 
@@ -466,20 +478,38 @@ impl VpkManager {
       return Ok(Vec::new());
     }
 
+    if original_names.len() != installed_vpks.len() {
+      return Err(Error::ModInvalid(format!(
+        "Cannot disable mod because original VPK name count ({}) does not match installed VPK count ({})",
+        original_names.len(),
+        installed_vpks.len()
+      )));
+    }
+
+    let missing_vpks: Vec<String> = installed_vpks
+      .iter()
+      .map(|vpk_name| Self::vpk_filename(vpk_name))
+      .filter(|vpk_name| !addons_path.join(vpk_name).exists())
+      .collect();
+
+    if !missing_vpks.is_empty() {
+      return Err(Error::ModInvalid(format!(
+        "Cannot disable mod because enabled VPK files are missing: {}",
+        missing_vpks.join(", ")
+      )));
+    }
+
     // Track successful renames so we can roll back on partial failure
     let mut renamed: Vec<(String, String)> = Vec::new();
 
     for (index, vpk_name) in installed_vpks.iter().enumerate() {
-      let old_path = addons_path.join(vpk_name);
-      if !old_path.exists() {
-        log::warn!("Installed VPK not found: {vpk_name}");
-        continue;
-      }
+      let vpk_name = Self::vpk_filename(vpk_name);
+      let old_path = addons_path.join(&vpk_name);
 
       let original_name = original_names
         .get(index)
         .map(|s| s.as_str())
-        .unwrap_or("addon.vpk");
+        .expect("original_names length is validated before disabling VPKs");
 
       let prefixed_name = format!("{mod_id}_{original_name}");
       let new_path = addons_path.join(&prefixed_name);
@@ -523,13 +553,43 @@ impl VpkManager {
 
   /// Extract mod ID from a prefixed VPK filename
   pub fn extract_mod_id_from_prefix(filename: &str) -> Option<String> {
+    if Self::is_enabled_vpk_name(filename) {
+      return None;
+    }
+
     if let Some(underscore_pos) = filename.find('_') {
       let potential_id = &filename[..underscore_pos];
-      if potential_id.chars().all(|c| c.is_ascii_digit()) {
+      if !potential_id.is_empty()
+        && (potential_id.chars().all(|c| c.is_ascii_digit()) || potential_id.starts_with("local-"))
+      {
         return Some(potential_id.to_string());
       }
     }
     None
+  }
+
+  fn is_enabled_vpk_name(filename: &str) -> bool {
+    Self::enabled_vpk_number(filename).is_some()
+  }
+
+  fn enabled_vpk_number(filename: &str) -> Option<u32> {
+    static ENABLED_VPK_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+      Regex::new(r"^pak(\d+)_dir\.vpk$").expect("enabled VPK regex must be valid")
+    });
+
+    ENABLED_VPK_PATTERN
+      .captures(filename)?
+      .get(1)?
+      .as_str()
+      .parse()
+      .ok()
+  }
+
+  fn vpk_filename(vpk_name: &str) -> String {
+    std::path::Path::new(vpk_name)
+      .file_name()
+      .map(|f| f.to_string_lossy().to_string())
+      .unwrap_or_else(|| vpk_name.to_string())
   }
 
   /// Replace VPK files for a mod with new ones
@@ -644,5 +704,94 @@ impl VpkManager {
 impl Default for VpkManager {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::fs;
+
+  fn write_vpk(addons_path: &std::path::Path, name: &str) {
+    fs::write(addons_path.join(name), b"test vpk").unwrap();
+  }
+
+  #[test]
+  fn detects_disabled_local_mod_prefixes() {
+    assert_eq!(
+      VpkManager::extract_mod_id_from_prefix("local-abc-123_mod.vpk"),
+      Some("local-abc-123".to_string())
+    );
+    assert_eq!(
+      VpkManager::extract_mod_id_from_prefix("123456_mod.vpk"),
+      Some("123456".to_string())
+    );
+    assert_eq!(
+      VpkManager::extract_mod_id_from_prefix("pak01_dir.vpk"),
+      None
+    );
+  }
+
+  #[test]
+  fn reorder_keeps_disabled_local_vpks_disabled() {
+    let temp = tempfile::tempdir().unwrap();
+    let addons_path = temp.path();
+    write_vpk(addons_path, "pak01_dir.vpk");
+    write_vpk(addons_path, "local-abc-123_original.vpk");
+
+    let manager = VpkManager::new();
+    let updated = manager
+      .reorder_vpks(
+        &[("123456".to_string(), vec!["pak01_dir.vpk".to_string()])],
+        addons_path,
+      )
+      .unwrap();
+
+    assert_eq!(
+      updated,
+      vec![("123456".to_string(), vec!["pak01_dir.vpk".to_string()])]
+    );
+    assert!(addons_path.join("local-abc-123_original.vpk").exists());
+    assert!(!addons_path.join("pak02_dir.vpk").exists());
+  }
+
+  #[test]
+  fn disable_errors_when_enabled_vpk_is_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    let manager = VpkManager::new();
+
+    let err = manager
+      .disable_vpks(
+        temp.path(),
+        "123456",
+        &["pak01_dir.vpk".to_string()],
+        &["original.vpk".to_string()],
+      )
+      .unwrap_err();
+
+    assert!(err.to_string().contains("enabled VPK files are missing"));
+  }
+
+  #[test]
+  fn disable_errors_when_original_name_count_does_not_match() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "pak01_dir.vpk");
+    write_vpk(temp.path(), "pak02_dir.vpk");
+    let manager = VpkManager::new();
+
+    let err = manager
+      .disable_vpks(
+        temp.path(),
+        "123456",
+        &["pak01_dir.vpk".to_string(), "pak02_dir.vpk".to_string()],
+        &["first.vpk".to_string()],
+      )
+      .unwrap_err();
+
+    assert!(
+      err
+        .to_string()
+        .contains("original VPK name count (1) does not match installed VPK count (2)")
+    );
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -2,7 +2,7 @@ use crate::errors::Error;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, io::ErrorKind, path::Path};
 
-const MANIFEST_FILENAME: &str = ".dmm-vpk-manifest.json";
+const MANIFEST_FILENAME: &str = ".dmm.json";
 const CURRENT_MANIFEST_VERSION: u32 = 1;
 
 const fn current_manifest_version() -> u32 {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -1,0 +1,233 @@
+use crate::errors::Error;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fs, io::ErrorKind, path::Path};
+
+const MANIFEST_FILENAME: &str = ".dmm-vpk-manifest.json";
+const CURRENT_MANIFEST_VERSION: u32 = 1;
+
+const fn current_manifest_version() -> u32 {
+  CURRENT_MANIFEST_VERSION
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkManifest {
+  #[serde(default = "current_manifest_version")]
+  pub version: u32,
+  #[serde(default)]
+  pub mods: BTreeMap<String, ProfileVpkManifestEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkManifestEntry {
+  #[serde(default)]
+  pub enabled: bool,
+  #[serde(default)]
+  pub order: Option<u32>,
+  #[serde(default)]
+  pub current_vpks: Vec<String>,
+  #[serde(default)]
+  pub disabled_vpks: Vec<String>,
+  #[serde(default)]
+  pub original_vpk_names: Vec<String>,
+}
+
+impl Default for ProfileVpkManifest {
+  fn default() -> Self {
+    Self {
+      version: CURRENT_MANIFEST_VERSION,
+      mods: BTreeMap::new(),
+    }
+  }
+}
+
+impl ProfileVpkManifest {
+  pub fn load(addons_path: &Path) -> Result<Self, Error> {
+    let manifest_path = addons_path.join(MANIFEST_FILENAME);
+    let temp_path = addons_path.join(format!("{MANIFEST_FILENAME}.tmp"));
+
+    if manifest_path.exists() && temp_path.exists() {
+      fs::remove_file(&temp_path).map_err(|e| {
+        Error::InvalidInput(format!(
+          "Failed to remove stale VPK manifest temp file at {}: {e}",
+          temp_path.display()
+        ))
+      })?;
+    } else if !manifest_path.exists() && temp_path.exists() {
+      fs::rename(&temp_path, &manifest_path).map_err(|e| {
+        Error::InvalidInput(format!(
+          "Failed to recover VPK manifest temp file from {} to {}: {e}",
+          temp_path.display(),
+          manifest_path.display()
+        ))
+      })?;
+    }
+
+    if !manifest_path.exists() {
+      return Ok(Self::default());
+    }
+
+    let manifest_json = fs::read_to_string(&manifest_path)?;
+    let mut manifest: Self = serde_json::from_str(&manifest_json).map_err(|e| {
+      Error::InvalidInput(format!(
+        "Failed to parse VPK manifest at {}: {e}",
+        manifest_path.display()
+      ))
+    })?;
+
+    if manifest.version == 0 {
+      manifest.version = CURRENT_MANIFEST_VERSION;
+    }
+
+    Ok(manifest)
+  }
+
+  pub fn save(&self, addons_path: &Path) -> Result<(), Error> {
+    fs::create_dir_all(addons_path)?;
+
+    let manifest_path = addons_path.join(MANIFEST_FILENAME);
+    let temp_path = addons_path.join(format!("{MANIFEST_FILENAME}.tmp"));
+    let manifest_json = serde_json::to_string_pretty(self).map_err(|e| {
+      Error::InvalidInput(format!(
+        "Failed to serialize VPK manifest at {}: {e}",
+        manifest_path.display()
+      ))
+    })?;
+
+    fs::write(&temp_path, manifest_json)?;
+    if let Err(err) = fs::rename(&temp_path, &manifest_path) {
+      if err.kind() == ErrorKind::AlreadyExists {
+        fs::remove_file(&manifest_path)?;
+        fs::rename(&temp_path, &manifest_path)?;
+      } else {
+        return Err(err.into());
+      }
+    }
+
+    Ok(())
+  }
+
+  pub fn mark_enabled(
+    &mut self,
+    mod_id: &str,
+    current_vpks: Vec<String>,
+    original_vpk_names: Vec<String>,
+    order: Option<u32>,
+  ) {
+    let entry = self.mods.entry(mod_id.to_string()).or_default();
+    entry.enabled = true;
+    entry.current_vpks = current_vpks;
+    entry.disabled_vpks.clear();
+    if !original_vpk_names.is_empty() {
+      entry.original_vpk_names = original_vpk_names;
+    }
+    if order.is_some() {
+      entry.order = order;
+    }
+  }
+
+  pub fn mark_disabled(
+    &mut self,
+    mod_id: &str,
+    disabled_vpks: Vec<String>,
+    original_vpk_names: Vec<String>,
+  ) {
+    let entry = self.mods.entry(mod_id.to_string()).or_default();
+    entry.enabled = false;
+    entry.current_vpks.clear();
+    entry.disabled_vpks = disabled_vpks;
+    if !original_vpk_names.is_empty() {
+      entry.original_vpk_names = original_vpk_names;
+    }
+  }
+
+  pub fn remove_mod(&mut self, mod_id: &str) {
+    self.mods.remove(mod_id);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn persists_profile_manifest() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["cool_mod.vpk".to_string()],
+      Some(0),
+    );
+
+    manifest.save(temp.path()).unwrap();
+    let loaded = ProfileVpkManifest::load(temp.path()).unwrap();
+
+    assert_eq!(loaded, manifest);
+  }
+
+  #[test]
+  fn load_recovers_temp_manifest_when_main_is_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["cool_mod.vpk".to_string()],
+      Some(0),
+    );
+    let temp_path = temp.path().join(format!("{MANIFEST_FILENAME}.tmp"));
+    fs::write(&temp_path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+
+    let loaded = ProfileVpkManifest::load(temp.path()).unwrap();
+
+    assert_eq!(loaded, manifest);
+    assert!(temp.path().join(MANIFEST_FILENAME).exists());
+    assert!(!temp_path.exists());
+  }
+
+  #[test]
+  fn load_removes_stale_temp_manifest_when_main_exists() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["cool_mod.vpk".to_string()],
+      Some(0),
+    );
+    manifest.save(temp.path()).unwrap();
+    let temp_path = temp.path().join(format!("{MANIFEST_FILENAME}.tmp"));
+    fs::write(&temp_path, "{}").unwrap();
+
+    let loaded = ProfileVpkManifest::load(temp.path()).unwrap();
+
+    assert_eq!(loaded, manifest);
+    assert!(!temp_path.exists());
+  }
+
+  #[test]
+  fn mark_enabled_preserves_original_names_when_empty() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["cool_mod.vpk".to_string()],
+      Some(0),
+    );
+
+    manifest.mark_enabled(
+      "123",
+      vec!["pak02_dir.vpk".to_string()],
+      Vec::new(),
+      Some(1),
+    );
+
+    let entry = manifest.mods.get("123").unwrap();
+    assert_eq!(entry.original_vpk_names, vec!["cool_mod.vpk".to_string()]);
+    assert_eq!(entry.current_vpks, vec!["pak02_dir.vpk".to_string()]);
+    assert_eq!(entry.order, Some(1));
+  }
+}

--- a/apps/desktop/src/components/mod-management/audio-player-preview.tsx
+++ b/apps/desktop/src/components/mod-management/audio-player-preview.tsx
@@ -49,6 +49,8 @@ const AudioPlayerPreview = ({
   const { isPlaying, togglePlayback } = useGlobalAudio(audioUrl, audioUrl);
 
   const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     onPlayClick?.(e);
     togglePlayback();
   };
@@ -69,7 +71,7 @@ const AudioPlayerPreview = ({
   };
 
   return (
-    <div className={cn(styles.container, className)}>
+    <div className={cn(styles.container, className)} onClick={handleClick}>
       <div className={styles.content}>
         {variant !== "compact" && <Music className={styles.icon} />}
         {variant === "hero" && <div className='mb-6' />}

--- a/apps/desktop/src/components/providers/app.tsx
+++ b/apps/desktop/src/components/providers/app.tsx
@@ -57,6 +57,7 @@ export const AppProvider = ({ children, ...props }: AppProviderProps) => {
 
     resolveGamePath()
       .then(cleanupStaleServerGameinfo)
+      .then(() => usePersistedStore.getState().restoreModsFromManifest())
       .catch((error) => {
         logger.withError(error).debug("App bootstrap initialization skipped");
       });

--- a/apps/desktop/src/hooks/use-addon-analysis.ts
+++ b/apps/desktop/src/hooks/use-addon-analysis.ts
@@ -106,11 +106,13 @@ export const useAddonAnalysis = () => {
               addIdentifiedLocalMod(modDetails, addon.filePath);
               processedIdentifiedCount++;
 
-              // Register in Rust-side ModRepository so batch update cleanup can find it
+              // Register in Rust-side ModRepository and persist to manifest
+              const activeProfile = getActiveProfile();
               await invoke("register_analyzed_mod", {
                 modId: addon.remoteId,
                 modName: modDetails.name,
                 installedVpks: [addon.fileName],
+                profileFolder: activeProfile?.folderName ?? null,
               });
             } else {
               // This is a prefixed VPK (no matchInfo) - add as downloaded but not installed

--- a/apps/desktop/src/lib/state-machines/mod-status.ts
+++ b/apps/desktop/src/lib/state-machines/mod-status.ts
@@ -33,7 +33,12 @@ const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
     ModStatus.FailedToInstall,
     ModStatus.Downloaded,
   ],
-  [ModStatus.Installed]: [ModStatus.Removing, ModStatus.Downloaded],
+  [ModStatus.Installed]: [
+    ModStatus.Downloading,
+    ModStatus.Extracting,
+    ModStatus.Removing,
+    ModStatus.Downloaded,
+  ],
   [ModStatus.Removing]: [ModStatus.Removed, ModStatus.FailedToRemove],
   [ModStatus.Removed]: [ModStatus.Error],
   [ModStatus.FailedToInstall]: [ModStatus.Downloaded, ModStatus.Error],

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -320,7 +320,10 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     set((state) => ({
       localMods: state.localMods.map((mod) => ({
         ...mod,
-        status: mod.remoteId === remoteId ? ModStatus.Installed : mod.status,
+        status:
+          mod.remoteId === remoteId && vpks.length > 0
+            ? ModStatus.Installed
+            : mod.status,
         installedVpks: mod.remoteId === remoteId ? vpks : mod.installedVpks,
         installedFileTree:
           mod.remoteId === remoteId ? fileTree : mod.installedFileTree,
@@ -373,8 +376,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         .info("Updating mod VPK mappings after reorder");
 
       const vpkMap = new Map(vpkMappings);
-      return {
-        localMods: state.localMods.map((mod) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => {
           const newVpks = vpkMap.get(mod.remoteId);
           if (newVpks) {
             logger
@@ -390,7 +393,20 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
             };
           }
           return mod;
-        }),
+        });
+      const activeProfile = state.profiles[state.activeProfileId];
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: activeProfile
+          ? {
+              ...state.profiles,
+              [state.activeProfileId]: {
+                ...activeProfile,
+                mods: updateMods(activeProfile.mods),
+              },
+            }
+          : state.profiles,
       };
     }),
 

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -14,6 +14,8 @@ import {
   type ModProfileEntry,
   type ProfileId,
   type ProfileSwitchResult,
+  type SeedManifestEntry,
+  type VpkManifest,
 } from "@/types/profiles";
 
 export interface ProfilesState {
@@ -750,6 +752,19 @@ export const createProfilesSlice: StateCreator<
       const allVpks = await invoke<string[]>("get_profile_installed_vpks", {
         profileFolder: profile.folderName,
       });
+      let manifest: VpkManifest = { version: 0, mods: {} };
+      try {
+        manifest = await invoke<VpkManifest>("get_profile_vpk_manifest", {
+          profileFolder: profile.folderName,
+        });
+      } catch (error) {
+        logger
+          .withMetadata({ profileId, folderName: profile.folderName })
+          .withError(error)
+          .warn(
+            "Failed to load VPK manifest; falling back to filename-pattern detection",
+          );
+      }
 
       logger
         .withMetadata({
@@ -768,12 +783,67 @@ export const createProfilesSlice: StateCreator<
 
       const updatedEnabledMods: Record<string, ModProfileEntry> = {};
       const updatedLocalMods: LocalMod[] = [];
+      const seedEntries: SeedManifestEntry[] = [];
 
       for (const mod of localMods) {
-        // Check if this mod has any VPKs in the profile folder (enabled or disabled)
-        const hasVpksInProfile = allVpks.some(
-          (vpk) => vpk.startsWith(`${mod.remoteId}_`) || enabledVpkSet.has(vpk),
+        const manifestEntry = manifest.mods[mod.remoteId];
+
+        if (manifestEntry) {
+          const currentVpks = manifestEntry.currentVpks ?? [];
+          const hasEnabledVpks =
+            manifestEntry.enabled &&
+            currentVpks.some((vpk) => enabledVpkSet.has(vpk));
+
+          if (hasEnabledVpks) {
+            updatedEnabledMods[mod.remoteId] = {
+              remoteId: mod.remoteId,
+              enabled: true,
+              lastModified: new Date(),
+            };
+
+            updatedLocalMods.push({
+              ...mod,
+              status: ModStatus.Installed,
+              installedVpks: currentVpks,
+              installOrder: manifestEntry.order ?? mod.installOrder,
+            });
+          } else {
+            if (manifestEntry.enabled) {
+              logger
+                .withMetadata({
+                  profileId,
+                  remoteId: mod.remoteId,
+                  currentVpks,
+                  enabledVpkCount: enabledVpkSet.size,
+                  enabledVpkSample: Array.from(enabledVpkSet).slice(0, 10),
+                })
+                .warn(
+                  "Manifest entry marked enabled but no matching enabled VPKs on disk; treating as downloaded",
+                );
+            }
+
+            updatedLocalMods.push({
+              ...mod,
+              status: ModStatus.Downloaded,
+              installedVpks: [],
+              installOrder: manifestEntry.order ?? mod.installOrder,
+            });
+          }
+
+          continue;
+        }
+
+        const disabledVpksForMod = allVpks.filter((vpk) =>
+          vpk.startsWith(`${mod.remoteId}_`),
         );
+        const enabledVpksForMod =
+          mod.installedVpks?.filter((installedVpk) => {
+            const filename = installedVpk.split(/[\\/]/).pop() || "";
+            return enabledVpkSet.has(filename);
+          }) ?? [];
+
+        const hasVpksInProfile =
+          disabledVpksForMod.length > 0 || enabledVpksForMod.length > 0;
 
         if (!hasVpksInProfile) {
           // Mod doesn't have any VPKs in this profile
@@ -782,11 +852,7 @@ export const createProfilesSlice: StateCreator<
         }
 
         // Check if the mod has enabled VPKs
-        const hasEnabledVpks =
-          mod.installedVpks?.some((installedVpk) => {
-            const filename = installedVpk.split(/[\\/]/).pop() || "";
-            return enabledVpkSet.has(filename);
-          }) ?? false;
+        const hasEnabledVpks = enabledVpksForMod.length > 0;
 
         if (hasEnabledVpks) {
           // Mod is enabled in this profile
@@ -800,10 +866,23 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Installed,
+              installedVpks: enabledVpksForMod,
             });
           } else {
-            updatedLocalMods.push(mod);
+            updatedLocalMods.push({
+              ...mod,
+              installedVpks: enabledVpksForMod,
+            });
           }
+
+          seedEntries.push({
+            modId: mod.remoteId,
+            enabled: true,
+            currentVpks: enabledVpksForMod,
+            disabledVpks: [],
+            originalVpkNames: [],
+            order: mod.installOrder ?? null,
+          });
         } else {
           // Mod has VPKs but they're disabled (prefixed)
           if (mod.status === ModStatus.Installed) {
@@ -814,6 +893,32 @@ export const createProfilesSlice: StateCreator<
           } else {
             updatedLocalMods.push(mod);
           }
+
+          seedEntries.push({
+            modId: mod.remoteId,
+            enabled: false,
+            currentVpks: [],
+            disabledVpks: disabledVpksForMod,
+            originalVpkNames: [],
+            order: mod.installOrder ?? null,
+          });
+        }
+      }
+
+      if (seedEntries.length > 0) {
+        try {
+          await invoke("seed_profile_vpk_manifest_entries", {
+            profileFolder: profile.folderName,
+            entries: seedEntries,
+          });
+          logger
+            .withMetadata({ profileId, seedCount: seedEntries.length })
+            .info("Seeded VPK manifest with legacy mod entries");
+        } catch (seedError) {
+          logger
+            .withMetadata({ profileId })
+            .withError(seedError)
+            .warn("Failed to seed VPK manifest with legacy entries");
         }
       }
 

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -2,6 +2,7 @@ import { type ModDto } from "@deadlock-mods/shared";
 import { invoke } from "@tauri-apps/api/core";
 import i18n from "i18next";
 import type { StateCreator } from "zustand";
+import { getMod } from "@/lib/api-client";
 import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { isInstalledModWithVpks } from "@/lib/mods/installed-helpers";
@@ -61,6 +62,7 @@ export interface ProfilesState {
   getEnabledModsCount: () => number;
   syncProfilesWithFilesystem: () => Promise<void>;
   syncProfileEnabledMods: (profileId: ProfileId) => Promise<void>;
+  restoreModsFromManifest: () => Promise<void>;
   saveCurrentModsToProfile: () => void;
   loadModsFromProfile: (profileId: ProfileId) => void;
 }
@@ -944,6 +946,95 @@ export const createProfilesSlice: StateCreator<
         .withMetadata({ profileId })
         .withError(error)
         .error("Failed to sync profile enabled mods");
+    }
+  },
+
+  restoreModsFromManifest: async () => {
+    const { localMods, activeProfileId, profiles } = get();
+    if (localMods.length > 0) {
+      return;
+    }
+
+    const profile = profiles[activeProfileId];
+    if (!profile) {
+      return;
+    }
+
+    let manifest: VpkManifest = { version: 0, mods: {} };
+    try {
+      manifest = await invoke<VpkManifest>("get_profile_vpk_manifest", {
+        profileFolder: profile.folderName,
+      });
+    } catch (error) {
+      logger.withError(error).warn("Failed to load manifest for restoration");
+      return;
+    }
+
+    const manifestEntries = Object.entries(manifest.mods);
+    if (manifestEntries.length === 0) {
+      return;
+    }
+
+    logger
+      .withMetadata({
+        profileId: activeProfileId,
+        manifestModCount: manifestEntries.length,
+      })
+      .info("Restoring mods from manifest (local state is empty)");
+
+    const restoredMods: LocalMod[] = [];
+    const enabledMods: Record<string, ModProfileEntry> = {};
+
+    for (const [modId, entry] of manifestEntries) {
+      try {
+        const modDetails = await getMod(modId);
+        const currentVpks = entry.currentVpks ?? [];
+        const isEnabled = entry.enabled && currentVpks.length > 0;
+
+        const restoredMod: LocalMod = {
+          ...modDetails,
+          status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
+          installedVpks: isEnabled ? currentVpks : [],
+          installOrder: entry.order ?? restoredMods.length,
+        };
+
+        restoredMods.push(restoredMod);
+
+        if (isEnabled) {
+          enabledMods[modId] = {
+            remoteId: modId,
+            enabled: true,
+            lastModified: new Date(),
+          };
+        }
+
+        logger
+          .withMetadata({ modId, name: modDetails.name, isEnabled })
+          .info("Restored mod from manifest");
+      } catch (error) {
+        logger
+          .withMetadata({ modId })
+          .withError(error)
+          .warn("Failed to fetch mod details during manifest restoration");
+      }
+    }
+
+    if (restoredMods.length > 0) {
+      set((state) => ({
+        localMods: restoredMods,
+        profiles: {
+          ...state.profiles,
+          [activeProfileId]: {
+            ...profile,
+            enabledMods: { ...profile.enabledMods, ...enabledMods },
+            mods: restoredMods,
+          },
+        },
+      }));
+
+      logger
+        .withMetadata({ restoredCount: restoredMods.length })
+        .info("Manifest restoration complete");
     }
   },
 

--- a/apps/desktop/src/types/profiles.ts
+++ b/apps/desktop/src/types/profiles.ts
@@ -20,6 +20,28 @@ export interface ModProfile {
   mods: LocalMod[];
 }
 
+export interface VpkManifestEntry {
+  enabled: boolean;
+  order?: number | null;
+  currentVpks: string[];
+  disabledVpks: string[];
+  originalVpkNames: string[];
+}
+
+export interface VpkManifest {
+  version: number;
+  mods: Record<string, VpkManifestEntry>;
+}
+
+export interface SeedManifestEntry {
+  modId: string;
+  enabled: boolean;
+  currentVpks: string[];
+  disabledVpks: string[];
+  originalVpkNames: string[];
+  order: number | null;
+}
+
 export interface ProfileSwitchResult {
   disabledMods: string[];
   enabledMods: string[];


### PR DESCRIPTION
## Description

Fixes profile/mod VPK state drift by adding a profile-scoped `.dmm-vpk-manifest.json` and making install, disable, reorder, purge, replace, and profile sync flows use that manifest instead of transient in-memory state or filename guessing.

This also fixes audio preview clicks so pressing the preview plays audio instead of opening the mod page.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [x] Tests (adding or updating tests)
- [ ] Chore (maintenance, dependency updates, etc.)

## Related Issues

- Related to user reports of mods becoming invalid, disabled mods staying enabled, and profile switches causing enabled-state drift.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted - Tool: OpenAI Codex, Used for: codebase analysis, implementation, local validation, and review follow-up.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes in a production-like build path where practical

Passed locally:

- `corepack pnpm --filter desktop check-types`
- `corepack pnpm --filter desktop test`
- `corepack pnpm --filter desktop ui:build`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `corepack pnpm changeset status --since=origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend/state-management fix plus a click-handling fix for the existing audio preview component.

## Checklist

- [x] I have read the Contributing Guidelines and AI Policy
- [x] My code follows the style guidelines of this project where locally verifiable
- [x] I have performed a self-review of my own code
- [x] I have commented my code only where it clarifies non-obvious behavior
- [x] I have made corresponding changes to the documentation where applicable
- [x] My changes generate no new warnings or errors in the checks listed above
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested the changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable)

## Additional Notes

Root cause: there were multiple competing sources of truth for VPK state: the in-memory `ModRepository`, persisted frontend profile state, and addon filenames where enabled VPKs use generic `pakNN_dir.vpk` names. After restarts, profile switches, or reorders those could diverge, which made disable/reorder/profile sync paths lie about actual disk state.

This PR makes the manifest authoritative per profile/addons folder, validates missing enabled VPK files loudly via `ModInvalid`, keeps disabled/local/custom VPKs out of reorder, and keeps frontend profile sync from treating every mod as present just because any enabled VPK exists.

The current red `Vercel - deadlock-mod-manager-docs` status points to a Vercel GitHub authorization URL, so it appears to be an integration/permission issue rather than a code failure in this PR.

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR introduces a persistent per-profile VPK manifest system to eliminate state drift in the Deadlock Mod Manager's profile and mod management. The root cause was multiple competing sources of truth (in-memory state, persisted frontend state, ambiguous filesystem naming) causing mods to report incorrect enabled/disabled status across restarts and profile switches.

## Affected Components

**Desktop App (Primary Impact)**
- Tauri Backend (Rust): Core mod management, profile state handling, and VPK file operations
- Frontend (TypeScript/React): Profile store, mod status tracking, addon analysis, and audio preview

## Key Functional Changes

### Backend (Rust/Tauri)

**New Manifest System**
- Introduced `ProfileVpkManifest` persisted as `.dmm.json` in each profile's addons folder
- Tracks per-mod VPK ownership, enabled/disabled state, installation order, current/disabled VPK filenames, and original names
- Manifest is now the authoritative source replacing transient in-memory state and filename guessing

**Refactored Mod Operations**
- `install_mod`, `disable_mod`, `uninstall_mod`, `purge_mod`, `clear_mods`, `replace_mod_vpks`: All converted to manifest-driven workflows that load, update, and persist manifest entries
- `reorder_vpks`: Enhanced with pre-flight existence validation and manifest synchronization; now fails early with detailed errors when enabled VPK files are missing
- `disable_vpks`: Added validation that all referenced enabled VPK files exist before attempting disable operations
- Added `get_profile_vpk_manifest` and `hydrate_mods_from_manifest` public utilities for loading/reconstructing mod state from manifest

**VPK Filename Normalization**
- Centralized VPK filename detection and normalization through new helpers (`is_enabled_vpk_name`, `enabled_vpk_number`, `vpk_filename`)
- `extract_mod_id_from_prefix` now correctly handles enabled vs. disabled VPK naming conventions

**Error Handling**
- `Error::ModInvalid` now includes the reason in serialized messages for better diagnostics

**New Tauri Commands**
- `get_profile_vpk_manifest`: Returns current profile manifest state
- `hydrate_mods_from_manifest`: Reconstructs mod repository from manifest
- `seed_profile_vpk_manifest_entries`: Batch updates manifest entries with mod enablement state and VPK lists

### Frontend (TypeScript/React)

**Profile State Restoration**
- New `restoreModsFromManifest()` method: Reconstructs local mod state from persisted manifest on profile load, enabling state recovery across app restarts
- Called during app bootstrap after game path resolution

**Profile Sync Refactoring**
- `syncProfileEnabledMods` now:
  - Loads per-profile VPK manifest (with fallback to filename pattern detection if manifest unavailable)
  - Uses manifest-recorded enablement state as authoritative source
  - Avoids marking mods installed when no enabled VPKs are present
  - Persists legacy enablement state back to manifest via `seed_profile_vpk_manifest_entries`

**Mod Status Tracking**
- `setInstalledVpks`: Refined to only mark mod as `Installed` when VPK list is non-empty; preserves status when list is empty
- `updateModVpksAfterReorder`: Refactored with helper function to apply VPK mappings to both local and profile mods consistently
- `ModStatus.Installed`: Expanded valid state transitions to include `Downloading`, `Extracting`, and `Removing`

**Addon Analysis**
- `register_analyzed_mod`: Now captures active profile and persists analyzed mods to profile manifest immediately upon registration

**UI Fixes**
- Audio preview: Fixed click handling so clicking the preview element correctly triggers playback instead of opening mod page

## New Type Definitions

Added TypeScript interfaces to support manifest operations:
- `VpkManifestEntry`: Tracks mod enablement, order, current/disabled VPK lists, and original names
- `VpkManifest`: Top-level manifest with version and per-mod entry mapping
- `SeedManifestEntry`: Input structure for batch manifest updates

## Cross-Boundary Changes

**Tauri FFI Boundary**: Three new Tauri commands added (`get_profile_vpk_manifest`, `hydrate_mods_from_manifest`, `seed_profile_vpk_manifest_entries`) to enable frontend-backend coordination on manifest state

**Backend → Frontend Flow**: 
- `register_analyzed_mod` command signature extended with `profile_folder` parameter
- Manifest persistence now occurs on both backend (during mod operations) and frontend (during profile sync)

## Testing & Validation

- Unit tests added for manifest save/load, temp file recovery, safe profile folder validation, and VPK naming conventions
- Reorder operations validated to leave disabled `local-*_*.vpk` files untouched
- Disable operations fail when manifest-recorded enabled VPKs are missing on disk

## Version Requirements

Changelog entries indicate a patch version bump is required for the desktop app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->