### PR TITLE
ci: skip non-CI workflows on forks

### DIFF
--- a/.github/workflows/aur-git.yml
+++ b/.github/workflows/aur-git.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   aur-git-push:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   aur-push:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   synchronize-with-crowdin:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   backup:
     name: Backup Database to S3
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
     steps:
       - name: Generate backup filename

--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   changes:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/download-gameinfo.yml
+++ b/.github/workflows/download-gameinfo.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   fetch:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   check-commits:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -72,6 +73,7 @@ jobs:
           echo "latest_commit=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   prepare-matrix:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/release-services.yml
+++ b/.github/workflows/release-services.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   create-release:
+    if: github.repository_owner == 'deadlock-mod-manager'
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   create-release:
+    if: github.repository_owner == 'deadlock-mod-manager'
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/update-language-table.yml
+++ b/.github/workflows/update-language-table.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   update-language-table:
+    if: github.repository_owner == 'deadlock-mod-manager'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Description

Earlier I forked this repo and because of that I get every day tons of ci/cd running and failed notifications. I have added a guard for schedule + publish/deploy workflows and kept ci checks/validations/tests

## Type of Change

- [] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [X] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

None

## AI Disclosure

- [X] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [X] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

N/A

## Checklist

- [X] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [X] My code follows the style guidelines of this project (`pnpm lint` passes)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested my changes on multiple platforms (if applicable)
- [X] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Functional Impact

This PR adds repository-owner guards to prevent non-CI workflows from executing on forked repositories. The change applies to 10 GitHub Actions workflows that handle deployments, releases, scheduled tasks, and external service integrations:

**Affected workflows and their functional scope:**
- **AUR deployment** (aur.yml, aur-git.yml): Package publishing workflows now restricted
- **Crowdin synchronization** (crowdin.yml): Translation sync restricted
- **Database backup** (db-backup.yml): Data backup operations restricted
- **Service deployment** (deploy-services.yml): Deployment pipeline for API, auth, bot, lockdex, mirror, and www services now gated
- **Service releases** (release-services.yml): Service release jobs restricted
- **General releases** (release.yml): Release creation restricted
- **Nightly operations** (nightly.yml): Scheduled commit checks and matrix preparation restricted
- **Game info downloads** (download-gameinfo.yml): Fetch operations restricted
- **Language table updates** (update-language-table.yml): Translation table update restricted

**Implementation detail:** Each workflow now includes a job-level conditional `if: github.repository_owner == 'deadlock-mod-manager'` that prevents execution on forks while allowing fork owners to still run CI checks (which are not modified by this PR).

**No application code changes.** All changes are infrastructure-only (GitHub Actions configuration). No cross-package dependencies, database migrations, Tauri plugin changes, or Rust FFI boundary changes are involved.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deadlock-mod-manager/deadlock-mod-manager/pull/446)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->