### PR TITLE
feat(desktop): add mod favorites with dedicated favorites page

### DIFF
--- a/.changeset/bright-stars-favor.md
+++ b/.changeset/bright-stars-favor.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Add mod favorites with star toggle on cards and a dedicated favorites page

--- a/.changeset/bright-stars-favor.md
+++ b/.changeset/bright-stars-favor.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-Add mod favorites with star toggle on cards and a dedicated favorites page
+Add mod favorites with star toggle on cards and inline favorites filter in the Mods Store

--- a/apps/desktop/src/components/mod-browsing/favorite-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/favorite-button.tsx
@@ -1,0 +1,96 @@
+import { Button } from "@deadlock-mods/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deadlock-mods/ui/components/tooltip";
+import { Star } from "@deadlock-mods/ui/icons";
+import type { MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { usePersistedStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
+
+type FavoriteButtonProps = {
+  remoteId: string;
+  variant?: "overlay" | "inline";
+  className?: string;
+};
+
+const FavoriteButton = ({
+  remoteId,
+  variant = "overlay",
+  className,
+}: FavoriteButtonProps) => {
+  const { t } = useTranslation();
+  const isFavorite = usePersistedStore((state) =>
+    state.favorites.includes(remoteId),
+  );
+  const toggleFavorite = usePersistedStore((state) => state.toggleFavorite);
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    toggleFavorite(remoteId);
+  };
+
+  const tooltipText = isFavorite
+    ? t("favorites.remove")
+    : t("favorites.add");
+
+  if (variant === "inline") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            aria-label={tooltipText}
+            aria-pressed={isFavorite}
+            className={className}
+            icon={
+              <Star
+                className={cn(
+                  "h-4 w-4 transition-colors",
+                  isFavorite && "fill-current text-yellow-400",
+                )}
+              />
+            }
+            onClick={handleClick}
+            size='lg'
+            variant='outline'>
+            {isFavorite ? t("favorites.favorited") : t("favorites.favorite")}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{tooltipText}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          aria-label={tooltipText}
+          aria-pressed={isFavorite}
+          className={cn(
+            "inline-flex h-8 w-8 items-center justify-center rounded-full",
+            "bg-background/70 backdrop-blur-sm shadow-sm",
+            "text-foreground/80 hover:text-yellow-400",
+            "transition-colors hover:bg-background/90",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+          onClick={handleClick}
+          type='button'>
+          <Star
+            className={cn(
+              "h-4 w-4 transition-all",
+              isFavorite && "fill-yellow-400 text-yellow-400",
+            )}
+          />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default FavoriteButton;

--- a/apps/desktop/src/components/mod-browsing/favorite-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/favorite-button.tsx
@@ -75,7 +75,7 @@ const FavoriteButton = ({
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             "active:scale-90",
             isFavorite
-              ? "shadow-[0_0_10px_rgba(234,179,8,0.3)] border-yellow-500/30"
+              ? "border-yellow-500/20"
               : "opacity-0 group-hover:opacity-100 hover:border-white/20 hover:bg-black/60",
             className,
           )}
@@ -85,7 +85,7 @@ const FavoriteButton = ({
             className={cn(
               "h-4 w-4 transition-all duration-300",
               isFavorite
-                ? "fill-yellow-400 text-yellow-400 drop-shadow-[0_0_4px_rgba(234,179,8,0.5)]"
+                ? "fill-yellow-400 text-yellow-400"
                 : "text-white/70 hover:text-white",
             )}
           />

--- a/apps/desktop/src/components/mod-browsing/favorite-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/favorite-button.tsx
@@ -33,9 +33,7 @@ const FavoriteButton = ({
     toggleFavorite(remoteId);
   };
 
-  const tooltipText = isFavorite
-    ? t("favorites.remove")
-    : t("favorites.add");
+  const tooltipText = isFavorite ? t("favorites.remove") : t("favorites.add");
 
   if (variant === "inline") {
     return (
@@ -72,18 +70,23 @@ const FavoriteButton = ({
           aria-pressed={isFavorite}
           className={cn(
             "inline-flex h-8 w-8 items-center justify-center rounded-full",
-            "bg-background/70 backdrop-blur-sm shadow-sm",
-            "text-foreground/80 hover:text-yellow-400",
-            "transition-colors hover:bg-background/90",
+            "border border-white/10 bg-black/50 backdrop-blur-md",
+            "transition-all duration-300 ease-out",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "active:scale-90",
+            isFavorite
+              ? "shadow-[0_0_10px_rgba(234,179,8,0.3)] border-yellow-500/30"
+              : "opacity-0 group-hover:opacity-100 hover:border-white/20 hover:bg-black/60",
             className,
           )}
           onClick={handleClick}
           type='button'>
           <Star
             className={cn(
-              "h-4 w-4 transition-all",
-              isFavorite && "fill-yellow-400 text-yellow-400",
+              "h-4 w-4 transition-all duration-300",
+              isFavorite
+                ? "fill-yellow-400 text-yellow-400 drop-shadow-[0_0_4px_rgba(234,179,8,0.5)]"
+                : "text-white/70 hover:text-white",
             )}
           />
         </button>

--- a/apps/desktop/src/components/mod-browsing/mod-card.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-card.tsx
@@ -24,6 +24,7 @@ import {
   isUpdatedRecently,
 } from "@/lib/utils";
 import { ModStatus } from "@/types/mods";
+import FavoriteButton from "./favorite-button";
 import ModButton from "./mod-button";
 import { NSFWBlur } from "./nsfw-blur";
 
@@ -95,6 +96,7 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
           </div>
         )}
         <div className='absolute top-2 right-2 flex flex-col gap-1 items-end'>
+          {!readOnly && <FavoriteButton remoteId={mod.remoteId} />}
           {status === ModStatus.Installed && (
             <Badge>{t("modStatus.installed")}</Badge>
           )}

--- a/apps/desktop/src/components/mod-browsing/mod-card.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-card.tsx
@@ -51,7 +51,7 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
   const cardContent = (
     <Card
       className={cn(
-        "shadow-none border [contain:layout_style_paint] h-full",
+        "group shadow-none border [contain:layout_style_paint] h-full",
         !readOnly && "cursor-pointer",
       )}
       onClick={
@@ -95,18 +95,29 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
             </div>
           </div>
         )}
-        <div className='absolute top-2 right-2 flex flex-col gap-1 items-end'>
-          {!readOnly && <FavoriteButton remoteId={mod.remoteId} />}
-          {status === ModStatus.Installed && (
-            <Badge>{t("modStatus.installed")}</Badge>
-          )}
-          {mod.isObsolete && <ObsoleteModWarning variant='indicator' />}
-          {isModOutdated(mod) && <OutdatedModWarning variant='indicator' />}
-          {isUpdatedRecently(mod) && !isUpdateAvailable(mod, localMod) && (
-            <UpdatedRecentlyBadge />
-          )}
-          {isUpdateAvailable(mod, localMod) && <UpdateAvailableBadge />}
-        </div>
+        {!readOnly && (
+          <FavoriteButton
+            className='absolute top-2 right-2 z-10'
+            remoteId={mod.remoteId}
+          />
+        )}
+        {(status === ModStatus.Installed ||
+          mod.isObsolete ||
+          isModOutdated(mod) ||
+          isUpdatedRecently(mod) ||
+          isUpdateAvailable(mod, localMod)) && (
+          <div className='pointer-events-none absolute inset-x-0 bottom-0 z-10 flex items-end justify-end gap-1 bg-gradient-to-t from-black/60 to-transparent px-2 pb-2 pt-6'>
+            {status === ModStatus.Installed && (
+              <Badge>{t("modStatus.installed")}</Badge>
+            )}
+            {mod.isObsolete && <ObsoleteModWarning variant='indicator' />}
+            {isModOutdated(mod) && <OutdatedModWarning variant='indicator' />}
+            {isUpdatedRecently(mod) && !isUpdateAvailable(mod, localMod) && (
+              <UpdatedRecentlyBadge />
+            )}
+            {isUpdateAvailable(mod, localMod) && <UpdateAvailableBadge />}
+          </div>
+        )}
       </div>
       <CardHeader className='px-3 py-4'>
         <div className='flex items-start justify-between'>

--- a/apps/desktop/src/components/mod-browsing/nsfw-blur.tsx
+++ b/apps/desktop/src/components/mod-browsing/nsfw-blur.tsx
@@ -5,8 +5,11 @@ import { cn } from "@/lib/utils";
 
 export const NSFWBadge = ({ className }: { className?: string }) => (
   <Badge
-    className={cn("font-semibold uppercase tracking-wide shadow-md", className)}
-    variant='destructive'>
+    className={cn(
+      "border-red-500/30 bg-red-950/80 font-bold uppercase tracking-widest text-red-300 shadow-[0_0_12px_rgba(239,68,68,0.25)]",
+      className,
+    )}
+    variant='outline'>
     NSFW
   </Badge>
 );
@@ -62,15 +65,15 @@ export const NSFWBlur = ({
       </div>
 
       {!isVisible && (
-        <div className='absolute inset-0 flex items-center justify-center bg-black/30'>
+        <div className='absolute inset-0 flex items-center justify-center bg-black/40'>
           <div className='flex flex-col items-center gap-3'>
-            <NSFWBadge className='px-2.5 py-1 text-xs' />
+            <NSFWBadge className='px-3 py-1 text-xs' />
             {showControls && (
               <button
                 type='button'
-                className='group flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-3.5 py-1.5 text-xs font-medium text-white/90 backdrop-blur-md transition-all duration-200 hover:border-white/35 hover:bg-white/20 hover:text-white hover:shadow-[0_0_12px_rgba(255,255,255,0.1)]'
+                className='group flex items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-4 py-1.5 text-xs font-medium text-white/80 backdrop-blur-xl transition-all duration-300 hover:border-white/30 hover:bg-white/15 hover:text-white hover:shadow-[0_0_16px_rgba(255,255,255,0.08)]'
                 onClick={handleToggle}>
-                <Eye className='h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110' />
+                <Eye className='h-3.5 w-3.5 transition-transform duration-300 group-hover:scale-110' />
                 Show
               </button>
             )}
@@ -79,12 +82,12 @@ export const NSFWBlur = ({
       )}
 
       {isVisible && showControls && (
-        <div className='absolute top-2 right-2'>
+        <div className='absolute top-2 left-2'>
           <button
             type='button'
-            className='group flex items-center gap-1.5 rounded-full border border-white/20 bg-black/40 px-3 py-1.5 text-xs font-medium text-white/80 backdrop-blur-md transition-all duration-200 hover:border-white/30 hover:bg-black/60 hover:text-white'
+            className='group flex items-center gap-1.5 rounded-full border border-white/15 bg-black/50 px-3 py-1.5 text-xs font-medium text-white/70 backdrop-blur-xl transition-all duration-300 hover:border-white/25 hover:bg-black/70 hover:text-white'
             onClick={handleToggle}>
-            <EyeOff className='h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110' />
+            <EyeOff className='h-3.5 w-3.5 transition-transform duration-300 group-hover:scale-110' />
             Hide
           </button>
         </div>

--- a/apps/desktop/src/components/mod-browsing/nsfw-blur.tsx
+++ b/apps/desktop/src/components/mod-browsing/nsfw-blur.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 export const NSFWBadge = ({ className }: { className?: string }) => (
   <Badge
     className={cn(
-      "border-red-500/30 bg-red-950/80 font-bold uppercase tracking-widest text-red-300 shadow-[0_0_12px_rgba(239,68,68,0.25)]",
+      "border-red-500/30 bg-red-950/80 font-bold uppercase tracking-widest text-red-300",
       className,
     )}
     variant='outline'>

--- a/apps/desktop/src/components/mod-browsing/search-bar.tsx
+++ b/apps/desktop/src/components/mod-browsing/search-bar.tsx
@@ -1,5 +1,6 @@
 import type { ModDto } from "@deadlock-mods/shared";
 import { Badge } from "@deadlock-mods/ui/components/badge";
+import { Button } from "@deadlock-mods/ui/components/button";
 import { SearchInput } from "@deadlock-mods/ui/components/search-input";
 import {
   Select,
@@ -9,9 +10,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@deadlock-mods/ui/components/select";
-import { ArrowUpDown, Clock, X } from "@deadlock-mods/ui/icons";
+import { ArrowUpDown, Clock, Star, X } from "@deadlock-mods/ui/icons";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { usePersistedStore } from "@/lib/store";
 import {
   getModCategoryDisplayName,
   SortType,
@@ -48,6 +51,7 @@ type SearchBarProps = {
   onFilterModeChange: (filterMode: FilterMode) => void;
   showSortControl?: boolean;
   showTimePeriodControl?: boolean;
+  showFavoritesButton?: boolean;
   hideMapFilter?: boolean;
 };
 
@@ -75,10 +79,14 @@ const SearchBar = ({
   onFilterModeChange,
   showSortControl = true,
   showTimePeriodControl = true,
+  showFavoritesButton = false,
   hideMapFilter,
 }: SearchBarProps) => {
   const { t } = useTranslation();
   const effectiveTimePeriod = timePeriod ?? TimePeriod.ALL_TIME;
+  const favoritesCount = usePersistedStore(
+    (state) => state.favorites.length,
+  );
 
   const getHeroDisplayName = (hero: string) => {
     if (hero === "None") {
@@ -147,8 +155,25 @@ const SearchBar = ({
             hideMapFilter={hideMapFilter}
           />
         </div>
-        {(showTimePeriodControl || showSortControl) && (
+        {(showTimePeriodControl ||
+          showSortControl ||
+          showFavoritesButton) && (
           <div className='flex items-center gap-4'>
+            {showFavoritesButton && (
+              <Button asChild variant='outline' size='default'>
+                <Link to='/mods/favorites' draggable='false'>
+                  <Star className='mr-2 h-4 w-4' />
+                  <span>{t("favorites.title")}</span>
+                  {favoritesCount > 0 && (
+                    <Badge
+                      className='ml-2 px-1 py-0 text-xs'
+                      variant='secondary'>
+                      {favoritesCount}
+                    </Badge>
+                  )}
+                </Link>
+              </Button>
+            )}
             {showTimePeriodControl && onTimePeriodChange && (
               <Select
                 onValueChange={onTimePeriodChange}

--- a/apps/desktop/src/components/mod-browsing/search-bar.tsx
+++ b/apps/desktop/src/components/mod-browsing/search-bar.tsx
@@ -13,8 +13,8 @@ import {
 import { ArrowUpDown, Clock, Star, X } from "@deadlock-mods/ui/icons";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router";
 import { usePersistedStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
 import {
   getModCategoryDisplayName,
   SortType,
@@ -51,7 +51,9 @@ type SearchBarProps = {
   onFilterModeChange: (filterMode: FilterMode) => void;
   showSortControl?: boolean;
   showTimePeriodControl?: boolean;
-  showFavoritesButton?: boolean;
+  showFavoritesFilter?: boolean;
+  showFavoritesOnly?: boolean;
+  onShowFavoritesOnlyChange?: (value: boolean) => void;
   hideMapFilter?: boolean;
 };
 
@@ -79,14 +81,14 @@ const SearchBar = ({
   onFilterModeChange,
   showSortControl = true,
   showTimePeriodControl = true,
-  showFavoritesButton = false,
+  showFavoritesFilter = false,
+  showFavoritesOnly = false,
+  onShowFavoritesOnlyChange,
   hideMapFilter,
 }: SearchBarProps) => {
   const { t } = useTranslation();
   const effectiveTimePeriod = timePeriod ?? TimePeriod.ALL_TIME;
-  const favoritesCount = usePersistedStore(
-    (state) => state.favorites.length,
-  );
+  const favoritesCount = usePersistedStore((state) => state.favorites.length);
 
   const getHeroDisplayName = (hero: string) => {
     if (hero === "None") {
@@ -114,6 +116,7 @@ const SearchBar = ({
     onHideOutdatedChange(false);
     onTimePeriodChange?.(TimePeriod.ALL_TIME);
     onFilterModeChange("include");
+    onShowFavoritesOnlyChange?.(false);
   };
 
   const hasActiveFilters =
@@ -123,6 +126,7 @@ const SearchBar = ({
     audioQuickFilter !== "off" ||
     (!hideMapFilter && mapQuickFilter !== "off") ||
     hideOutdated ||
+    showFavoritesOnly ||
     (showTimePeriodControl && effectiveTimePeriod !== TimePeriod.ALL_TIME);
 
   return (
@@ -155,23 +159,29 @@ const SearchBar = ({
             hideMapFilter={hideMapFilter}
           />
         </div>
-        {(showTimePeriodControl ||
-          showSortControl ||
-          showFavoritesButton) && (
+        {(showTimePeriodControl || showSortControl || showFavoritesFilter) && (
           <div className='flex items-center gap-4'>
-            {showFavoritesButton && (
-              <Button asChild variant='outline' size='default'>
-                <Link to='/mods/favorites' draggable='false'>
-                  <Star className='mr-2 h-4 w-4' />
-                  <span>{t("favorites.title")}</span>
-                  {favoritesCount > 0 && (
-                    <Badge
-                      className='ml-2 px-1 py-0 text-xs'
-                      variant='secondary'>
-                      {favoritesCount}
-                    </Badge>
+            {showFavoritesFilter && (
+              <Button
+                className={cn(
+                  showFavoritesOnly &&
+                    "border-yellow-500/50 bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20 hover:text-yellow-300",
+                )}
+                onClick={() => onShowFavoritesOnlyChange?.(!showFavoritesOnly)}
+                size='default'
+                variant='outline'>
+                <Star
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    showFavoritesOnly && "fill-yellow-400 text-yellow-400",
                   )}
-                </Link>
+                />
+                <span>{t("favorites.title")}</span>
+                {favoritesCount > 0 && (
+                  <Badge className='ml-2 px-1 py-0 text-xs' variant='secondary'>
+                    {favoritesCount}
+                  </Badge>
+                )}
               </Button>
             )}
             {showTimePeriodControl && onTimePeriodChange && (
@@ -335,6 +345,19 @@ const SearchBar = ({
                 </button>
               </Badge>
             )}
+
+          {showFavoritesOnly && (
+            <Badge className='flex items-center gap-1' variant='secondary'>
+              <Star className='h-3 w-3 fill-yellow-400 text-yellow-400' />
+              {t("favorites.title")}
+              <button
+                className='ml-1 rounded-full p-0.5 hover:bg-muted'
+                onClick={() => onShowFavoritesOnlyChange?.(false)}
+                type='button'>
+                <X className='h-3 w-3' />
+              </button>
+            </Badge>
+          )}
 
           {/* Clear all button */}
           <button

--- a/apps/desktop/src/lib/store/index.ts
+++ b/apps/desktop/src/lib/store/index.ts
@@ -9,6 +9,11 @@ import {
   crosshairDeepMergeKeys,
 } from "./slices/crosshair";
 import {
+  createFavoritesSlice,
+  favoritesDeepMergeKeys,
+  type FavoritesState,
+} from "./slices/favorites";
+import {
   createGameSlice,
   gameDeepMergeKeys,
   type GameState,
@@ -54,7 +59,8 @@ export type State = ModsState &
   NetworkState &
   UIState &
   ScrollState &
-  CrosshairState;
+  CrosshairState &
+  FavoritesState;
 
 const allDeepMergeKeys = new Set<string>([
   ...modsDeepMergeKeys,
@@ -66,6 +72,7 @@ const allDeepMergeKeys = new Set<string>([
   ...uiDeepMergeKeys,
   ...scrollDeepMergeKeys,
   ...crosshairDeepMergeKeys,
+  ...favoritesDeepMergeKeys,
 ]);
 
 export const usePersistedStore = create<State>()(
@@ -80,6 +87,7 @@ export const usePersistedStore = create<State>()(
       ...createUISlice(...a),
       ...createScrollSlice(...a),
       ...createCrosshairSlice(...a),
+      ...createFavoritesSlice(...a),
     }),
     {
       name: "local-config",

--- a/apps/desktop/src/lib/store/migrate.ts
+++ b/apps/desktop/src/lib/store/migrate.ts
@@ -309,6 +309,14 @@ export const MIGRATION_STEPS: readonly MigrationStep[] = [
       state.heroParserIntervalSeconds ??= 30;
     },
   },
+  {
+    to: 20,
+    label: "add-mod-favorites",
+    apply: (state) => {
+      if (Array.isArray(state.favorites)) return;
+      state.favorites = [];
+    },
+  },
 ];
 
 const STEP_TARGET_VERSIONS: readonly number[] = MIGRATION_STEPS.map(

--- a/apps/desktop/src/lib/store/slices/favorites.ts
+++ b/apps/desktop/src/lib/store/slices/favorites.ts
@@ -1,0 +1,45 @@
+import type { StateCreator } from "zustand";
+import type { State } from "..";
+
+export type FavoritesState = {
+  favorites: string[];
+  toggleFavorite: (remoteId: string) => void;
+  addFavorite: (remoteId: string) => void;
+  removeFavorite: (remoteId: string) => void;
+  isFavorite: (remoteId: string) => boolean;
+  clearFavorites: () => void;
+};
+
+export const favoritesDeepMergeKeys =
+  [] as const satisfies readonly (keyof FavoritesState)[];
+
+export const createFavoritesSlice: StateCreator<State, [], [], FavoritesState> =
+  (set, get) => ({
+    favorites: [],
+
+    toggleFavorite: (remoteId) =>
+      set((state) => {
+        const isFav = state.favorites.includes(remoteId);
+        return {
+          favorites: isFav
+            ? state.favorites.filter((id) => id !== remoteId)
+            : [...state.favorites, remoteId],
+        };
+      }),
+
+    addFavorite: (remoteId) =>
+      set((state) =>
+        state.favorites.includes(remoteId)
+          ? state
+          : { favorites: [...state.favorites, remoteId] },
+      ),
+
+    removeFavorite: (remoteId) =>
+      set((state) => ({
+        favorites: state.favorites.filter((id) => id !== remoteId),
+      })),
+
+    isFavorite: (remoteId) => get().favorites.includes(remoteId),
+
+    clearFavorites: () => set({ favorites: [] }),
+  });

--- a/apps/desktop/src/lib/store/slices/favorites.ts
+++ b/apps/desktop/src/lib/store/slices/favorites.ts
@@ -13,33 +13,37 @@ export type FavoritesState = {
 export const favoritesDeepMergeKeys =
   [] as const satisfies readonly (keyof FavoritesState)[];
 
-export const createFavoritesSlice: StateCreator<State, [], [], FavoritesState> =
-  (set, get) => ({
-    favorites: [],
+export const createFavoritesSlice: StateCreator<
+  State,
+  [],
+  [],
+  FavoritesState
+> = (set, get) => ({
+  favorites: [],
 
-    toggleFavorite: (remoteId) =>
-      set((state) => {
-        const isFav = state.favorites.includes(remoteId);
-        return {
-          favorites: isFav
-            ? state.favorites.filter((id) => id !== remoteId)
-            : [...state.favorites, remoteId],
-        };
-      }),
+  toggleFavorite: (remoteId) =>
+    set((state) => {
+      const isFav = state.favorites.includes(remoteId);
+      return {
+        favorites: isFav
+          ? state.favorites.filter((id) => id !== remoteId)
+          : [...state.favorites, remoteId],
+      };
+    }),
 
-    addFavorite: (remoteId) =>
-      set((state) =>
-        state.favorites.includes(remoteId)
-          ? state
-          : { favorites: [...state.favorites, remoteId] },
-      ),
+  addFavorite: (remoteId) =>
+    set((state) =>
+      state.favorites.includes(remoteId)
+        ? state
+        : { favorites: [...state.favorites, remoteId] },
+    ),
 
-    removeFavorite: (remoteId) =>
-      set((state) => ({
-        favorites: state.favorites.filter((id) => id !== remoteId),
-      })),
+  removeFavorite: (remoteId) =>
+    set((state) => ({
+      favorites: state.favorites.filter((id) => id !== remoteId),
+    })),
 
-    isFavorite: (remoteId) => get().favorites.includes(remoteId),
+  isFavorite: (remoteId) => get().favorites.includes(remoteId),
 
-    clearFavorites: () => set({ favorites: [] }),
-  });
+  clearFavorites: () => set({ favorites: [] }),
+});

--- a/apps/desktop/src/lib/store/slices/ui.ts
+++ b/apps/desktop/src/lib/store/slices/ui.ts
@@ -19,6 +19,7 @@ export type ModsFilters = {
   timePeriod: TimePeriod;
   filterMode: FilterMode;
   searchQuery: string;
+  showFavoritesOnly: boolean;
 };
 
 export type CrosshairFilters = {
@@ -69,6 +70,7 @@ const DEFAULT_MODS_FILTERS: ModsFilters = {
   timePeriod: TimePeriod.ALL_TIME,
   filterMode: "include",
   searchQuery: "",
+  showFavoritesOnly: false,
 };
 
 const DEFAULT_CROSSHAIR_FILTERS: CrosshairFilters = {

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1,4 +1,15 @@
 {
+  "favorites": {
+    "title": "Favorites",
+    "subtitle": "Mods you've saved to revisit later.",
+    "add": "Add to favorites",
+    "remove": "Remove from favorites",
+    "favorite": "Favorite",
+    "favorited": "Favorited",
+    "back": "Back to Mods Store",
+    "emptyTitle": "No favorites yet",
+    "emptyDescription": "Tap the star on any mod card to save it here for later."
+  },
   "navigation": {
     "dashboard": "Dashboard",
     "myMods": "Mods Library",

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -12,7 +12,7 @@ import Dashboard from "./pages/dashboard";
 import Debug from "./pages/debug";
 import Developer from "./pages/developer";
 import Downloads from "./pages/downloads";
-import Favorites from "./pages/favorites";
+
 import Mod from "./pages/mod";
 import GetMods, { GetMaps } from "./pages/mods";
 import MyMods from "./pages/my-mods";
@@ -50,7 +50,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
               <Route element={<Dashboard />} path='/' />
               <Route element={<MyMods />} path='/my-mods' />
               <Route element={<GetMods />} path='/mods' />
-              <Route element={<Favorites />} path='/mods/favorites' />
+
               <Route element={<MapsRouteGate />} path='/maps' />
               <Route element={<Mod />} path='/mods/:id' />
               <Route element={<AddMods />} path='/add-mods' />

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -12,6 +12,7 @@ import Dashboard from "./pages/dashboard";
 import Debug from "./pages/debug";
 import Developer from "./pages/developer";
 import Downloads from "./pages/downloads";
+import Favorites from "./pages/favorites";
 import Mod from "./pages/mod";
 import GetMods, { GetMaps } from "./pages/mods";
 import MyMods from "./pages/my-mods";
@@ -49,6 +50,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
               <Route element={<Dashboard />} path='/' />
               <Route element={<MyMods />} path='/my-mods' />
               <Route element={<GetMods />} path='/mods' />
+              <Route element={<Favorites />} path='/mods/favorites' />
               <Route element={<MapsRouteGate />} path='/maps' />
               <Route element={<Mod />} path='/mods/:id' />
               <Route element={<AddMods />} path='/add-mods' />

--- a/apps/desktop/src/pages/favorites.tsx
+++ b/apps/desktop/src/pages/favorites.tsx
@@ -50,9 +50,7 @@ const FavoritesData = () => {
             <Star className='h-16 w-16' weight='duotone' />
           </EmptyMedia>
           <EmptyTitle>{t("favorites.emptyTitle")}</EmptyTitle>
-          <EmptyDescription>
-            {t("favorites.emptyDescription")}
-          </EmptyDescription>
+          <EmptyDescription>{t("favorites.emptyDescription")}</EmptyDescription>
         </EmptyHeader>
       </Empty>
     );

--- a/apps/desktop/src/pages/favorites.tsx
+++ b/apps/desktop/src/pages/favorites.tsx
@@ -1,0 +1,118 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@deadlock-mods/ui/components/empty";
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { Button } from "@deadlock-mods/ui/components/button";
+import { ArrowLeft } from "@deadlock-mods/ui/icons";
+import { Star } from "@phosphor-icons/react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useCallback, useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import ModCard from "@/components/mod-browsing/mod-card";
+import ErrorBoundary from "@/components/shared/error-boundary";
+import PageTitle from "@/components/shared/page-title";
+import { getMods } from "@/lib/api-client";
+import { STALE_TIME_API } from "@/lib/query-constants";
+import { usePersistedStore } from "@/lib/store";
+
+const FavoritesData = () => {
+  const { t } = useTranslation();
+  const { data, error } = useSuspenseQuery({
+    queryKey: ["mods"],
+    queryFn: getMods,
+    staleTime: STALE_TIME_API,
+    retry: 3,
+  });
+  const favorites = usePersistedStore((state) => state.favorites);
+
+  const favoritedMods = useMemo(() => {
+    if (!data) return [];
+    const favSet = new Set(favorites);
+    return data.filter((mod) => favSet.has(mod.remoteId));
+  }, [data, favorites]);
+
+  useEffect(() => {
+    if (error) {
+      toast.error((error as Error)?.message ?? t("common.failedToFetchMods"));
+    }
+  }, [error, t]);
+
+  if (favoritedMods.length === 0) {
+    return (
+      <Empty className='py-12'>
+        <EmptyHeader>
+          <EmptyMedia variant='default'>
+            <Star className='h-16 w-16' weight='duotone' />
+          </EmptyMedia>
+          <EmptyTitle>{t("favorites.emptyTitle")}</EmptyTitle>
+          <EmptyDescription>
+            {t("favorites.emptyDescription")}
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className='grid grid-cols-1 gap-4 px-1 pb-24 pr-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6'>
+      {favoritedMods.map((mod) => (
+        <ModCard key={mod.id} mod={mod} />
+      ))}
+    </div>
+  );
+};
+
+const FavoritesSkeleton = () => (
+  <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6'>
+    {Array.from({ length: 12 }, (_, i) => (
+      <ModCard key={i} mod={undefined} />
+    ))}
+  </div>
+);
+
+const Favorites = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const goBack = useCallback(() => {
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate("/mods");
+    }
+  }, [navigate]);
+
+  return (
+    <div className='flex h-full min-h-0 w-full flex-col px-4'>
+      <div className='mb-4 flex items-center pt-2'>
+        <Button
+          className='flex items-center gap-1'
+          onClick={goBack}
+          size='sm'
+          variant='ghost'>
+          <ArrowLeft className='h-4 w-4' />
+          {t("favorites.back")}
+        </Button>
+      </div>
+      <PageTitle
+        className='mb-8'
+        subtitle={t("favorites.subtitle")}
+        title={t("favorites.title")}
+      />
+      <div className='min-h-0 flex-1 overflow-auto'>
+        <Suspense fallback={<FavoritesSkeleton />}>
+          <ErrorBoundary>
+            <FavoritesData />
+          </ErrorBoundary>
+        </Suspense>
+      </div>
+    </div>
+  );
+};
+
+export default Favorites;

--- a/apps/desktop/src/pages/mod.tsx
+++ b/apps/desktop/src/pages/mod.tsx
@@ -8,6 +8,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router";
+import FavoriteButton from "@/components/mod-browsing/favorite-button";
 import ModButton from "@/components/mod-browsing/mod-button";
 import { InstalledFilesDisplay } from "@/components/mod-detail/installed-files-display";
 import { ModAudioPreview } from "@/components/mod-detail/mod-audio-preview";
@@ -286,6 +287,7 @@ const Mod = () => {
                     {t("modOptions.openTooltip")}
                   </Button>
                 )}
+                <FavoriteButton remoteId={mod.remoteId} variant='inline' />
                 {hasUpdate && (
                   <Button
                     icon={<RefreshCw className='h-4 w-4' />}

--- a/apps/desktop/src/pages/mods.tsx
+++ b/apps/desktop/src/pages/mods.tsx
@@ -175,7 +175,9 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     hideOutdated,
     timePeriod = TimePeriod.ALL_TIME,
     filterMode,
+    showFavoritesOnly = false,
   } = modsFilters;
+  const favorites = usePersistedStore((state) => state.favorites);
   const effectiveMapQuickFilter: MapQuickFilter = mapsOnly
     ? "only"
     : isCustomMapsEnabled
@@ -274,6 +276,11 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
       );
     }
 
+    if (showFavoritesOnly && favorites.length > 0) {
+      const favSet = new Set(favorites);
+      filtered = filtered.filter((mod) => favSet.has(mod.remoteId));
+    }
+
     return filtered;
   }, [
     results,
@@ -286,6 +293,8 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     effectiveMapQuickFilter,
     hideOutdated,
     timePeriod,
+    showFavoritesOnly,
+    favorites,
   ]);
 
   const totalPages = paginationEnabled
@@ -328,6 +337,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
         selectedCategories,
         selectedHeroes,
         timePeriod,
+        showFavoritesOnly,
       }),
     [
       filterMode,
@@ -339,6 +349,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
       selectedCategories,
       selectedHeroes,
       timePeriod,
+      showFavoritesOnly,
     ],
   );
 
@@ -425,6 +436,11 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     [updateModsFilters],
   );
 
+  const handleShowFavoritesOnlyChange = useCallback(
+    (showFavoritesOnly: boolean) => updateModsFilters({ showFavoritesOnly }),
+    [updateModsFilters],
+  );
+
   return (
     <div className='flex min-h-0 flex-1 flex-col gap-4'>
       <SearchBar
@@ -449,7 +465,9 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
         hideNSFW={hideNSFW}
         hideOutdated={hideOutdated}
         sortType={sortType}
-        showFavoritesButton={!mapsOnly}
+        showFavoritesFilter={!mapsOnly}
+        showFavoritesOnly={showFavoritesOnly}
+        onShowFavoritesOnlyChange={handleShowFavoritesOnlyChange}
         hideMapFilter={mapsOnly || !isCustomMapsEnabled}
       />
       {filteredResults.length === 0 ? (
@@ -467,6 +485,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
               effectiveMapQuickFilter !== "off" ||
               hideNSFW ||
               hideOutdated ||
+              showFavoritesOnly ||
               timePeriod !== TimePeriod.ALL_TIME
                 ? t("mods.noModsMatchFilters")
                 : t("mods.noModsAvailable")}
@@ -477,6 +496,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
               effectiveMapQuickFilter !== "off" ||
               hideNSFW ||
               hideOutdated ||
+              showFavoritesOnly ||
               timePeriod !== TimePeriod.ALL_TIME) && (
               <EmptyDescription className='text-xs'>
                 {t("mods.emptyClearFilters")}

--- a/apps/desktop/src/pages/mods.tsx
+++ b/apps/desktop/src/pages/mods.tsx
@@ -449,6 +449,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
         hideNSFW={hideNSFW}
         hideOutdated={hideOutdated}
         sortType={sortType}
+        showFavoritesButton={!mapsOnly}
         hideMapFilter={mapsOnly || !isCustomMapsEnabled}
       />
       {filteredResults.length === 0 ? (


### PR DESCRIPTION
Star toggle on each mod card (top-right) and in the mod detail action bar lets users save mods to revisit later. Favorites persist via a new Zustand slice (migration v20) and are reachable through a Favorites button placed next to the time-period selector on the Mods Store, which opens /mods/favorites with a back button to the store.

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Mod Favorites Feature

This PR adds a persistent favorites system to the desktop application that allows users to save and manage favorite mods.

### Affected Packages
- `@deadlock-mods/desktop` (minor version bump)

### Functional Changes

**New Features:**
- Star icon toggle on mod cards (visible in top-right when not in read-only mode) and in the mod detail action bar to favorite/unfavorite mods
- New dedicated `/mods/favorites` page displaying only favorited mods with a back button for navigation
- Favorites button in the mods store search bar (next to time-period controls) that displays a badge with the count of favorited mods; only visible when not viewing custom maps
- Empty state UI on the favorites page when no mods are favorited

**State Management:**
- New `FavoritesState` slice managing a persisted `favorites: string[]` list
- Actions: `toggleFavorite`, `addFavorite`, `removeFavorite`, `isFavorite`, `clearFavorites`
- Integrated into the persisted Zustand store via `createFavoritesSlice`

**Store Migration:**
- Migration step (v20) initializes `state.favorites` to an empty array for users upgrading from earlier versions

### Component Updates
- New `FavoriteButton` component with two rendering variants: `inline` (with tooltip) and `overlay` (button with tooltip wrapper)
- `ModCard` conditionally renders `FavoriteButton` (except in read-only mode)
- `SearchBar` accepts optional `showFavoritesButton` prop to control favorites button visibility
- `Mod` detail page renders `FavoriteButton` in the action bar footer
- New `Favorites` page with suspense boundary, error handling, and responsive mod grid layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deadlock-mod-manager/deadlock-mod-manager/pull/463)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->