### PR TITLE
fix(desktop): repair mod metadata and hero detection

### DIFF
--- a/.changeset/repair-manifest-metadata.md
+++ b/.changeset/repair-manifest-metadata.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Add profile manifest repair metadata and surface broken VPK state as repairable instead of silently treating missing files as disabled.

--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -33,6 +33,19 @@ import {
 const modRepository = new ModRepository(db);
 const modDownloadRepository = new ModDownloadRepository(db);
 
+const arraysEqualIgnoringOrder = (
+  left: readonly string[] | null | undefined,
+  right: readonly string[] | null | undefined,
+): boolean => {
+  const sortedLeft = [...(left ?? [])].sort();
+  const sortedRight = [...(right ?? [])].sort();
+
+  return (
+    sortedLeft.length === sortedRight.length &&
+    sortedLeft.every((value, index) => value === sortedRight[index])
+  );
+};
+
 const hasCachedModFieldChanges = (
   existing: Mod | null,
   payload: NewMod,
@@ -54,9 +67,8 @@ const hasCachedModFieldChanges = (
   existing.audioUrl !== payload.audioUrl ||
   existing.remoteAddedAt.getTime() !== payload.remoteAddedAt.getTime() ||
   existing.remoteUpdatedAt.getTime() !== payload.remoteUpdatedAt.getTime() ||
-  JSON.stringify(existing.tags ?? []) !== JSON.stringify(payload.tags ?? []) ||
-  JSON.stringify(existing.images ?? []) !==
-    JSON.stringify(payload.images ?? []);
+  !arraysEqualIgnoringOrder(existing.tags, payload.tags) ||
+  !arraysEqualIgnoringOrder(existing.images, payload.images);
 
 export class GameBananaProvider extends Provider<GameBananaSubmission> {
   async getAllSubmissions(

--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -6,11 +6,7 @@ import {
   ModRepository,
   type NewMod,
 } from "@deadlock-mods/database";
-import {
-  GameBanana,
-  type FileserverDto,
-  guessHero,
-} from "@deadlock-mods/shared";
+import { GameBanana, type FileserverDto } from "@deadlock-mods/shared";
 import { cache } from "../../lib/redis";
 import { wideEventContext } from "../../lib/logger";
 import { resolveFileserverGeo } from "../../services/geo";
@@ -28,6 +24,7 @@ import {
   buildMetadata,
   categoryFromGameBananaProfile,
   classifyNSFW,
+  heroFromGameBananaProfile,
   mapGameBananaFileserverState,
   parseTags,
   submitterDisplayName,
@@ -35,6 +32,31 @@ import {
 
 const modRepository = new ModRepository(db);
 const modDownloadRepository = new ModDownloadRepository(db);
+
+const hasCachedModFieldChanges = (
+  existing: Mod | null,
+  payload: NewMod,
+): boolean =>
+  !existing ||
+  existing.name !== payload.name ||
+  existing.description !== payload.description ||
+  existing.author !== payload.author ||
+  existing.likes !== payload.likes ||
+  existing.hero !== payload.hero ||
+  existing.downloadCount !== payload.downloadCount ||
+  existing.remoteUrl !== payload.remoteUrl ||
+  existing.category !== payload.category ||
+  existing.downloadable !== payload.downloadable ||
+  existing.isNSFW !== payload.isNSFW ||
+  existing.isObsolete !== payload.isObsolete ||
+  existing.isMap !== payload.isMap ||
+  existing.isAudio !== payload.isAudio ||
+  existing.audioUrl !== payload.audioUrl ||
+  existing.remoteAddedAt.getTime() !== payload.remoteAddedAt.getTime() ||
+  existing.remoteUpdatedAt.getTime() !== payload.remoteUpdatedAt.getTime() ||
+  JSON.stringify(existing.tags ?? []) !== JSON.stringify(payload.tags ?? []) ||
+  JSON.stringify(existing.images ?? []) !==
+    JSON.stringify(payload.images ?? []);
 
 export class GameBananaProvider extends Provider<GameBananaSubmission> {
   async getAllSubmissions(
@@ -355,7 +377,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       tags: parseTags(profile._aTags),
       author: submitterDisplayName(profile),
       likes: profile._nLikeCount ?? 0,
-      hero: guessHero(profile._sName),
+      hero: heroFromGameBananaProfile(profile),
       downloadCount: profile._nDownloadCount ?? 0,
       remoteUrl: profile._sProfileUrl,
       category: categoryFromGameBananaProfile(profile),
@@ -399,7 +421,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       tags: parseTags(profile._aTags),
       author: submitterDisplayName(profile),
       likes: profile._nLikeCount ?? 0,
-      hero: guessHero(profile._sName),
+      hero: heroFromGameBananaProfile(profile),
       downloadCount: profile._nDownloadCount ?? 0,
       remoteUrl: profile._sProfileUrl,
       category,
@@ -500,6 +522,14 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
         };
       }
 
+      const existingMod =
+        await modRepository.findByRemoteIdIncludingBlacklisted(
+          payload.remoteId,
+        );
+      const cachedFieldsChanged = hasCachedModFieldChanges(
+        existingMod,
+        payload,
+      );
       const dbMod = await modRepository.upsertByRemoteId(payload);
 
       this.logger
@@ -517,6 +547,10 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
           dbMod,
           filesUpdatedAt,
         );
+      }
+      if (cachedFieldsChanged) {
+        await cache.del(`mod:${dbMod.remoteId}`);
+        await cache.del("mods:listing");
       }
 
       return { mod: dbMod, filesChanged };

--- a/apps/api/src/providers/game-banana/utils.test.ts
+++ b/apps/api/src/providers/game-banana/utils.test.ts
@@ -6,7 +6,30 @@ import {
   donationLinksFromMethods,
   extractDonationLinksFromDescription,
   extractMapName,
+  heroFromGameBananaProfile,
 } from "./utils";
+
+describe("heroFromGameBananaProfile", () => {
+  it("prefers the GameBanana sub-category when the public category is Skins", () => {
+    const profile = {
+      _sName: "Toon Seven",
+      _aCategory: { _sName: "Seven" },
+      _aSuperCategory: { _sName: "Skins" },
+    } as GameBanana.GameBananaModProfile;
+
+    expect(heroFromGameBananaProfile(profile)).toBe("Seven");
+  });
+
+  it("falls back to mod name aliases when GameBanana does not provide a hero category", () => {
+    const profile = {
+      _sName: "Toon Viktor",
+      _aCategory: { _sName: "Skins" },
+      _aSuperCategory: { _sName: "Skins" },
+    } as GameBanana.GameBananaModProfile;
+
+    expect(heroFromGameBananaProfile(profile)).toBe("Victor");
+  });
+});
 
 describe("extractMapName", () => {
   it("returns undefined for empty description", () => {

--- a/apps/api/src/providers/game-banana/utils.ts
+++ b/apps/api/src/providers/game-banana/utils.ts
@@ -5,6 +5,7 @@ import type {
   GameBanana,
   ModMetadata,
 } from "@deadlock-mods/shared";
+import { guessHero, normalizeHero } from "@deadlock-mods/shared";
 import { NSFW_CONTENT_RATINGS, NSFW_KEYWORDS } from "./constants";
 import type { GameBananaSubmission } from "./types";
 
@@ -24,6 +25,12 @@ export function categoryFromGameBananaProfile(
     return rootName;
   }
   return profile._aCategory?._sName ?? "Other";
+}
+
+export function heroFromGameBananaProfile(
+  profile: GameBananaProfileForCategory,
+): string | null {
+  return normalizeHero(profile._aCategory?._sName) ?? guessHero(profile._sName);
 }
 
 export function submitterDisplayName(

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -1,7 +1,8 @@
 use crate::download_manager::DownloadTask;
 use crate::errors::Error;
-use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use crate::mod_manager::Mod;
+use crate::mod_manager::ProfileVpkManifestSourceDownload;
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -571,9 +572,7 @@ pub async fn get_profile_vpk_manifest(
 }
 
 #[tauri::command]
-pub async fn hydrate_mods_from_manifest(
-  profile_folder: Option<String>,
-) -> Result<usize, Error> {
+pub async fn hydrate_mods_from_manifest(profile_folder: Option<String>) -> Result<usize, Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
   mod_manager.hydrate_mods_from_manifest(profile_folder)
 }
@@ -628,6 +627,23 @@ pub async fn seed_profile_vpk_manifest_entries(
   if changed {
     manifest.save(&addons_path)?;
   }
+
+  Ok(())
+}
+
+#[tauri::command]
+pub async fn update_profile_vpk_manifest_repair_metadata(
+  profile_folder: Option<String>,
+  mod_id: String,
+  source_downloads: Vec<ProfileVpkManifestSourceDownload>,
+) -> Result<(), Error> {
+  log::info!("Updating VPK repair metadata for mod {mod_id} in profile {profile_folder:?}");
+
+  let mod_manager = MANAGER.lock().unwrap();
+  let addons_path = mod_manager.get_addons_path(profile_folder.as_deref())?;
+  let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+  manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
+  manifest.save(&addons_path)?;
 
   Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -639,8 +639,10 @@ pub async fn update_profile_vpk_manifest_repair_metadata(
 ) -> Result<(), Error> {
   log::info!("Updating VPK repair metadata for mod {mod_id} in profile {profile_folder:?}");
 
-  let mod_manager = MANAGER.lock().unwrap();
-  let addons_path = mod_manager.get_addons_path(profile_folder.as_deref())?;
+  let addons_path = {
+    let mod_manager = MANAGER.lock().unwrap();
+    mod_manager.get_addons_path(profile_folder.as_deref())?
+  };
   let mut manifest = ProfileVpkManifest::load(&addons_path)?;
   manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
   manifest.save(&addons_path)?;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -195,6 +195,7 @@ pub fn run() {
       commands::profiles::get_profile_vpk_manifest,
       commands::profiles::hydrate_mods_from_manifest,
       commands::profiles::seed_profile_vpk_manifest_entries,
+      commands::profiles::update_profile_vpk_manifest_repair_metadata,
       commands::profiles::delete_profile_vpk,
       commands::profiles::show_profile_vpk_in_folder,
       commands::profiles::import_profile_batch,

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -304,7 +304,7 @@ impl ModManager {
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     let manifest_entry = manifest.mods.get(&mod_id).cloned();
 
-    let (installed_vpks, original_vpk_names) = if let Some(entry) = manifest_entry.as_ref()
+    let (mut installed_vpks, mut original_vpk_names) = if let Some(entry) = manifest_entry.as_ref()
       && !entry.current_vpks.is_empty()
     {
       log::info!("Using manifest VPK state for mod {mod_id}");
@@ -343,6 +343,53 @@ impl ModManager {
         "Cannot disable mod {mod_id}: no enabled VPK files are recorded for this profile"
       )));
     };
+
+    let existing_vpk_pairs = installed_vpks
+      .iter()
+      .enumerate()
+      .filter_map(|(index, vpk_name)| {
+        if addons_path.join(vpk_name).exists() {
+          Some((
+            vpk_name.clone(),
+            original_vpk_names
+              .get(index)
+              .cloned()
+              .unwrap_or_else(|| vpk_name.clone()),
+          ))
+        } else {
+          None
+        }
+      })
+      .collect::<Vec<_>>();
+
+    if existing_vpk_pairs.len() != installed_vpks.len() {
+      if existing_vpk_pairs.is_empty() {
+        log::warn!(
+          "Mod {mod_id} is marked enabled but none of its enabled VPK files exist; marking it disabled without renaming files"
+        );
+        manifest.mark_disabled(&mod_id, Vec::new(), original_vpk_names);
+        manifest.save(&addons_path)?;
+
+        if let Some(mut local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
+          local_mod.installed_vpks = Vec::new();
+          self.mod_repository.add_mod(local_mod);
+        }
+
+        return Ok(());
+      }
+
+      log::warn!(
+        "Mod {mod_id} is missing some enabled VPK files; disabling only the files that still exist"
+      );
+      installed_vpks = existing_vpk_pairs
+        .iter()
+        .map(|(vpk_name, _)| vpk_name.clone())
+        .collect();
+      original_vpk_names = existing_vpk_pairs
+        .into_iter()
+        .map(|(_, original_name)| original_name)
+        .collect();
+    }
 
     let prefixed_vpks =
       self
@@ -457,17 +504,27 @@ impl ModManager {
       .vpk_manager
       .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
 
+    let mut updated_mod_ids = Vec::new();
     for (mod_id, new_vpk_names) in updated_vpk_mappings {
       if let Some(entry) = manifest.mods.get_mut(&mod_id) {
         entry.enabled = true;
         entry.current_vpks = new_vpk_names.clone();
         entry.disabled_vpks.clear();
       }
+      updated_mod_ids.push(mod_id.clone());
 
       if let Some(mut mod_entry) = self.mod_repository.remove_mod(&mod_id) {
         mod_entry.installed_vpks = new_vpk_names;
         self.mod_repository.add_mod(mod_entry);
       }
+    }
+    for mod_id in updated_mod_ids {
+      let source_downloads = manifest
+        .mods
+        .get(&mod_id)
+        .map(|entry| entry.source_downloads.clone())
+        .unwrap_or_default();
+      manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
     }
 
     manifest.save(&addons_path)?;
@@ -554,6 +611,14 @@ impl ModManager {
         self.mod_repository.add_mod(mod_entry);
       }
     }
+    for (remote_id, _) in &updated_mappings {
+      let source_downloads = manifest
+        .mods
+        .get(remote_id)
+        .map(|entry| entry.source_downloads.clone())
+        .unwrap_or_default();
+      manifest.update_repair_metadata(&addons_path, remote_id, source_downloads)?;
+    }
 
     manifest.save(&addons_path)?;
 
@@ -620,12 +685,14 @@ impl ModManager {
 
     // Update mod data with new VPK names and re-add to repository
     let mut result_mods = Vec::new();
+    let mut updated_mod_ids = Vec::new();
     for (mod_id, new_vpk_names) in updated_vpk_mappings {
       if let Some(entry) = manifest.mods.get_mut(&mod_id) {
         entry.enabled = true;
         entry.current_vpks = new_vpk_names.clone();
         entry.disabled_vpks.clear();
       }
+      updated_mod_ids.push(mod_id.clone());
 
       if let Some(index) = updated_mods
         .iter()
@@ -636,6 +703,14 @@ impl ModManager {
         self.mod_repository.add_mod(deadlock_mod.clone());
         result_mods.push(deadlock_mod);
       }
+    }
+    for mod_id in updated_mod_ids {
+      let source_downloads = manifest
+        .mods
+        .get(&mod_id)
+        .map(|entry| entry.source_downloads.clone())
+        .unwrap_or_default();
+      manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
     }
 
     for deadlock_mod in updated_mods {

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -519,12 +519,7 @@ impl ModManager {
       }
     }
     for mod_id in updated_mod_ids {
-      let source_downloads = manifest
-        .mods
-        .get(&mod_id)
-        .map(|entry| entry.source_downloads.clone())
-        .unwrap_or_default();
-      manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
+      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, &mod_id);
     }
 
     manifest.save(&addons_path)?;
@@ -612,12 +607,7 @@ impl ModManager {
       }
     }
     for (remote_id, _) in &updated_mappings {
-      let source_downloads = manifest
-        .mods
-        .get(remote_id)
-        .map(|entry| entry.source_downloads.clone())
-        .unwrap_or_default();
-      manifest.update_repair_metadata(&addons_path, remote_id, source_downloads)?;
+      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, remote_id);
     }
 
     manifest.save(&addons_path)?;
@@ -705,12 +695,7 @@ impl ModManager {
       }
     }
     for mod_id in updated_mod_ids {
-      let source_downloads = manifest
-        .mods
-        .get(&mod_id)
-        .map(|entry| entry.source_downloads.clone())
-        .unwrap_or_default();
-      manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
+      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, &mod_id);
     }
 
     for deadlock_mod in updated_mods {
@@ -721,6 +706,22 @@ impl ModManager {
 
     log::info!("Successfully reordered {} mods", result_mods.len());
     Ok(result_mods)
+  }
+
+  fn refresh_repair_metadata_after_reorder(
+    manifest: &mut ProfileVpkManifest,
+    addons_path: &Path,
+    mod_id: &str,
+  ) {
+    let source_downloads = manifest
+      .mods
+      .get(mod_id)
+      .map(|entry| entry.source_downloads.clone())
+      .unwrap_or_default();
+
+    if let Err(e) = manifest.update_repair_metadata(addons_path, mod_id, source_downloads) {
+      log::warn!("Failed to refresh repair metadata for {mod_id} after reorder: {e}");
+    }
   }
 
   pub fn clear_mods(&mut self, profile_folder: Option<String>) -> Result<(), Error> {

--- a/apps/desktop/src-tauri/src/mod_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod.rs
@@ -21,3 +21,4 @@ pub use file_tree::ModFileTree;
 pub use font_manager::{FontInfo, FontManager};
 pub use manager::ModManager;
 pub use mod_repository::Mod;
+pub use vpk_manifest::ProfileVpkManifestSourceDownload;

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -3,8 +3,14 @@ use crate::mod_manager::filesystem_helper::FileSystemHelper;
 use log;
 use regex::Regex;
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::sync::LazyLock;
+use std::thread;
+use std::time::Duration;
+
+const VPK_FILE_OPERATION_RETRIES: usize = 5;
+const VPK_FILE_OPERATION_RETRY_DELAY: Duration = Duration::from_millis(150);
 
 /// Manages VPK file operations and installation
 pub struct VpkManager {
@@ -183,12 +189,13 @@ impl VpkManager {
       let vpk_name = vpk_name.as_ref();
       let vpk_path = addons_path.join(vpk_name);
       if vpk_path.exists()
-        && let Err(e) = fs::OpenOptions::new().write(true).open(&vpk_path) {
-          log::error!(
-            "Cannot access {label_for_log} for removal (file may be in use): {vpk_name}: {e}"
-          );
-          locked_files.push(vpk_name.to_string());
-        }
+        && let Err(e) = fs::OpenOptions::new().write(true).open(&vpk_path)
+      {
+        log::error!(
+          "Cannot access {label_for_log} for removal (file may be in use): {vpk_name}: {e}"
+        );
+        locked_files.push(vpk_name.to_string());
+      }
     }
 
     if !locked_files.is_empty() {
@@ -202,6 +209,8 @@ impl VpkManager {
     addons_path: &Path,
     renamed: Vec<(String, String)>,
     original_error: std::io::Error,
+    operation: &str,
+    vpk_name: &str,
   ) -> Error {
     let mut rollback_failures = Vec::new();
     for (from_name, to_name) in renamed.into_iter().rev() {
@@ -220,7 +229,66 @@ impl VpkManager {
         rollback_failures.join(", ")
       ))
     } else {
-      original_error.into()
+      Self::vpk_file_operation_error(operation, vpk_name, original_error)
+    }
+  }
+
+  fn is_transient_vpk_file_lock_error(error: &io::Error) -> bool {
+    matches!(
+      error.raw_os_error(),
+      // Windows sharing violation, lock violation, and access denied.
+      Some(32 | 33 | 5)
+    ) || matches!(
+      error.kind(),
+      io::ErrorKind::PermissionDenied | io::ErrorKind::WouldBlock
+    )
+  }
+
+  fn retry_vpk_file_operation(
+    operation: &str,
+    vpk_name: &str,
+    mut run: impl FnMut() -> io::Result<()>,
+  ) -> io::Result<()> {
+    let mut last_error = None;
+
+    for attempt in 0..=VPK_FILE_OPERATION_RETRIES {
+      match run() {
+        Ok(()) => return Ok(()),
+        Err(error) => {
+          let should_retry =
+            attempt < VPK_FILE_OPERATION_RETRIES && Self::is_transient_vpk_file_lock_error(&error);
+          if should_retry {
+            log::warn!(
+              "VPK {operation} for {vpk_name} failed because the file may be temporarily locked; retrying ({}/{}) after {}ms: {error}",
+              attempt + 1,
+              VPK_FILE_OPERATION_RETRIES,
+              VPK_FILE_OPERATION_RETRY_DELAY.as_millis()
+            );
+            last_error = Some(error);
+            thread::sleep(VPK_FILE_OPERATION_RETRY_DELAY);
+          } else {
+            return Err(error);
+          }
+        }
+      }
+    }
+
+    Err(last_error.unwrap_or_else(|| io::Error::other("VPK file operation failed")))
+  }
+
+  fn retry_vpk_rename(from: &Path, to: &Path, vpk_name: &str) -> io::Result<()> {
+    Self::retry_vpk_file_operation("rename", vpk_name, || fs::rename(from, to))
+  }
+
+  fn retry_vpk_remove(path: &Path, vpk_name: &str) -> io::Result<()> {
+    Self::retry_vpk_file_operation("remove", vpk_name, || fs::remove_file(path))
+  }
+
+  fn vpk_file_operation_error(operation: &str, vpk_name: &str, error: io::Error) -> Error {
+    if Self::is_transient_vpk_file_lock_error(&error) {
+      Error::VpkInUse(format!("{vpk_name} ({operation} failed: {error})"))
+    } else {
+      Error::Io(error)
     }
   }
 
@@ -447,7 +515,7 @@ impl VpkManager {
       let new_name = format!("pak{next_number:02}_dir.vpk");
       let new_path = addons_path.join(&new_name);
 
-      if let Err(e) = fs::rename(&old_path, &new_path) {
+      if let Err(e) = Self::retry_vpk_rename(&old_path, &new_path, prefixed_name) {
         log::error!(
           "Failed to enable VPK {prefixed_name}: {e}, rolling back {count} already-renamed file(s)",
           count = renamed.len()
@@ -456,6 +524,8 @@ impl VpkManager {
           addons_path,
           renamed,
           e,
+          "enable",
+          prefixed_name,
         ));
       }
 
@@ -518,7 +588,7 @@ impl VpkManager {
         log::info!(
           "Prefixed destination already exists (newly staged variant), removing old active VPK: {vpk_name}"
         );
-        if let Err(e) = fs::remove_file(&old_path) {
+        if let Err(e) = Self::retry_vpk_remove(&old_path, &vpk_name) {
           log::error!(
             "Failed to remove old active VPK {vpk_name}: {e}, rolling back {count} already-renamed file(s)",
             count = renamed.len()
@@ -527,9 +597,11 @@ impl VpkManager {
             addons_path,
             renamed,
             e,
+            "disable",
+            &vpk_name,
           ));
         }
-      } else if let Err(e) = fs::rename(&old_path, &new_path) {
+      } else if let Err(e) = Self::retry_vpk_rename(&old_path, &new_path, &vpk_name) {
         log::error!(
           "Failed to disable VPK {vpk_name}: {e}, rolling back {count} already-renamed file(s)",
           count = renamed.len()
@@ -538,6 +610,8 @@ impl VpkManager {
           addons_path,
           renamed,
           e,
+          "disable",
+          &vpk_name,
         ));
       }
 
@@ -657,13 +731,10 @@ impl VpkManager {
           "Selected VPK not found for mod {mod_id}: {prefixed}, restoring previous state"
         );
         if !previously_prefixed.is_empty()
-          && let Err(restore_err) =
-            self.enable_vpks(addons_path, mod_id, &previously_prefixed)
-          {
-            log::error!(
-              "Failed to restore previous state for mod {mod_id}: {restore_err}"
-            );
-          }
+          && let Err(restore_err) = self.enable_vpks(addons_path, mod_id, &previously_prefixed)
+        {
+          log::error!("Failed to restore previous state for mod {mod_id}: {restore_err}");
+        }
         return Err(Error::ModFileNotFound);
       }
     }
@@ -675,13 +746,10 @@ impl VpkManager {
           "Failed to enable selected VPKs for mod {mod_id}: {e}, restoring previous state"
         );
         if !previously_prefixed.is_empty()
-          && let Err(restore_err) =
-            self.enable_vpks(addons_path, mod_id, &previously_prefixed)
-          {
-            log::error!(
-              "Failed to restore previous state for mod {mod_id}: {restore_err}"
-            );
-          }
+          && let Err(restore_err) = self.enable_vpks(addons_path, mod_id, &previously_prefixed)
+        {
+          log::error!("Failed to restore previous state for mod {mod_id}: {restore_err}");
+        }
         Err(e)
       }
     }

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -1,9 +1,10 @@
 use crate::errors::Error;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, io::ErrorKind, path::Path};
+use vpk_parser::{VpkParseOptions, VpkParser};
 
 const MANIFEST_FILENAME: &str = ".dmm.json";
-const CURRENT_MANIFEST_VERSION: u32 = 1;
+const CURRENT_MANIFEST_VERSION: u32 = 2;
 
 const fn current_manifest_version() -> u32 {
   CURRENT_MANIFEST_VERSION
@@ -31,6 +32,32 @@ pub struct ProfileVpkManifestEntry {
   pub disabled_vpks: Vec<String>,
   #[serde(default)]
   pub original_vpk_names: Vec<String>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub source_downloads: Vec<ProfileVpkManifestSourceDownload>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub vpk_fingerprints: Vec<ProfileVpkManifestVpkFingerprint>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkManifestSourceDownload {
+  pub name: String,
+  pub size: u64,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub url: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub md5_checksum: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkManifestVpkFingerprint {
+  pub current_name: String,
+  pub original_name: String,
+  pub file_size: u64,
+  pub fast_hash: String,
+  pub sha256: String,
+  pub manifest_sha256: String,
 }
 
 impl Default for ProfileVpkManifest {
@@ -76,7 +103,7 @@ impl ProfileVpkManifest {
       ))
     })?;
 
-    if manifest.version == 0 {
+    if manifest.version < CURRENT_MANIFEST_VERSION {
       manifest.version = CURRENT_MANIFEST_VERSION;
     }
 
@@ -144,6 +171,78 @@ impl ProfileVpkManifest {
 
   pub fn remove_mod(&mut self, mod_id: &str) {
     self.mods.remove(mod_id);
+  }
+
+  pub fn update_repair_metadata(
+    &mut self,
+    addons_path: &Path,
+    mod_id: &str,
+    source_downloads: Vec<ProfileVpkManifestSourceDownload>,
+  ) -> Result<(), Error> {
+    let Some(entry) = self.mods.get_mut(mod_id) else {
+      return Ok(());
+    };
+
+    entry.source_downloads = source_downloads;
+    entry.vpk_fingerprints =
+      Self::fingerprints_for_entry(addons_path, &entry.current_vpks, &entry.original_vpk_names)?;
+    Ok(())
+  }
+
+  fn fingerprints_for_entry(
+    addons_path: &Path,
+    current_vpks: &[String],
+    original_vpk_names: &[String],
+  ) -> Result<Vec<ProfileVpkManifestVpkFingerprint>, Error> {
+    let mut fingerprints = Vec::new();
+    for (index, current_name) in current_vpks.iter().enumerate() {
+      let path = addons_path.join(current_name);
+      if !path.exists() {
+        log::warn!(
+          "Skipping VPK fingerprint for missing manifest file: {}",
+          path.display()
+        );
+        continue;
+      }
+
+      let vpk_data = fs::read(&path)?;
+      let metadata = fs::metadata(&path)?;
+      let last_modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|duration| chrono::DateTime::from_timestamp(duration.as_secs() as i64, 0));
+      let parsed = VpkParser::parse(
+        vpk_data,
+        VpkParseOptions {
+          include_full_file_hash: true,
+          file_path: path.to_string_lossy().to_string(),
+          last_modified,
+          include_merkle: false,
+          include_entries: false,
+        },
+      )
+      .map_err(|e| {
+        Error::InvalidInput(format!(
+          "Failed to fingerprint VPK file {}: {e}",
+          path.display()
+        ))
+      })?;
+
+      fingerprints.push(ProfileVpkManifestVpkFingerprint {
+        current_name: current_name.clone(),
+        original_name: original_vpk_names
+          .get(index)
+          .cloned()
+          .unwrap_or_else(|| current_name.clone()),
+        file_size: parsed.fingerprint.file_size as u64,
+        fast_hash: parsed.fingerprint.fast_hash,
+        sha256: parsed.fingerprint.sha256,
+        manifest_sha256: parsed.manifest_sha256,
+      });
+    }
+
+    Ok(fingerprints)
   }
 }
 
@@ -229,5 +328,14 @@ mod tests {
     assert_eq!(entry.original_vpk_names, vec!["cool_mod.vpk".to_string()]);
     assert_eq!(entry.current_vpks, vec!["pak02_dir.vpk".to_string()]);
     assert_eq!(entry.order, Some(1));
+  }
+
+  #[test]
+  fn source_downloads_are_omitted_when_empty() {
+    let manifest = ProfileVpkManifest::default();
+    let json = serde_json::to_string(&manifest).unwrap();
+
+    assert!(!json.contains("sourceDownloads"));
+    assert!(!json.contains("vpkFingerprints"));
   }
 }

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -59,6 +59,12 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
         pillClass: "bg-primary/15 text-primary",
         dotClass: "bg-primary",
       };
+    case ModStatus.NeedsRepair:
+      return {
+        label: "Needs repair",
+        pillClass: "bg-amber-500/15 text-amber-800 dark:text-amber-300",
+        dotClass: "bg-amber-500",
+      };
     case ModStatus.FailedToDownload:
       return {
         label: "Failed",

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -2,6 +2,7 @@ import { Button } from "@deadlock-mods/ui/components/button";
 import { Card } from "@deadlock-mods/ui/components/card";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Pause, Play } from "@phosphor-icons/react";
+import type { TFunction } from "i18next";
 import { type MouseEvent, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -21,7 +22,10 @@ type StatusChipVariant = {
   dotClass: string;
 };
 
-const getStatusVariant = (status: ModStatus): StatusChipVariant => {
+const getStatusVariant = (
+  status: ModStatus,
+  t: TFunction,
+): StatusChipVariant => {
   switch (status) {
     case ModStatus.Downloading:
       return {
@@ -37,7 +41,7 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
       };
     case ModStatus.Paused:
       return {
-        label: "Paused",
+        label: t("downloads.paused"),
         pillClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
         dotClass: "bg-amber-500",
       };
@@ -61,7 +65,7 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
       };
     case ModStatus.NeedsRepair:
       return {
-        label: "Needs repair",
+        label: t("downloads.needsRepair"),
         pillClass: "bg-amber-500/15 text-amber-800 dark:text-amber-300",
         dotClass: "bg-amber-500",
       };
@@ -82,9 +86,7 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
 
 const StatusChip = ({ status }: { status: ModStatus }) => {
   const { t } = useTranslation();
-  const variant = getStatusVariant(status);
-  const label =
-    status === ModStatus.Paused ? t("downloads.paused") : variant.label;
+  const variant = getStatusVariant(status, t);
   return (
     <span
       className={cn(
@@ -95,7 +97,7 @@ const StatusChip = ({ status }: { status: ModStatus }) => {
         aria-hidden
         className={cn("size-1.5 rounded-full", variant.dotClass)}
       />
-      {label}
+      {variant.label}
     </span>
   );
 };

--- a/apps/desktop/src/components/mod-browsing/hero-filter.tsx
+++ b/apps/desktop/src/components/mod-browsing/hero-filter.tsx
@@ -17,10 +17,13 @@ import {
 import { Check } from "@deadlock-mods/ui/icons";
 import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { cn } from "@/lib/utils";
 
 type HeroFilterProps = {
-  mods: ModDto[];
+  mods: Array<
+    ModDto & { detectedHero?: string | null; heroOverride?: string | null }
+  >;
   selectedHeroes: string[];
   onHeroesChange: (heroes: string[]) => void;
 };
@@ -37,12 +40,15 @@ const HeroFilter = ({
     const heroes = Array.from(
       new Set(
         mods
-          .map((mod) => mod.hero)
+          .map((mod) => resolveModHero(mod, mod).hero)
           .filter((hero): hero is string => Boolean(hero)),
       ),
     ).sort((a, b) => a.localeCompare(b));
     // Add "None" option for mods without specific heroes
-    if (mods.some((mod) => !mod.hero) && !heroes.includes("None")) {
+    if (
+      mods.some((mod) => !resolveModHero(mod, mod).hero) &&
+      !heroes.includes("None")
+    ) {
       heroes.unshift("None");
     }
     return heroes;

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -2,6 +2,7 @@ import type { ModDto } from "@deadlock-mods/shared";
 import { Button } from "@deadlock-mods/ui/components/button";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Switch } from "@deadlock-mods/ui/components/switch";
+import { invoke } from "@tauri-apps/api/core";
 import {
   Tooltip,
   TooltipContent,
@@ -9,9 +10,11 @@ import {
 } from "@deadlock-mods/ui/components/tooltip";
 import {
   Check,
+  CircleHelp,
   DownloadIcon,
   Loader2,
   PlusIcon,
+  WrenchIcon,
   X,
   XIcon,
 } from "@deadlock-mods/ui/icons";
@@ -32,11 +35,21 @@ import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { useDownload } from "@/hooks/use-download";
 import useInstallWithCollection from "@/hooks/use-install-with-collection";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
+import {
+  normalizeRepairDownloads,
+  useRepairMods,
+} from "@/hooks/use-repair-mods";
 import useUninstall from "@/hooks/use-uninstall";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { type LocalMod, ModStatus } from "@/types/mods";
+import {
+  type LocalMod,
+  type ModDownloadItem,
+  ModStatus,
+  type RepairReason,
+} from "@/types/mods";
+import { isTauriError } from "@/types/tauri";
 
 interface ModButtonProps {
   remoteMod: Pick<ModDto, "remoteId" | "name" | "downloadable"> | undefined;
@@ -47,10 +60,12 @@ export const ModStatusIcon = ({
   status,
   hovering,
   className,
+  repairReason,
 }: {
   status: ModStatus | undefined;
   hovering?: boolean;
   className?: string;
+  repairReason?: RepairReason;
 }) => {
   const loadingStatuses = [
     ModStatus.Downloading,
@@ -73,6 +88,14 @@ export const ModStatusIcon = ({
       case ModStatus.FailedToInstall:
       case ModStatus.FailedToRemove:
         return XIcon;
+      case ModStatus.NeedsRepair:
+        if (
+          repairReason === "needsDownloadChoice" ||
+          repairReason === "needsFileSelection"
+        ) {
+          return CircleHelp;
+        }
+        return WrenchIcon;
       case ModStatus.Removed:
       case ModStatus.Error:
         return RiErrorWarningLine;
@@ -101,6 +124,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
   const { analytics } = useAnalyticsContext();
   const confirm = useConfirm();
   const localMods = usePersistedStore((state) => state.localMods);
+  const getActiveProfile = usePersistedStore((state) => state.getActiveProfile);
 
   const { availableFiles } = useModDownloads({
     remoteId: remoteMod?.remoteId,
@@ -122,6 +146,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     cancelInstallation,
     currentMod,
   } = useInstallWithCollection();
+  const { repairMod } = useRepairMods();
   const { uninstall } = useUninstall();
   const getModProgress = usePersistedStore((state) => state.getModProgress);
   const setInstalledVpks = usePersistedStore((state) => state.setInstalledVpks);
@@ -141,6 +166,23 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     ((resolution: HeroConflictResolution) => void) | null
   >(null);
 
+  const persistRepairMetadata = useCallback(
+    async (mod: LocalMod, sourceDownloads: ModDownloadItem[]) => {
+      const activeProfile = getActiveProfile();
+      await invoke("update_profile_vpk_manifest_repair_metadata", {
+        profileFolder: activeProfile?.folderName ?? null,
+        modId: mod.remoteId,
+        sourceDownloads: sourceDownloads.map((download) => ({
+          name: download.name,
+          size: download.size ?? 0,
+          url: download.url,
+          md5Checksum: download.md5Checksum ?? null,
+        })),
+      });
+    },
+    [getActiveProfile],
+  );
+
   const performInstall = useCallback(
     async (mod: typeof localMod) => {
       if (!mod) {
@@ -154,7 +196,24 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           setModStatus(m.remoteId, ModStatus.Installed);
           setInstalledVpks(m.remoteId, result.installed_vpks, result.file_tree);
           setModEnabledInCurrentProfile(m.remoteId, true);
-          toast.success(t("notifications.modInstalledSuccessfully"));
+          persistRepairMetadata(
+            m,
+            m.selectedDownloads?.length
+              ? m.selectedDownloads
+              : m.repairDownloads?.length
+                ? normalizeRepairDownloads(m.repairDownloads)
+                : (m.downloads ?? []),
+          ).catch((error) => {
+            logger
+              .withMetadata({ modId: m.remoteId })
+              .withError(error)
+              .warn("Failed to persist VPK repair metadata");
+          });
+          const successMessage =
+            m.status === ModStatus.NeedsRepair
+              ? t("notifications.modRepairedSuccessfully")
+              : t("notifications.modEnabledSuccessfully");
+          toast.success(successMessage);
           analytics.trackModInstalled(m.remoteId, {
             vpk_count: result.installed_vpks.length,
             file_tree_complexity: result.file_tree?.has_multiple_files
@@ -164,7 +223,13 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         },
         onError: (m, error) => {
           setModStatus(m.remoteId, ModStatus.Downloaded);
-          toast.error(error.message || t("notifications.failedToInstallMod"));
+          if (isTauriError(error) && error.kind === "vpkInUse") {
+            toast.error(t("notifications.failedToEnableMod"), {
+              description: t("notifications.enableErrorVpkInUse"),
+            });
+          } else {
+            toast.error(error.message || t("notifications.failedToInstallMod"));
+          }
           analytics.trackError(
             "mod_installation",
             error.message || "Unknown installation error",
@@ -192,6 +257,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
       setModStatus,
       setInstalledVpks,
       setModEnabledInCurrentProfile,
+      persistRepairMetadata,
       t,
       analytics,
     ],
@@ -277,6 +343,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           await uninstall(localMod, false);
           analytics.trackModUninstalled(localMod.remoteId, "user_choice");
           break;
+        case ModStatus.NeedsRepair:
+          await repairMod(localMod, {
+            interactive: true,
+            availableFiles,
+            installInteractively: performInstall,
+            requestDownloadSelection: async () => {
+              await download();
+              toast.info(t("modButton.needsRepairSelectDownload"));
+            },
+          });
+          break;
         case ModStatus.FailedToDownload:
           break;
         case ModStatus.Error:
@@ -300,6 +377,8 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     removeMod,
     askHeroConflict,
     performInstall,
+    repairMod,
+    availableFiles,
     t,
     analytics,
     remoteMod?.remoteId,
@@ -335,12 +414,20 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           return t("modButton.enableMod");
         }
         return t("modButton.downloaded");
+      case ModStatus.NeedsRepair:
+        if (
+          localMod.repairReason === "needsDownloadChoice" ||
+          localMod.repairReason === "needsFileSelection"
+        ) {
+          return t("modButton.chooseRepairSource");
+        }
+        return t("modButton.needsRepair");
       case undefined:
         return t("modButton.add");
       default:
         return t(`modButton.${localMod?.status}`);
     }
-  }, [localMod?.status, t, hovering]);
+  }, [localMod?.status, localMod?.repairReason, t, hovering]);
 
   const tooltip = useMemo(() => {
     switch (localMod?.status) {
@@ -348,12 +435,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         return t("modButton.installedTooltip");
       case ModStatus.Downloaded:
         return t("modButton.downloadedTooltip");
+      case ModStatus.NeedsRepair:
+        if (localMod.repairReason) {
+          return t(`modStatus.repairReason.${localMod.repairReason}`);
+        }
+        return t("modButton.needsRepairTooltip");
       case undefined:
         return t("modButton.add");
       default:
         return t(`modButton.${localMod?.status}`);
     }
-  }, [localMod?.status, t]);
+  }, [localMod?.status, localMod?.repairReason, t]);
 
   const buttonVariant = useMemo(() => {
     switch (localMod?.status) {
@@ -367,10 +459,20 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           return "default";
         }
         return "outline";
+      case ModStatus.NeedsRepair:
+        return "outline";
       default:
         return variant === "iconOnly" ? "outline" : "default";
     }
   }, [variant, localMod?.status, hovering]);
+
+  const buttonClassName = useMemo(
+    () =>
+      localMod?.status === ModStatus.NeedsRepair
+        ? "border-amber-500/50 bg-amber-500/10 text-amber-800 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200"
+        : undefined,
+    [localMod?.status],
+  );
 
   return (
     <ErrorBoundary>
@@ -415,13 +517,18 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
             <Button
               disabled={isActionInProgress || isAnalyzing}
               icon={
-                <ModStatusIcon hovering={hovering} status={localMod?.status} />
+                <ModStatusIcon
+                  hovering={hovering}
+                  repairReason={localMod?.repairReason}
+                  status={localMod?.status}
+                />
               }
               onClick={onClick}
               ref={ref}
               size={variant === "iconOnly" ? "icon" : "default"}
               title={text}
-              variant={buttonVariant}>
+              variant={buttonVariant}
+              className={buttonClassName}>
               {variant === "iconOnly" ? null : text}
             </Button>
           </TooltipTrigger>

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/hooks/use-repair-mods";
 import useUninstall from "@/hooks/use-uninstall";
 import logger from "@/lib/logger";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import {
@@ -300,17 +301,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           break;
         case ModStatus.Downloaded:
         case ModStatus.FailedToInstall: {
-          const detectedHero = localMod.detectedHero;
-          if (detectedHero) {
+          const resolvedHero = resolveModHero(localMod, localMod).hero;
+          if (resolvedHero) {
             const conflictingMod = localMods.find(
               (m) =>
                 m.remoteId !== localMod.remoteId &&
                 m.status === ModStatus.Installed &&
-                m.detectedHero === detectedHero,
+                resolveModHero(m, m).hero === resolvedHero,
             );
             if (conflictingMod) {
               const resolution = await askHeroConflict(
-                detectedHero,
+                resolvedHero,
                 conflictingMod,
                 localMod,
               );

--- a/apps/desktop/src/components/mod-browsing/mod-card.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-card.tsx
@@ -11,6 +11,7 @@ import {
   UpdateAvailableBadge,
   UpdatedRecentlyBadge,
 } from "@/components/mod-management/mod-update-badges";
+import { NeedsRepairBadge } from "@/components/mod-management/needs-repair-badge";
 import { ObsoleteModWarning } from "@/components/mod-management/obsolete-mod-warning";
 import { OutdatedModWarning } from "@/components/mod-management/outdated-mod-warning";
 import { useThemeOverride } from "@/components/providers/theme-overrides";
@@ -102,6 +103,7 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
           />
         )}
         {(status === ModStatus.Installed ||
+          status === ModStatus.NeedsRepair ||
           mod.isObsolete ||
           isModOutdated(mod) ||
           isUpdatedRecently(mod) ||
@@ -109,6 +111,9 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
           <div className='pointer-events-none absolute inset-x-0 bottom-0 z-10 flex items-end justify-end gap-1 bg-gradient-to-t from-black/60 to-transparent px-2 pb-2 pt-6'>
             {status === ModStatus.Installed && (
               <Badge>{t("modStatus.installed")}</Badge>
+            )}
+            {status === ModStatus.NeedsRepair && (
+              <NeedsRepairBadge reason={localMod?.repairReason} />
             )}
             {mod.isObsolete && <ObsoleteModWarning variant='indicator' />}
             {isModOutdated(mod) && <OutdatedModWarning variant='indicator' />}

--- a/apps/desktop/src/components/mod-detail/mod-info.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-info.tsx
@@ -1,16 +1,31 @@
-import type { ModDto } from "@deadlock-mods/shared";
+import { DeadlockHeroes, type ModDto } from "@deadlock-mods/shared";
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@deadlock-mods/ui/components/avatar";
 import { Badge } from "@deadlock-mods/ui/components/badge";
+import { Button } from "@deadlock-mods/ui/components/button";
 import {
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@deadlock-mods/ui/components/card";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@deadlock-mods/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deadlock-mods/ui/components/popover";
 import { Separator } from "@deadlock-mods/ui/components/separator";
 import {
   Tooltip,
@@ -20,16 +35,25 @@ import {
 import {
   Calendar,
   CalendarPlus,
+  Check,
   Download,
   Heart,
   Package,
+  RotateCcw,
+  Settings,
   Tag,
   User,
 } from "@deadlock-mods/ui/icons";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHero } from "@/hooks/use-hero";
 import { getModCategoryDisplayName } from "@/lib/constants";
+import {
+  type ResolvedModHero,
+  resolveModHero,
+} from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
 import { DateDisplay } from "../date-display";
 
 interface ModInfoProps {
@@ -52,10 +76,11 @@ export const ModInfo = ({
   const localMods = usePersistedStore((state) => state.localMods);
   const localMod = localMods.find((m) => m.remoteId === mod.remoteId);
 
-  const heroLabel = localMod?.detectedHero ?? null;
+  const resolvedHero = resolveModHero(mod, localMod);
+  const showHeroStat = resolvedHero.hero !== null || localMod !== undefined;
   const hasTags = mod.tags && mod.tags.length > 0;
   const hasFileInfo = activeArchiveNames.size > 0 && totalDownloads > 1;
-  const statCount = (heroLabel ? 1 : 0) + 3 + (hasFileInfo ? 1 : 0);
+  const statCount = (showHeroStat ? 1 : 0) + 3 + (hasFileInfo ? 1 : 0);
   const gridCols =
     statCount <= 3
       ? "grid grid-cols-1 gap-3 sm:grid-cols-3"
@@ -77,7 +102,13 @@ export const ModInfo = ({
       <CardContent className={hasHero || mod.isAudio ? "" : "pt-6"}>
         <div className='space-y-5'>
           <div className={gridCols}>
-            {heroLabel && <HeroDisplay name={heroLabel} />}
+            {showHeroStat && (
+              <HeroDisplay
+                mod={mod}
+                resolvedHero={resolvedHero}
+                canOverride={localMod !== undefined}
+              />
+            )}
             <PrimaryStat
               icon={<User className='h-4 w-4' />}
               label={t("modDetail.authorLabel")}
@@ -173,18 +204,44 @@ export const ModInfo = ({
 };
 
 interface HeroDisplayProps {
-  name: string;
+  mod: ModDto;
+  resolvedHero: ResolvedModHero;
+  canOverride: boolean;
 }
 
-const HeroDisplay = ({ name }: HeroDisplayProps) => {
+const HERO_OVERRIDE_OPTIONS = Object.values(DeadlockHeroes).sort((a, b) =>
+  a.localeCompare(b),
+);
+const GENERAL_OTHER_HERO_LABEL = "General/Other";
+
+const HeroDisplay = ({ mod, resolvedHero, canOverride }: HeroDisplayProps) => {
   const { t } = useTranslation();
-  const { data: hero } = useHero(name);
+  const [open, setOpen] = useState(false);
+  const setHeroOverride = usePersistedStore((state) => state.setHeroOverride);
+  const name = resolvedHero.hero ?? GENERAL_OTHER_HERO_LABEL;
+  const { data: hero } = useHero(resolvedHero.hero ?? "");
   const imageSrc =
     hero?.images.icon_hero_card_webp ??
     hero?.images.icon_hero_card ??
     hero?.images.icon_image_small_webp ??
     hero?.images.icon_image_small;
   const initial = name.charAt(0).toUpperCase();
+  const sourceLabel = {
+    api: t("modDetail.heroSource.api", { defaultValue: "API" }),
+    manual: t("modDetail.heroSource.manual", { defaultValue: "Manual" }),
+    name: t("modDetail.heroSource.name", { defaultValue: "Name" }),
+    none: t("modDetail.heroSource.none", { defaultValue: "Unset" }),
+    vpk: t("modDetail.heroSource.vpk", { defaultValue: "VPK" }),
+  }[resolvedHero.source];
+  const selectedValue =
+    resolvedHero.hasOverride && resolvedHero.hero === null
+      ? null
+      : resolvedHero.hero;
+
+  const handleOverride = (heroOverride: string | null | undefined) => {
+    setHeroOverride(mod.remoteId, heroOverride);
+    setOpen(false);
+  };
 
   return (
     <div className='group flex items-center gap-3 rounded-lg border border-border/50 bg-muted/30 px-3 py-2.5 transition-colors hover:bg-muted/60'>
@@ -196,10 +253,84 @@ const HeroDisplay = ({ name }: HeroDisplayProps) => {
         <span className='text-muted-foreground text-xs uppercase tracking-wide'>
           {t("modDetail.detectedHero")}
         </span>
-        <span className='truncate font-medium text-foreground text-sm'>
-          {name}
+        <span className='flex min-w-0 items-center gap-1.5'>
+          <span className='truncate font-medium text-foreground text-sm'>
+            {name}
+          </span>
+          <span className='shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-muted-foreground leading-none'>
+            {sourceLabel}
+          </span>
         </span>
       </div>
+      {canOverride && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <Button
+                  aria-label={t("modDetail.changeHero", {
+                    defaultValue: "Change hero",
+                  })}
+                  className='ml-auto h-7 w-7 shrink-0 opacity-80 group-hover:opacity-100'
+                  size='icon'
+                  variant='ghost'>
+                  <Settings className='h-3.5 w-3.5' />
+                </Button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t("modDetail.changeHero", { defaultValue: "Change hero" })}
+            </TooltipContent>
+          </Tooltip>
+          <PopoverContent align='start' className='w-[260px] p-0'>
+            <Command>
+              <CommandInput placeholder={t("filters.searchHeroes")} />
+              <CommandList>
+                <CommandEmpty>{t("filters.noHeroesFound")}</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem onSelect={() => handleOverride(undefined)}>
+                    <RotateCcw className='mr-2 h-4 w-4 flex-shrink-0' />
+                    <span>
+                      {t("modDetail.heroOverrideAutomatic", {
+                        defaultValue: "Use automatic",
+                      })}
+                    </span>
+                  </CommandItem>
+                  <CommandItem onSelect={() => handleOverride(null)}>
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4 flex-shrink-0",
+                        resolvedHero.hasOverride && selectedValue === null
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                    <span>{GENERAL_OTHER_HERO_LABEL}</span>
+                  </CommandItem>
+                </CommandGroup>
+                <CommandSeparator />
+                <CommandGroup>
+                  {HERO_OVERRIDE_OPTIONS.map((heroName) => (
+                    <CommandItem
+                      key={heroName}
+                      onSelect={() => handleOverride(heroName)}>
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4 flex-shrink-0",
+                          resolvedHero.hasOverride && selectedValue === heroName
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      <span className='truncate'>{heroName}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      )}
     </div>
   );
 };

--- a/apps/desktop/src/components/mod-management/needs-repair-badge.tsx
+++ b/apps/desktop/src/components/mod-management/needs-repair-badge.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@deadlock-mods/ui/components/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deadlock-mods/ui/components/tooltip";
+import { AlertTriangle, CircleHelp } from "@deadlock-mods/ui/icons";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import type { RepairReason } from "@/types/mods";
+
+type NeedsRepairBadgeProps = {
+  className?: string;
+  reason?: RepairReason;
+};
+
+const manualChoiceReasons = new Set<RepairReason>([
+  "needsDownloadChoice",
+  "needsFileSelection",
+]);
+
+export const NeedsRepairBadge = ({
+  className,
+  reason,
+}: NeedsRepairBadgeProps) => {
+  const { t } = useTranslation();
+  const needsChoice = reason ? manualChoiceReasons.has(reason) : false;
+  const Icon = needsChoice ? CircleHelp : AlertTriangle;
+  const tooltip = reason
+    ? t(`modStatus.repairReason.${reason}`)
+    : t("modStatus.needsRepairTooltip");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant='outline'
+          className={cn(
+            "border-amber-500/50 bg-amber-500/15 text-amber-800 hover:bg-amber-500/20 dark:text-amber-300",
+            className,
+          )}>
+          <Icon className='h-3 w-3' />
+          {t("modStatus.needsRepair")}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+};

--- a/apps/desktop/src/components/mod-management/status.tsx
+++ b/apps/desktop/src/components/mod-management/status.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { ModStatus } from "@/types/mods";
+import { NeedsRepairBadge } from "./needs-repair-badge";
 
 const Status = ({ status }: { status: ModStatus }) => {
   const { t } = useTranslation();
@@ -16,6 +17,7 @@ const Status = ({ status }: { status: ModStatus }) => {
         return Loader2;
       case ModStatus.Installed:
         return Check;
+      case ModStatus.NeedsRepair:
       case ModStatus.Error:
         return X;
       default:
@@ -35,12 +37,18 @@ const Status = ({ status }: { status: ModStatus }) => {
         return t("modStatus.paused");
       case ModStatus.Installed:
         return t("modStatus.installed");
+      case ModStatus.NeedsRepair:
+        return t("modStatus.needsRepair");
       case ModStatus.Error:
         return t("modStatus.error");
       default:
         return t("modStatus.unknown");
     }
   }, [status, t]);
+
+  if (status === ModStatus.NeedsRepair) {
+    return <NeedsRepairBadge />;
+  }
 
   return (
     <Badge className='flex w-fit items-center gap-2' variant='secondary'>

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -61,7 +61,7 @@ export const useDownload = (
           .then((result) => {
             setDetectedHero(
               mod.remoteId,
-              result.hero ?? null,
+              result.heroDisplay ?? result.hero ?? null,
               result.usesCriticalPaths,
             );
           })

--- a/apps/desktop/src/hooks/use-downloads-migration.ts
+++ b/apps/desktop/src/hooks/use-downloads-migration.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { getModDownloads } from "@/lib/api-client";
 import { createLogger } from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
+import type { ModDownloadItem } from "@/types/mods";
 
 const logger = createLogger("downloads-migration");
 
@@ -9,15 +10,7 @@ const CONCURRENCY = 3;
 
 const fetchInBatches = async (
   remoteIds: string[],
-  onResult: (
-    remoteId: string,
-    downloads: {
-      name: string;
-      url: string;
-      size: number;
-      description?: string;
-    }[],
-  ) => void,
+  onResult: (remoteId: string, downloads: ModDownloadItem[]) => void,
 ) => {
   let cursor = 0;
   const run = async () => {

--- a/apps/desktop/src/hooks/use-hero-detection.ts
+++ b/apps/desktop/src/hooks/use-hero-detection.ts
@@ -144,7 +144,7 @@ const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {
       for (const resp of responses) {
         setDetectedHero(
           resp.modId,
-          resp.result.hero ?? null,
+          resp.result.heroDisplay ?? resp.result.hero ?? null,
           resp.result.usesCriticalPaths,
         );
       }
@@ -166,7 +166,7 @@ const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {
           });
           setDetectedHero(
             mod.remoteId,
-            result.hero ?? null,
+            result.heroDisplay ?? result.hero ?? null,
             result.usesCriticalPaths,
           );
         } catch {

--- a/apps/desktop/src/hooks/use-mod-processor.ts
+++ b/apps/desktop/src/hooks/use-mod-processor.ts
@@ -311,7 +311,11 @@ export const useModProcessor = () => {
 
     invoke<HeroDetectionResult>("detect_mod_hero", { modId })
       .then((result) =>
-        setDetectedHero(modId, result.hero ?? null, result.usesCriticalPaths),
+        setDetectedHero(
+          modId,
+          result.heroDisplay ?? result.hero ?? null,
+          result.usesCriticalPaths,
+        ),
       )
       .catch(() => setDetectedHero(modId, null));
 
@@ -416,7 +420,11 @@ export const useModProcessor = () => {
 
     invoke<HeroDetectionResult>("detect_mod_hero", { modId })
       .then((result) =>
-        setDetectedHero(modId, result.hero ?? null, result.usesCriticalPaths),
+        setDetectedHero(
+          modId,
+          result.heroDisplay ?? result.hero ?? null,
+          result.usesCriticalPaths,
+        ),
       )
       .catch(() => setDetectedHero(modId, null));
 

--- a/apps/desktop/src/hooks/use-repair-mods.ts
+++ b/apps/desktop/src/hooks/use-repair-mods.ts
@@ -103,18 +103,18 @@ const selectedFileTreeForBatch = (
     return "needs-file-selection";
   }
 
-  const selectedNames = new Set(
+  const selectedPaths = new Set(
     previousTree.files
       .filter((file) => file.is_selected)
-      .flatMap((file) => [file.name, file.path]),
+      .map((file) => file.path),
   );
-  if (selectedNames.size === 0) {
+  if (selectedPaths.size === 0) {
     return "needs-file-selection";
   }
 
   const files = analyzedFileTree.files.map((file) => ({
     ...file,
-    is_selected: selectedNames.has(file.name) || selectedNames.has(file.path),
+    is_selected: selectedPaths.has(file.path),
   }));
   if (!files.some((file) => file.is_selected)) {
     return "needs-file-selection";

--- a/apps/desktop/src/hooks/use-repair-mods.ts
+++ b/apps/desktop/src/hooks/use-repair-mods.ts
@@ -1,0 +1,502 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { invoke } from "@tauri-apps/api/core";
+import { appLocalDataDir, join } from "@tauri-apps/api/path";
+import { useTranslation } from "react-i18next";
+import { getModDownloads } from "@/lib/api-client";
+import { downloadManager } from "@/lib/download/manager";
+import { getErrorMessage } from "@/lib/errors";
+import logger from "@/lib/logger";
+import { usePersistedStore } from "@/lib/store";
+import {
+  type InstallableMod,
+  type LocalMod,
+  type ModDownloadItem,
+  type ModFileTree,
+  ModStatus,
+  type RepairDownloadItem,
+  type RepairReason,
+} from "@/types/mods";
+
+type RepairSkipReason =
+  | "missing-downloads"
+  | "multiple-downloads"
+  | "needs-file-selection";
+
+export type RepairSkippedMod = {
+  remoteId: string;
+  reason: RepairSkipReason;
+};
+
+export type RepairFailedMod = {
+  remoteId: string;
+  error: string;
+};
+
+export type RepairModsResult = {
+  queued: string[];
+  repaired: string[];
+  skipped: RepairSkippedMod[];
+  failed: RepairFailedMod[];
+};
+
+type RepairModOptions = {
+  interactive?: boolean;
+  availableFiles?: ModDownloadItem[];
+  requestDownloadSelection?: () => Promise<void> | void;
+  installInteractively?: (mod: LocalMod) => Promise<void>;
+};
+
+export const normalizeRepairDownloads = (
+  downloads: RepairDownloadItem[],
+): ModDownloadItem[] =>
+  downloads.map((download) => ({
+    name: download.name,
+    size: download.size,
+    url: download.url,
+    description: download.description ?? null,
+    createdAt: download.createdAt ?? null,
+    updatedAt: download.updatedAt ?? null,
+    md5Checksum: download.md5Checksum ?? null,
+  }));
+
+const downloadFilesForMetadata = (downloads: ModDownloadItem[]) =>
+  downloads.map((download) => ({
+    name: download.name,
+    size: download.size ?? 0,
+    url: download.url,
+    md5Checksum: download.md5Checksum ?? null,
+  }));
+
+const getStoredDownloads = (mod: LocalMod): ModDownloadItem[] | null => {
+  if (mod.repairDownloads?.length) {
+    return normalizeRepairDownloads(mod.repairDownloads);
+  }
+
+  if (mod.selectedDownloads?.length) {
+    return mod.selectedDownloads;
+  }
+
+  return null;
+};
+
+const repairReasonForSkip = (reason: RepairSkipReason): RepairReason => {
+  switch (reason) {
+    case "multiple-downloads":
+      return "needsDownloadChoice";
+    case "needs-file-selection":
+      return "needsFileSelection";
+    case "missing-downloads":
+      return "missingPayload";
+  }
+};
+
+const selectedFileTreeForBatch = (
+  mod: LocalMod,
+  analyzedFileTree: ModFileTree,
+): ModFileTree | RepairSkipReason => {
+  if (!analyzedFileTree.has_multiple_files) {
+    return analyzedFileTree;
+  }
+
+  const previousTree = mod.installedFileTree;
+  if (!previousTree?.has_multiple_files) {
+    return "needs-file-selection";
+  }
+
+  const selectedNames = new Set(
+    previousTree.files
+      .filter((file) => file.is_selected)
+      .flatMap((file) => [file.name, file.path]),
+  );
+  if (selectedNames.size === 0) {
+    return "needs-file-selection";
+  }
+
+  const files = analyzedFileTree.files.map((file) => ({
+    ...file,
+    is_selected: selectedNames.has(file.name) || selectedNames.has(file.path),
+  }));
+  if (!files.some((file) => file.is_selected)) {
+    return "needs-file-selection";
+  }
+
+  return {
+    ...analyzedFileTree,
+    files,
+  };
+};
+
+export const useRepairMods = () => {
+  const { t } = useTranslation();
+  const {
+    getActiveProfile,
+    setModStatus,
+    setModProgress,
+    setInstalledVpks,
+    setSelectedDownloads,
+    setModDownloads,
+    setModEnabledInCurrentProfile,
+    isRepairingMods,
+    setIsRepairingMods,
+    setModRepairReason,
+  } = usePersistedStore();
+
+  const persistRepairMetadata = async (
+    profileFolder: string | null,
+    modId: string,
+    sourceDownloads: ModDownloadItem[],
+  ) => {
+    await invoke("update_profile_vpk_manifest_repair_metadata", {
+      profileFolder,
+      modId,
+      sourceDownloads: downloadFilesForMetadata(sourceDownloads),
+    });
+  };
+
+  const resolveDownloads = async (
+    mod: LocalMod,
+    options: RepairModOptions,
+  ): Promise<ModDownloadItem[] | RepairSkipReason> => {
+    const storedDownloads = getStoredDownloads(mod);
+    if (storedDownloads?.length) {
+      return storedDownloads;
+    }
+
+    const availableFiles = options.availableFiles ?? [];
+    if (availableFiles.length === 1) {
+      return availableFiles;
+    }
+    if (availableFiles.length > 1) {
+      return "multiple-downloads";
+    }
+
+    try {
+      const response = await getModDownloads(mod.remoteId);
+      if (response.downloads.length === 1) {
+        return response.downloads;
+      }
+      return response.downloads.length > 1
+        ? "multiple-downloads"
+        : "missing-downloads";
+    } catch (error) {
+      logger
+        .withMetadata({ modId: mod.remoteId })
+        .withError(error)
+        .warn("Failed to fetch repair downloads");
+      return "missing-downloads";
+    }
+  };
+
+  const queueRepairDownload = (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+    profileFolder: string | null,
+  ) =>
+    new Promise<void>((resolve, reject) => {
+      setModStatus(mod.remoteId, ModStatus.Downloading);
+      downloadManager.addToQueue({
+        ...mod,
+        downloads,
+        profileFolder,
+        onStart: () => {
+          setModStatus(mod.remoteId, ModStatus.Downloading);
+        },
+        onProgress: (progress) => {
+          setModProgress(mod.remoteId, progress);
+        },
+        onComplete: () => {
+          setModStatus(mod.remoteId, ModStatus.Downloaded);
+          resolve();
+        },
+        onError: (error) => {
+          setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+          setModRepairReason(mod.remoteId, "repairFailed");
+          reject(error);
+        },
+      });
+    });
+
+  const rememberRepairDownloads = (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+  ) => {
+    setModDownloads(mod.remoteId, downloads);
+    setSelectedDownloads(mod.remoteId, downloads);
+    usePersistedStore.setState((state) => ({
+      localMods: state.localMods.map((localMod) =>
+        localMod.remoteId === mod.remoteId
+          ? { ...localMod, repairDownloads: downloads }
+          : localMod,
+      ),
+    }));
+  };
+
+  const installDownloadedRepair = async (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+    profileFolder: string | null,
+  ): Promise<RepairModsResult> => {
+    try {
+      const base = await appLocalDataDir();
+      const modsRoot = await join(base, "mods");
+      const modDir = await join(modsRoot, mod.remoteId);
+      const analyzedFileTree = await invoke<ModFileTree>("get_mod_file_tree", {
+        modPath: modDir,
+      });
+      const fileTree = selectedFileTreeForBatch(mod, analyzedFileTree);
+      if (typeof fileTree === "string") {
+        setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+        setModRepairReason(mod.remoteId, repairReasonForSkip(fileTree));
+        return {
+          queued: [],
+          repaired: [],
+          skipped: [{ remoteId: mod.remoteId, reason: fileTree }],
+          failed: [],
+        };
+      }
+
+      setModStatus(mod.remoteId, ModStatus.Installing);
+      const result = await invoke<InstallableMod>("install_mod", {
+        deadlockMod: {
+          id: mod.remoteId,
+          name: mod.name,
+          is_map: mod.isMap,
+          file_tree: fileTree,
+        },
+        profileFolder,
+      });
+
+      setInstalledVpks(mod.remoteId, result.installed_vpks, result.file_tree);
+      setModEnabledInCurrentProfile(mod.remoteId, true);
+      setModRepairReason(mod.remoteId, undefined);
+      await persistRepairMetadata(profileFolder, mod.remoteId, downloads);
+
+      return {
+        queued: [],
+        repaired: [mod.remoteId],
+        skipped: [],
+        failed: [],
+      };
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger
+        .withMetadata({ modId: mod.remoteId })
+        .withError(error)
+        .error("Failed to repair mod");
+      setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+      setModRepairReason(mod.remoteId, "repairFailed");
+      return {
+        queued: [],
+        repaired: [],
+        skipped: [],
+        failed: [{ remoteId: mod.remoteId, error: message }],
+      };
+    }
+  };
+
+  const repairModDirectly = async (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+    profileFolder: string | null,
+  ): Promise<RepairModsResult> => {
+    rememberRepairDownloads(mod, downloads);
+    await queueRepairDownload(mod, downloads, profileFolder);
+    const result = await installDownloadedRepair(mod, downloads, profileFolder);
+    return {
+      ...result,
+      queued: [mod.remoteId],
+    };
+  };
+
+  const repairMod = async (
+    mod: LocalMod,
+    options: RepairModOptions = {},
+  ): Promise<RepairModsResult> => {
+    const interactive = options.interactive ?? true;
+    const profileFolder = getActiveProfile()?.folderName ?? null;
+    const downloads = await resolveDownloads(mod, options);
+
+    if (typeof downloads === "string") {
+      setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+      setModRepairReason(mod.remoteId, repairReasonForSkip(downloads));
+      if (interactive && options.requestDownloadSelection) {
+        await options.requestDownloadSelection();
+      }
+      return {
+        queued: [],
+        repaired: [],
+        skipped: [{ remoteId: mod.remoteId, reason: downloads }],
+        failed: [],
+      };
+    }
+
+    if (interactive && options.installInteractively) {
+      rememberRepairDownloads(mod, downloads);
+      const repairCandidate: LocalMod = {
+        ...mod,
+        status: ModStatus.Downloaded,
+        downloads,
+        selectedDownloads: downloads,
+        repairDownloads: downloads,
+      };
+
+      downloadManager.addToQueue({
+        ...repairCandidate,
+        downloads,
+        profileFolder,
+        onStart: () => {
+          setModStatus(mod.remoteId, ModStatus.Downloading);
+        },
+        onProgress: (progress) => {
+          setModProgress(mod.remoteId, progress);
+        },
+        onComplete: async () => {
+          setModStatus(mod.remoteId, ModStatus.Downloaded);
+          const latestMod =
+            usePersistedStore
+              .getState()
+              .localMods.find((m) => m.remoteId === mod.remoteId) ??
+            repairCandidate;
+
+          await options.installInteractively?.({
+            ...latestMod,
+            status: ModStatus.Downloaded,
+            downloads,
+            selectedDownloads: downloads,
+            repairDownloads: downloads,
+          });
+        },
+        onError: (error) => {
+          toast.error(`Failed to repair ${mod.name}: ${error.message}`);
+          setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+          setModRepairReason(mod.remoteId, "repairFailed");
+        },
+      });
+
+      return {
+        queued: [mod.remoteId],
+        repaired: [],
+        skipped: [],
+        failed: [],
+      };
+    }
+
+    return repairModDirectly(mod, downloads, profileFolder);
+  };
+
+  const repairMods = async (mods: LocalMod[]): Promise<RepairModsResult> => {
+    if (mods.length === 0 || usePersistedStore.getState().isRepairingMods) {
+      return { queued: [], repaired: [], skipped: [], failed: [] };
+    }
+
+    setIsRepairingMods(true);
+    const aggregate: RepairModsResult = {
+      queued: [],
+      repaired: [],
+      skipped: [],
+      failed: [],
+    };
+
+    try {
+      const profileFolder = getActiveProfile()?.folderName ?? null;
+      const resolvedRepairs = await Promise.all(
+        mods.map(async (mod) => ({
+          mod,
+          downloads: await resolveDownloads(mod, { interactive: false }),
+        })),
+      );
+
+      const queuedRepairs: Array<{
+        mod: LocalMod;
+        downloads: ModDownloadItem[];
+        downloadComplete: Promise<
+          | { ok: true }
+          | {
+              ok: false;
+              error: string;
+            }
+        >;
+      }> = [];
+
+      for (const { mod, downloads } of resolvedRepairs) {
+        if (typeof downloads === "string") {
+          setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+          setModRepairReason(mod.remoteId, repairReasonForSkip(downloads));
+          aggregate.skipped.push({ remoteId: mod.remoteId, reason: downloads });
+          continue;
+        }
+
+        rememberRepairDownloads(mod, downloads);
+        queuedRepairs.push({
+          mod,
+          downloads,
+          downloadComplete: queueRepairDownload(mod, downloads, profileFolder)
+            .then(() => ({ ok: true as const }))
+            .catch((error) => ({
+              ok: false as const,
+              error: getErrorMessage(error),
+            })),
+        });
+        aggregate.queued.push(mod.remoteId);
+      }
+
+      for (const repair of queuedRepairs) {
+        const downloadResult = await repair.downloadComplete;
+        if (!downloadResult.ok) {
+          aggregate.failed.push({
+            remoteId: repair.mod.remoteId,
+            error: downloadResult.error,
+          });
+          continue;
+        }
+
+        const result = await installDownloadedRepair(
+          repair.mod,
+          repair.downloads,
+          profileFolder,
+        );
+        aggregate.repaired.push(...result.repaired);
+        aggregate.skipped.push(...result.skipped);
+        aggregate.failed.push(...result.failed);
+      }
+
+      if (aggregate.skipped.length === 0 && aggregate.failed.length === 0) {
+        toast.success(
+          t("modButton.repairAllSuccess", {
+            count: aggregate.repaired.length,
+          }),
+        );
+      } else if (
+        aggregate.queued.length === 0 &&
+        aggregate.repaired.length === 0 &&
+        aggregate.failed.length === 0 &&
+        aggregate.skipped.length > 0
+      ) {
+        toast.warning(
+          t("modButton.repairAllManualOnly", {
+            count: aggregate.skipped.length,
+          }),
+        );
+      } else {
+        toast.warning(
+          t("modButton.repairAllPartial", {
+            queued: aggregate.queued.length,
+            repaired: aggregate.repaired.length,
+            manual: aggregate.skipped.length,
+            failed: aggregate.failed.length,
+          }),
+        );
+      }
+
+      return aggregate;
+    } finally {
+      setIsRepairingMods(false);
+    }
+  };
+
+  return {
+    isRepairing: isRepairingMods,
+    repairMod,
+    repairMods,
+  };
+};

--- a/apps/desktop/src/hooks/use-uninstall.ts
+++ b/apps/desktop/src/hooks/use-uninstall.ts
@@ -82,9 +82,11 @@ const useUninstall = () => {
     } catch (error) {
       logger.errorOnly(error);
 
-      if (remove && isTauriError(error) && error.kind === "vpkInUse") {
-        toast.error(t("mods.deleteError"), {
-          description: t("mods.deleteErrorVpkInUse"),
+      if (isTauriError(error) && error.kind === "vpkInUse") {
+        toast.error(remove ? t("mods.deleteError") : t("mods.disableError"), {
+          description: remove
+            ? t("mods.deleteErrorVpkInUse")
+            : t("mods.disableErrorVpkInUse"),
         });
         return;
       }

--- a/apps/desktop/src/lib/download/manager.ts
+++ b/apps/desktop/src/lib/download/manager.ts
@@ -266,7 +266,7 @@ class DownloadManager {
     // Extracting) that the backend doesn't know about is stale from a previous
     // session and should be flagged as failed so the UI doesn't show a phantom
     // queue.
-    const staleStatuses: ModStatus[] = new Set([
+    const staleStatuses = new Set<ModStatus>([
       ModStatus.Downloading,
       ModStatus.Paused,
       ModStatus.Extracting,

--- a/apps/desktop/src/lib/mods/hero-resolution.test.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { LocalMod } from "@/types/mods";
+import { resolveModHero } from "./hero-resolution";
+
+const mod = (values: {
+  name: string;
+  hero?: string | null;
+  detectedHero?: string | null;
+  heroOverride?: string | null;
+}) =>
+  ({
+    name: values.name,
+    hero: values.hero ?? null,
+    detectedHero: values.detectedHero,
+    heroOverride: values.heroOverride,
+  }) as LocalMod;
+
+describe("resolveModHero", () => {
+  it("prefers manual overrides over all automatic sources", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+      heroOverride: "Victor",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Victor",
+      source: "manual",
+      hasOverride: true,
+    });
+  });
+
+  it("prefers API heroes over stale local VPK detection", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Seven",
+      source: "api",
+    });
+  });
+
+  it("uses name aliases before VPK detection when the API is missing a hero", () => {
+    const localMod = mod({
+      name: "Toon Viktor",
+      hero: null,
+      detectedHero: "Infernus",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Victor",
+      source: "name",
+    });
+  });
+
+  it("can manually mark a local mod as general or other", () => {
+    const localMod = mod({
+      name: "Mystery Pack",
+      hero: "Seven",
+      heroOverride: null,
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: null,
+      source: "manual",
+      hasOverride: true,
+    });
+  });
+});

--- a/apps/desktop/src/lib/mods/hero-resolution.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.ts
@@ -1,0 +1,69 @@
+import type { ModDto } from "@deadlock-mods/shared";
+import { guessHero, normalizeHero } from "@deadlock-mods/shared";
+import type { LocalMod } from "@/types/mods";
+
+export type ResolvedHeroSource = "manual" | "api" | "name" | "vpk" | "none";
+
+export type ResolvedModHero = {
+  hero: string | null;
+  source: ResolvedHeroSource;
+  isManual: boolean;
+  hasOverride: boolean;
+};
+
+type HeroResolvableMod = Pick<ModDto, "hero" | "name">;
+type HeroResolvableLocalMod = Pick<LocalMod, "detectedHero" | "heroOverride">;
+
+export function resolveModHero(
+  mod: HeroResolvableMod,
+  localMod?: HeroResolvableLocalMod | null,
+): ResolvedModHero {
+  if (localMod && "heroOverride" in localMod) {
+    const { heroOverride } = localMod;
+    if (heroOverride !== undefined) {
+      return {
+        hero: normalizeHero(heroOverride) ?? heroOverride,
+        source: "manual",
+        isManual: true,
+        hasOverride: true,
+      };
+    }
+  }
+
+  const apiHero = normalizeHero(mod.hero);
+  if (apiHero) {
+    return {
+      hero: apiHero,
+      source: "api",
+      isManual: false,
+      hasOverride: false,
+    };
+  }
+
+  const nameHero = guessHero(mod.name);
+  if (nameHero) {
+    return {
+      hero: nameHero,
+      source: "name",
+      isManual: false,
+      hasOverride: false,
+    };
+  }
+
+  const vpkHero = normalizeHero(localMod?.detectedHero);
+  if (vpkHero) {
+    return {
+      hero: vpkHero,
+      source: "vpk",
+      isManual: false,
+      hasOverride: false,
+    };
+  }
+
+  return {
+    hero: null,
+    source: "none",
+    isManual: false,
+    hasOverride: false,
+  };
+}

--- a/apps/desktop/src/lib/mods/hero-resolution.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.ts
@@ -21,6 +21,7 @@ export function resolveModHero(
   if (localMod && "heroOverride" in localMod) {
     const { heroOverride } = localMod;
     if (heroOverride !== undefined) {
+      // Preserve unknown manual overrides so imported or future hero values remain visible.
       return {
         hero: normalizeHero(heroOverride) ?? heroOverride,
         source: "manual",

--- a/apps/desktop/src/lib/mods/installed-helpers.ts
+++ b/apps/desktop/src/lib/mods/installed-helpers.ts
@@ -1,4 +1,9 @@
-import { type LocalMod, ModStatus } from "@/types/mods";
+import { type LocalMod, ModStatus, type RepairReason } from "@/types/mods";
+
+const manualRepairReasons = new Set<RepairReason>([
+  "needsDownloadChoice",
+  "needsFileSelection",
+]);
 
 export function isInstalledModWithVpks(mod: LocalMod): boolean {
   return (
@@ -6,4 +11,32 @@ export function isInstalledModWithVpks(mod: LocalMod): boolean {
     !!mod.installedVpks &&
     mod.installedVpks.length > 0
   );
+}
+
+export function isRepairableMod(mod: LocalMod): boolean {
+  return mod.status === ModStatus.NeedsRepair;
+}
+
+export function isManualRepairMod(mod: LocalMod): boolean {
+  return (
+    isRepairableMod(mod) &&
+    !!mod.repairReason &&
+    manualRepairReasons.has(mod.repairReason)
+  );
+}
+
+export function isAutomaticRepairMod(mod: LocalMod): boolean {
+  return isRepairableMod(mod) && !isManualRepairMod(mod);
+}
+
+export function getModStatusSortRank(mod: LocalMod): number {
+  if (isInstalledModWithVpks(mod)) {
+    return 0;
+  }
+
+  if (isRepairableMod(mod)) {
+    return 1;
+  }
+
+  return 2;
 }

--- a/apps/desktop/src/lib/mods/library-display.test.ts
+++ b/apps/desktop/src/lib/mods/library-display.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { filterStableLibraryModsByStatus } from "./library-display";
+import { type LocalMod, ModStatus } from "@/types/mods";
+
+const mod = (
+  remoteId: string,
+  status: ModStatus,
+  extra: Partial<LocalMod> = {},
+): LocalMod =>
+  ({
+    id: remoteId,
+    remoteId,
+    name: remoteId,
+    author: "Test Author",
+    status,
+    ...extra,
+  }) as LocalMod;
+
+const ids = (mods: LocalMod[]) => mods.map((item) => item.remoteId);
+
+describe("filterStableLibraryModsByStatus", () => {
+  it("preserves library order in the all view across enabled, repair, and disabled mods", () => {
+    const mods = [
+      mod("disabled-newer", ModStatus.Downloaded, {
+        downloadedAt: new Date("2026-04-03"),
+      }),
+      mod("enabled-late-load-order", ModStatus.Installed, {
+        installOrder: 99,
+        installedVpks: ["late.vpk"],
+      }),
+      mod("repair", ModStatus.NeedsRepair),
+      mod("enabled-early-load-order", ModStatus.Installed, {
+        installOrder: 0,
+        installedVpks: ["early.vpk"],
+      }),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "all"))).toEqual([
+      "disabled-newer",
+      "enabled-late-load-order",
+      "repair",
+      "enabled-early-load-order",
+    ]);
+  });
+
+  it("preserves library-relative order in the enabled view instead of sorting by installOrder", () => {
+    const mods = [
+      mod("enabled-load-order-10", ModStatus.Installed, {
+        installOrder: 10,
+        installedVpks: ["ten.vpk"],
+      }),
+      mod("disabled", ModStatus.Downloaded),
+      mod("enabled-load-order-1", ModStatus.Installed, {
+        installOrder: 1,
+        installedVpks: ["one.vpk"],
+      }),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "enabled"))).toEqual([
+      "enabled-load-order-10",
+      "enabled-load-order-1",
+    ]);
+  });
+
+  it("filters disabled mods without including installed or repairable mods", () => {
+    const mods = [
+      mod("installed", ModStatus.Installed, {
+        installedVpks: ["installed.vpk"],
+      }),
+      mod("repair", ModStatus.NeedsRepair),
+      mod("downloaded", ModStatus.Downloaded),
+      mod("failed-install", ModStatus.FailedToInstall),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "disabled"))).toEqual([
+      "downloaded",
+      "failed-install",
+    ]);
+  });
+
+  it("preserves caller-provided search result order instead of regrouping by status", () => {
+    const searchResults = [
+      mod("search-hit-disabled", ModStatus.Downloaded),
+      mod("search-hit-enabled", ModStatus.Installed, {
+        installOrder: 0,
+        installedVpks: ["enabled.vpk"],
+      }),
+      mod("search-hit-repair", ModStatus.NeedsRepair),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(searchResults, "all"))).toEqual([
+      "search-hit-disabled",
+      "search-hit-enabled",
+      "search-hit-repair",
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/mods/library-display.ts
+++ b/apps/desktop/src/lib/mods/library-display.ts
@@ -1,0 +1,22 @@
+import type { LocalMod } from "@/types/mods";
+import { isInstalledModWithVpks, isRepairableMod } from "./installed-helpers";
+
+export type ModLibraryFilter = "all" | "enabled" | "needsRepair" | "disabled";
+
+export function filterStableLibraryModsByStatus(
+  mods: LocalMod[],
+  filter: ModLibraryFilter,
+): LocalMod[] {
+  switch (filter) {
+    case "enabled":
+      return mods.filter(isInstalledModWithVpks);
+    case "needsRepair":
+      return mods.filter(isRepairableMod);
+    case "disabled":
+      return mods.filter(
+        (mod) => !isInstalledModWithVpks(mod) && !isRepairableMod(mod),
+      );
+    case "all":
+      return mods;
+  }
+}

--- a/apps/desktop/src/lib/state-machines/mod-status.ts
+++ b/apps/desktop/src/lib/state-machines/mod-status.ts
@@ -20,24 +20,32 @@ const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
     ModStatus.Downloaded,
     ModStatus.FailedToDownload,
     ModStatus.Paused,
+    ModStatus.NeedsRepair,
   ],
-  [ModStatus.Extracting]: [ModStatus.Downloaded, ModStatus.FailedToDownload],
+  [ModStatus.Extracting]: [
+    ModStatus.Downloaded,
+    ModStatus.FailedToDownload,
+    ModStatus.NeedsRepair,
+  ],
   [ModStatus.Paused]: [ModStatus.Downloading, ModStatus.FailedToDownload],
   [ModStatus.Downloaded]: [
     ModStatus.Installing,
     ModStatus.Removing,
     ModStatus.Installed,
+    ModStatus.NeedsRepair,
   ],
   [ModStatus.Installing]: [
     ModStatus.Installed,
     ModStatus.FailedToInstall,
     ModStatus.Downloaded,
+    ModStatus.NeedsRepair,
   ],
   [ModStatus.Installed]: [
     ModStatus.Downloading,
     ModStatus.Extracting,
     ModStatus.Removing,
     ModStatus.Downloaded,
+    ModStatus.NeedsRepair,
   ],
   [ModStatus.Removing]: [ModStatus.Removed, ModStatus.FailedToRemove],
   [ModStatus.Removed]: [ModStatus.Error],
@@ -49,6 +57,12 @@ const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
     ModStatus.Error,
   ],
   [ModStatus.Error]: [],
+  [ModStatus.NeedsRepair]: [
+    ModStatus.Downloading,
+    ModStatus.Installing,
+    ModStatus.Downloaded,
+    ModStatus.Error,
+  ],
 };
 
 /**

--- a/apps/desktop/src/lib/store/index.ts
+++ b/apps/desktop/src/lib/store/index.ts
@@ -111,6 +111,7 @@ export const usePersistedStore = create<State>()(
       partialize: (state) => {
         const {
           modProgress: _modProgress,
+          isRepairingMods: _isRepairingMods,
           isSwitching: _isSwitching,
           showWhatsNew: _showWhatsNew,
           lastSeenVersion: _lastSeenVersion,

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -10,6 +10,7 @@ import {
   type ModFileTree,
   ModStatus,
   type Progress,
+  type RepairReason,
 } from "@/types/mods";
 import type { State } from "..";
 
@@ -28,6 +29,7 @@ export type HeroDetectionProgress = {
 export type ModsState = {
   localMods: LocalMod[];
   modProgress: Record<string, ModProgress>;
+  isRepairingMods: boolean;
   defaultSort: SortType;
   // Analysis dialog state
   analysisResult: AnalyzeAddonsResult | null;
@@ -46,6 +48,11 @@ export type ModsState = {
   setMods: (mods: LocalMod[]) => void;
   setModStatus: (remoteId: string, status: ModStatus) => void;
   setModProgress: (remoteId: string, progress: Progress) => void;
+  setIsRepairingMods: (isRepairing: boolean) => void;
+  setModRepairReason: (
+    remoteId: string,
+    repairReason: RepairReason | undefined,
+  ) => void;
   clearMods: () => void;
   setInstalledVpks: (
     remoteId: string,
@@ -86,6 +93,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 ) => ({
   localMods: [],
   modProgress: {},
+  isRepairingMods: false,
   analysisResult: null,
   analysisDialogOpen: false,
   heroDetection: { status: "idle", current: 0, total: 0, currentModName: null },
@@ -255,6 +263,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         return {
           ...mod,
           status,
+          repairReason:
+            status === ModStatus.NeedsRepair ? mod.repairReason : undefined,
           downloadedAt:
             (status === ModStatus.Downloaded &&
               mod.status !== ModStatus.Installed) ||
@@ -312,6 +322,18 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       },
     })),
 
+  setIsRepairingMods: (isRepairing) =>
+    set(() => ({
+      isRepairingMods: isRepairing,
+    })),
+
+  setModRepairReason: (remoteId, repairReason) =>
+    set((state) => ({
+      localMods: state.localMods.map((mod) =>
+        mod.remoteId === remoteId ? { ...mod, repairReason } : mod,
+      ),
+    })),
+
   getModProgress: (remoteId) => get().modProgress[remoteId],
 
   setInstalledVpks: (
@@ -329,6 +351,10 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         installedVpks: mod.remoteId === remoteId ? vpks : mod.installedVpks,
         installedFileTree:
           mod.remoteId === remoteId ? fileTree : mod.installedFileTree,
+        repairReason:
+          mod.remoteId === remoteId && vpks.length > 0
+            ? undefined
+            : mod.repairReason,
       })),
     })),
 

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -80,6 +80,10 @@ export type ModsState = {
     hero: string | null,
     usesCriticalPaths?: boolean,
   ) => void;
+  setHeroOverride: (
+    remoteId: string,
+    heroOverride: string | null | undefined,
+  ) => void;
   clearAllDetectedHeroes: () => void;
   setHeroDetection: (progress: Partial<HeroDetectionProgress>) => void;
 };
@@ -554,25 +558,90 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     hero: string | null,
     usesCriticalPaths?: boolean,
   ) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) =>
-        mod.remoteId === remoteId
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) =>
+          mod.remoteId === remoteId
+            ? {
+                ...mod,
+                detectedHero: hero,
+                usesCriticalPaths: usesCriticalPaths ?? mod.usesCriticalPaths,
+              }
+            : mod,
+        );
+
+      const activeProfile = state.profiles[state.activeProfileId];
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: activeProfile
           ? {
-              ...mod,
-              detectedHero: hero,
-              usesCriticalPaths: usesCriticalPaths ?? mod.usesCriticalPaths,
+              ...state.profiles,
+              [state.activeProfileId]: {
+                ...activeProfile,
+                mods: updateMods(activeProfile.mods),
+              },
             }
-          : mod,
-      ),
-    })),
+          : state.profiles,
+      };
+    }),
+
+  setHeroOverride: (remoteId, heroOverride) =>
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => {
+          if (mod.remoteId !== remoteId) return mod;
+
+          if (heroOverride === undefined) {
+            const { heroOverride: _heroOverride, ...nextMod } = mod;
+            return nextMod;
+          }
+
+          return {
+            ...mod,
+            heroOverride,
+          };
+        });
+
+      const updatedProfiles = Object.fromEntries(
+        Object.entries(state.profiles).map(([profileId, profile]) => [
+          profileId,
+          {
+            ...profile,
+            mods: updateMods(profile.mods),
+          },
+        ]),
+      );
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: updatedProfiles,
+      };
+    }),
 
   clearAllDetectedHeroes: () =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        detectedHero: undefined,
-      })),
-    })),
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => ({
+          ...mod,
+          detectedHero: undefined,
+        }));
+
+      const updatedProfiles = Object.fromEntries(
+        Object.entries(state.profiles).map(([profileId, profile]) => [
+          profileId,
+          {
+            ...profile,
+            mods: updateMods(profile.mods),
+          },
+        ]),
+      );
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: updatedProfiles,
+      };
+    }),
 
   setHeroDetection: (progress) =>
     set((state) => ({

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -782,6 +782,7 @@ export const createProfilesSlice: StateCreator<
       const enabledVpkSet = new Set(
         allVpks.filter((vpk) => enabledVpkPattern.test(vpk)),
       );
+      const allVpkSet = new Set(allVpks);
 
       const updatedEnabledMods: Record<string, ModProfileEntry> = {};
       const updatedLocalMods: LocalMod[] = [];
@@ -792,9 +793,15 @@ export const createProfilesSlice: StateCreator<
 
         if (manifestEntry) {
           const currentVpks = manifestEntry.currentVpks ?? [];
+          const disabledVpks = manifestEntry.disabledVpks ?? [];
           const hasEnabledVpks =
             manifestEntry.enabled &&
             currentVpks.some((vpk) => enabledVpkSet.has(vpk));
+          const hasDisabledVpks =
+            !manifestEntry.enabled &&
+            disabledVpks.some((vpk) => allVpkSet.has(vpk));
+          const existingRepairReason =
+            mod.status === ModStatus.NeedsRepair ? mod.repairReason : undefined;
 
           if (hasEnabledVpks) {
             updatedEnabledMods[mod.remoteId] = {
@@ -806,8 +813,11 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Installed,
+              repairReason: undefined,
               installedVpks: currentVpks,
               installOrder: manifestEntry.order ?? mod.installOrder,
+              repairDownloads:
+                manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
           } else {
             if (manifestEntry.enabled) {
@@ -826,9 +836,20 @@ export const createProfilesSlice: StateCreator<
 
             updatedLocalMods.push({
               ...mod,
-              status: ModStatus.Downloaded,
+              status: manifestEntry.enabled
+                ? ModStatus.NeedsRepair
+                : hasDisabledVpks
+                  ? ModStatus.Downloaded
+                  : ModStatus.NeedsRepair,
+              repairReason: manifestEntry.enabled
+                ? (existingRepairReason ?? "missingEnabledVpks")
+                : hasDisabledVpks
+                  ? undefined
+                  : (existingRepairReason ?? "missingPayload"),
               installedVpks: [],
               installOrder: manifestEntry.order ?? mod.installOrder,
+              repairDownloads:
+                manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
           }
 
@@ -848,8 +869,54 @@ export const createProfilesSlice: StateCreator<
           disabledVpksForMod.length > 0 || enabledVpksForMod.length > 0;
 
         if (!hasVpksInProfile) {
-          // Mod doesn't have any VPKs in this profile
-          updatedLocalMods.push(mod);
+          const staleEnabledState =
+            mod.status === ModStatus.Installed ||
+            profile.enabledMods[mod.remoteId]?.enabled === true;
+
+          if (staleEnabledState) {
+            logger
+              .withMetadata({ profileId, remoteId: mod.remoteId })
+              .warn(
+                "Profile thinks mod is enabled but no manifest entry or VPK files exist; marking repairable",
+              );
+
+            updatedLocalMods.push({
+              ...mod,
+              status: ModStatus.NeedsRepair,
+              repairReason:
+                mod.status === ModStatus.NeedsRepair
+                  ? (mod.repairReason ?? "missingPayload")
+                  : "missingPayload",
+              installedVpks: [],
+            });
+
+            seedEntries.push({
+              modId: mod.remoteId,
+              enabled: true,
+              currentVpks: [],
+              disabledVpks: [],
+              originalVpkNames: [],
+              order: mod.installOrder ?? null,
+            });
+          } else {
+            const missingDownloadedPayload =
+              mod.status === ModStatus.Downloaded ||
+              mod.status === ModStatus.FailedToInstall;
+
+            updatedLocalMods.push(
+              missingDownloadedPayload
+                ? {
+                    ...mod,
+                    status: ModStatus.NeedsRepair,
+                    repairReason:
+                      mod.status === ModStatus.NeedsRepair
+                        ? (mod.repairReason ?? "missingPayload")
+                        : "missingPayload",
+                    installedVpks: [],
+                  }
+                : mod,
+            );
+          }
           continue;
         }
 
@@ -868,11 +935,13 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Installed,
+              repairReason: undefined,
               installedVpks: enabledVpksForMod,
             });
           } else {
             updatedLocalMods.push({
               ...mod,
+              repairReason: undefined,
               installedVpks: enabledVpksForMod,
             });
           }
@@ -891,9 +960,13 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Downloaded,
+              repairReason: undefined,
             });
           } else {
-            updatedLocalMods.push(mod);
+            updatedLocalMods.push({
+              ...mod,
+              repairReason: undefined,
+            });
           }
 
           seedEntries.push({
@@ -952,6 +1025,7 @@ export const createProfilesSlice: StateCreator<
   restoreModsFromManifest: async () => {
     const { localMods, activeProfileId, profiles } = get();
     if (localMods.length > 0) {
+      await get().syncProfileEnabledMods(activeProfileId);
       return;
     }
 
@@ -961,8 +1035,12 @@ export const createProfilesSlice: StateCreator<
     }
 
     let manifest: VpkManifest = { version: 0, mods: {} };
+    let allVpks: string[] = [];
     try {
       manifest = await invoke<VpkManifest>("get_profile_vpk_manifest", {
+        profileFolder: profile.folderName,
+      });
+      allVpks = await invoke<string[]>("get_profile_installed_vpks", {
         profileFolder: profile.folderName,
       });
     } catch (error) {
@@ -984,24 +1062,35 @@ export const createProfilesSlice: StateCreator<
 
     const restoredMods: LocalMod[] = [];
     const enabledMods: Record<string, ModProfileEntry> = {};
+    const enabledVpkSet = new Set(
+      allVpks.filter((vpk) => /^pak\d+_dir\.vpk$/i.test(vpk)),
+    );
 
     for (const [modId, entry] of manifestEntries) {
       try {
         const modDetails = await getMod(modId);
         const currentVpks = entry.currentVpks ?? [];
-        const isEnabled = entry.enabled && currentVpks.length > 0;
+        const hasEnabledVpks =
+          entry.enabled && currentVpks.some((vpk) => enabledVpkSet.has(vpk));
+        const needsRepair = entry.enabled && !hasEnabledVpks;
 
         const restoredMod: LocalMod = {
           ...modDetails,
-          status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
-          installedVpks: isEnabled ? currentVpks : [],
+          status: hasEnabledVpks
+            ? ModStatus.Installed
+            : needsRepair
+              ? ModStatus.NeedsRepair
+              : ModStatus.Downloaded,
+          repairReason: needsRepair ? "missingEnabledVpks" : undefined,
+          installedVpks: hasEnabledVpks ? currentVpks : [],
           installOrder: entry.order ?? restoredMods.length,
           downloadedAt: new Date(),
+          repairDownloads: entry.sourceDownloads,
         };
 
         restoredMods.push(restoredMod);
 
-        if (isEnabled) {
+        if (hasEnabledVpks) {
           enabledMods[modId] = {
             remoteId: modId,
             enabled: true,
@@ -1010,7 +1099,12 @@ export const createProfilesSlice: StateCreator<
         }
 
         logger
-          .withMetadata({ modId, name: modDetails.name, isEnabled })
+          .withMetadata({
+            modId,
+            name: modDetails.name,
+            hasEnabledVpks,
+            needsRepair,
+          })
           .info("Restored mod from manifest");
       } catch (error) {
         logger

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -352,6 +352,7 @@
     "pause": "Pause",
     "resume": "Resume",
     "paused": "Paused",
+    "needsRepair": "Needs repair",
     "pauseError": "Could not pause download: {{message}}",
     "resumeError": "Could not resume download: {{message}}"
   },

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -240,9 +240,14 @@
     "disableAllConfirmAction": "Disable all",
     "disableAllConfirmCancel": "Cancel",
     "disableAllSuccess": "All mods disabled",
+    "repairBroken": "Repair broken ({{count}})",
+    "manualRepair": "Manual repair ({{count}})",
+    "manualRepairTooltip_one": "{{count}} mod needs a download or VPK choice before repair. Use the question-mark repair button on the mod.",
+    "manualRepairTooltip_other": "{{count}} mods need a download or VPK choice before repair. Use the question-mark repair button on each mod.",
     "tabs": {
       "all": "All",
       "installed": "Installed",
+      "needsRepair": "Needs repair",
       "downloaded": "Downloaded"
     }
   },
@@ -289,6 +294,7 @@
     "deleteError": "Failed to delete mod",
     "deleteErrorVpkInUse": "Some mod files are currently in use by the game. Please close Deadlock and try again.",
     "disableError": "Failed to disable mod",
+    "disableErrorVpkInUse": "Some mod files are temporarily locked by Deadlock, Steam, or another process. Wait a few seconds, close the game if it is running, then try again.",
     "vpkScanAlert": {
       "title": "Unrecognized VPK files found",
       "titleWithCount_one": "{{count}} unrecognized VPK file",
@@ -351,7 +357,11 @@
   },
   "notifications": {
     "modInstalledSuccessfully": "Mod installed successfully",
+    "modEnabledSuccessfully": "Mod enabled successfully",
+    "modRepairedSuccessfully": "Mod repaired successfully",
     "failedToInstallMod": "Failed to install mod",
+    "failedToEnableMod": "Failed to enable mod",
+    "enableErrorVpkInUse": "Some VPK files are temporarily locked by Deadlock, Steam, or another process. Wait a few seconds, close the game if it is running, then try again.",
     "installationCanceled": "Installation canceled",
     "modContainsFiles": "{{modName}} contains {{fileCount}} files. Select which ones to install.",
     "failedToPerformAction": "Failed to perform action",
@@ -901,6 +911,15 @@
     "removed": "Removed",
     "failedToRemove": "Failed to remove",
     "error": "Error occurred",
+    "needsRepair": "Needs repair",
+    "needsRepairTooltip": "Manifest says this mod is enabled, but its VPK files are missing.",
+    "repairReason": {
+      "missingEnabledVpks": "Manifest says this mod is enabled, but its VPK files are missing.",
+      "missingPayload": "This mod is in your library, but its downloaded VPK files are missing. Redownload it to repair.",
+      "needsDownloadChoice": "Repair needs you to choose which download file to use.",
+      "needsFileSelection": "Repair needs you to choose which VPK file to install.",
+      "repairFailed": "Repair failed. Try again, or redownload this mod manually."
+    },
     "unknown": "Unknown"
   },
   "modButton": {
@@ -917,6 +936,14 @@
     "removed": "Removed",
     "failedToRemove": "Failed to remove",
     "error": "Error occurred",
+    "needsRepair": "Repair Mod",
+    "chooseRepairSource": "Choose repair source",
+    "needsRepairTooltip": "The manifest says this mod should be enabled, but its VPK files are missing. Redownload and reinstall it.",
+    "needsRepairSelectDownload": "Select the download file to repair this mod.",
+    "repairAllSuccess": "Repaired {{count}} broken mods.",
+    "repairAllManualOnly_one": "{{count}} mod needs manual repair.",
+    "repairAllManualOnly_other": "{{count}} mods need manual repair.",
+    "repairAllPartial": "Queued {{queued}}, repaired {{repaired}}, manual {{manual}}, failed {{failed}}.",
     "disableMod": "Disable Mod?",
     "enableMod": "Enable Mod?",
     "installedTooltip": "Toggle to disable mod (will not delete, just disable it ingame)",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1839,6 +1839,15 @@
     "likesLabel": "Likes",
     "modStatusLabel": "Status",
     "detectedHero": "Hero",
+    "changeHero": "Change hero",
+    "heroOverrideAutomatic": "Use automatic",
+    "heroSource": {
+      "manual": "Manual",
+      "api": "API",
+      "name": "Name",
+      "vpk": "VPK",
+      "none": "Unset"
+    },
     "viewOriginalPost": "View Post on GameBanana",
     "updateMod": "Update Mod",
     "forceUpdate": "Force Update",

--- a/apps/desktop/src/pages/mods.tsx
+++ b/apps/desktop/src/pages/mods.tsx
@@ -39,6 +39,7 @@ import { useScrollPosition } from "@/hooks/use-scroll-position";
 import { useSearch } from "@/hooks/use-search";
 import { getMods } from "@/lib/api-client";
 import { ModCategory, TimePeriod } from "@/lib/constants";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { STALE_TIME_API } from "@/lib/query-constants";
 import { usePersistedStore } from "@/lib/store";
 import { getTimePeriodCutoff } from "@/lib/utils";
@@ -178,6 +179,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     showFavoritesOnly = false,
   } = modsFilters;
   const favorites = usePersistedStore((state) => state.favorites);
+  const localMods = usePersistedStore((state) => state.localMods);
   const effectiveMapQuickFilter: MapQuickFilter = mapsOnly
     ? "only"
     : isCustomMapsEnabled
@@ -209,6 +211,10 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     data: deferredData,
     keys: SEARCH_KEYS,
   });
+  const localModsByRemoteId = useMemo(
+    () => new Map(localMods.map((mod) => [mod.remoteId, mod])),
+    [localMods],
+  );
   const filteredResults = useMemo(() => {
     let filtered = results;
 
@@ -232,14 +238,19 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
 
     if (selectedHeroes.length > 0) {
       filtered = filtered.filter((mod) => {
+        const resolvedHero = resolveModHero(
+          mod,
+          localModsByRemoteId.get(mod.remoteId),
+        ).hero;
         let matchesHero = false;
 
         if (selectedHeroes.includes("None")) {
           matchesHero =
-            !mod.hero ||
-            (mod.hero !== null && selectedHeroes.includes(mod.hero));
+            !resolvedHero ||
+            (resolvedHero !== null && selectedHeroes.includes(resolvedHero));
         } else {
-          matchesHero = mod.hero !== null && selectedHeroes.includes(mod.hero);
+          matchesHero =
+            resolvedHero !== null && selectedHeroes.includes(resolvedHero);
         }
 
         return filterMode === "include" ? matchesHero : !matchesHero;
@@ -284,6 +295,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     return filtered;
   }, [
     results,
+    localModsByRemoteId,
     selectedCategories,
     selectedHeroes,
     filterMode,

--- a/apps/desktop/src/pages/mods.tsx
+++ b/apps/desktop/src/pages/mods.tsx
@@ -245,12 +245,9 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
         let matchesHero = false;
 
         if (selectedHeroes.includes("None")) {
-          matchesHero =
-            !resolvedHero ||
-            (resolvedHero !== null && selectedHeroes.includes(resolvedHero));
+          matchesHero = !resolvedHero || selectedHeroes.includes(resolvedHero);
         } else {
-          matchesHero =
-            resolvedHero !== null && selectedHeroes.includes(resolvedHero);
+          matchesHero = !!resolvedHero && selectedHeroes.includes(resolvedHero);
         }
 
         return filterMode === "include" ? matchesHero : !matchesHero;

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -44,16 +44,18 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  CircleHelp,
   Download,
   EllipsisVertical,
   FolderOpen,
   LayoutGrid,
-  Settings,
   LayoutList,
   Loader2,
   PowerOff,
   RefreshCw,
   ScanSearch,
+  Settings,
+  WrenchIcon,
 } from "@deadlock-mods/ui/icons";
 import { Trash, UploadSimple } from "@phosphor-icons/react";
 import { MagnifyingGlass } from "@phosphor-icons/react";
@@ -66,6 +68,7 @@ import ModButton from "@/components/mod-browsing/mod-button";
 import NSFWBlur from "@/components/mod-browsing/nsfw-blur";
 import AudioPlayerPreview from "@/components/mod-management/audio-player-preview";
 import { ModContextMenu } from "@/components/mod-management/mod-context-menu";
+import { NeedsRepairBadge } from "@/components/mod-management/needs-repair-badge";
 import { ModOptionsDialog } from "@/components/mod-management/mod-options-dialog";
 import { OutdatedModWarning } from "@/components/mod-management/outdated-mod-warning";
 import SearchBar from "@/components/mod-browsing/search-bar";
@@ -83,6 +86,7 @@ import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { useSearch } from "@/hooks/use-search";
 import { useModOptions } from "@/hooks/use-mod-options";
+import { useRepairMods } from "@/hooks/use-repair-mods";
 import useUninstall from "@/hooks/use-uninstall";
 import { useVpkScan } from "@/hooks/use-vpk-scan";
 import { useThemeOverride } from "@/components/providers/theme-overrides";
@@ -95,7 +99,13 @@ import type {
   FilterMode,
   MapQuickFilter,
 } from "@/lib/store/slices/ui";
-import { isInstalledModWithVpks } from "@/lib/mods/installed-helpers";
+import {
+  getModStatusSortRank,
+  isAutomaticRepairMod,
+  isInstalledModWithVpks,
+  isManualRepairMod,
+  isRepairableMod,
+} from "@/lib/mods/installed-helpers";
 import { cn, isModOutdated } from "@/lib/utils";
 import { type LocalMod, ModStatus } from "@/types/mods";
 
@@ -196,6 +206,7 @@ enum ViewMode {
 enum ModFilter {
   ALL = "all",
   ENABLED = "enabled",
+  NEEDS_REPAIR = "needsRepair",
   DISABLED = "disabled",
 }
 
@@ -277,6 +288,9 @@ const GridModCard = ({ mod }: { mod: LocalMod }) => {
             )}
           </div>
           <div className='absolute top-2 right-2 flex flex-col gap-1'>
+            {mod.status === ModStatus.NeedsRepair && (
+              <NeedsRepairBadge reason={mod.repairReason} />
+            )}
             {mod.isAudio && (
               <Badge variant='secondary'>{t("mods.audio")}</Badge>
             )}
@@ -425,6 +439,12 @@ const ListModCard = ({ mod }: { mod: LocalMod }) => {
                 </div>
               )}
               <div className='absolute top-1 right-1 flex flex-col gap-1'>
+                {mod.status === ModStatus.NeedsRepair && (
+                  <NeedsRepairBadge
+                    className='text-xs'
+                    reason={mod.repairReason}
+                  />
+                )}
                 {mod.isAudio && (
                   <Badge className='text-xs' variant='secondary'>
                     {t("mods.audio")}
@@ -612,6 +632,7 @@ const MyMods = () => {
     dismissProgressToast,
   } = useAddonAnalysis();
   const { disableAll, isPending: isDisablingAll } = useDisableAllMods();
+  const { repairMods, isRepairing } = useRepairMods();
 
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.GRID);
   const [activeTab, setActiveTab] = useState<ModFilter>(ModFilter.ALL);
@@ -653,12 +674,12 @@ const MyMods = () => {
             mod.installedVpks &&
             mod.installedVpks.length > 0,
         );
+      case ModFilter.NEEDS_REPAIR:
+        return modsToFilter.filter(isRepairableMod);
       case ModFilter.DISABLED:
         return modsToFilter.filter(
           (mod) =>
-            mod.status !== ModStatus.Installed ||
-            !mod.installedVpks ||
-            mod.installedVpks.length === 0,
+            !isInstalledModWithVpks(mod) && !isRepairableMod(mod),
         );
       default:
         return modsToFilter;
@@ -666,6 +687,10 @@ const MyMods = () => {
   };
 
   const sortedMods = [...mods].sort((a, b) => {
+    const aRank = getModStatusSortRank(a);
+    const bRank = getModStatusSortRank(b);
+    if (aRank !== bRank) return aRank - bRank;
+
     const aIsInstalled =
       a.status === ModStatus.Installed &&
       a.installedVpks &&
@@ -674,9 +699,6 @@ const MyMods = () => {
       b.status === ModStatus.Installed &&
       b.installedVpks &&
       b.installedVpks.length > 0;
-
-    if (aIsInstalled && !bIsInstalled) return -1;
-    if (!aIsInstalled && bIsInstalled) return 1;
 
     if (aIsInstalled && bIsInstalled) {
       const aOrder = a.installOrder ?? 999;
@@ -690,7 +712,14 @@ const MyMods = () => {
   });
 
   const displayMods = useMemo(() => {
-    const baseMods = query.trim() ? results : sortedMods;
+    const baseMods = query.trim()
+      ? [...results].sort((a, b) => {
+          const aRank = getModStatusSortRank(a);
+          const bRank = getModStatusSortRank(b);
+          if (aRank !== bRank) return aRank - bRank;
+          return 0;
+        })
+      : sortedMods;
     const predefinedCategorySet = new Set<string>(Object.values(ModCategory));
     let filteredMods = baseMods;
 
@@ -799,12 +828,24 @@ const MyMods = () => {
   const installedMods = getOrderedMods();
 
   const enabledModsCount = mods.filter(isInstalledModWithVpks).length;
+  const needsRepairMods = mods.filter(isRepairableMod);
+  const needsRepairCount = needsRepairMods.length;
+  const autoRepairMods = needsRepairMods.filter(isAutomaticRepairMod);
+  const autoRepairCount = autoRepairMods.length;
+  const manualRepairMods = needsRepairMods.filter(isManualRepairMod);
+  const manualRepairCount = manualRepairMods.length;
   const disabledModsCount = mods.filter(
-    (mod) => !isInstalledModWithVpks(mod),
+    (mod) => !isInstalledModWithVpks(mod) && !isRepairableMod(mod),
   ).length;
   const enabledVpkFileCount = mods
     .filter(isInstalledModWithVpks)
     .reduce((sum, mod) => sum + (mod.installedVpks?.length ?? 0), 0);
+
+  useEffect(() => {
+    if (activeTab === ModFilter.NEEDS_REPAIR && needsRepairCount === 0) {
+      setActiveTab(ModFilter.ALL);
+    }
+  }, [activeTab, needsRepairCount]);
 
   const vpkStatSubordinateClass =
     enabledVpkFileCount >= ENGINE_VPK_LIMIT
@@ -1063,7 +1104,44 @@ const MyMods = () => {
                   showTimePeriodControl={false}
                   hideMapFilter={!isCustomMapsEnabled}
                 />
-                <div className='flex shrink-0 items-center gap-2'>
+                <div className='flex shrink-0 flex-wrap items-center justify-end gap-2'>
+                  {autoRepairCount > 0 && (
+                    <Button
+                      onClick={() => repairMods(autoRepairMods)}
+                      size='sm'
+                      variant='outline'
+                      disabled={isRepairing}
+                      isLoading={isRepairing}
+                      icon={<WrenchIcon className='h-4 w-4' />}
+                      className='border-amber-500/50 bg-amber-500/10 text-amber-800 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200'>
+                      {t("myMods.repairBroken", {
+                        count: autoRepairCount,
+                      })}
+                    </Button>
+                  )}
+                  {manualRepairCount > 0 && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant='outline'
+                          tabIndex={0}
+                          aria-label={t("myMods.manualRepairTooltip", {
+                            count: manualRepairCount,
+                          })}
+                          className='cursor-help border-amber-500/50 bg-amber-500/15 px-2.5 py-1.5 text-sm text-amber-800 hover:bg-amber-500/20 focus-visible:outline-none dark:text-amber-300'>
+                          <CircleHelp className='h-4 w-4' />
+                          {t("myMods.manualRepair", {
+                            count: manualRepairCount,
+                          })}
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent className='max-w-xs text-pretty'>
+                        {t("myMods.manualRepairTooltip", {
+                          count: manualRepairCount,
+                        })}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
                   <TabsList>
                     <TabsTrigger value={ModFilter.ALL}>
                       {t("myMods.tabs.all")}
@@ -1078,6 +1156,15 @@ const MyMods = () => {
                         ({enabledModsCount})
                       </span>
                     </TabsTrigger>
+                    {needsRepairCount > 0 && (
+                      <TabsTrigger value={ModFilter.NEEDS_REPAIR}>
+                        <WrenchIcon className='mr-2 h-4 w-4' />
+                        {t("myMods.tabs.needsRepair")}
+                        <span className='ml-2 text-muted-foreground text-xs'>
+                          ({needsRepairCount})
+                        </span>
+                      </TabsTrigger>
+                    )}
                     <TabsTrigger value={ModFilter.DISABLED}>
                       <Download className='mr-2 h-4 w-4' />
                       {t("myMods.tabs.downloaded")}
@@ -1149,6 +1236,12 @@ const MyMods = () => {
 
               {displayMods.length > 0 && (
                 <TabsContent value={ModFilter.ENABLED}>
+                  <ModsList mods={visibleMods} viewMode={viewMode} />
+                </TabsContent>
+              )}
+
+              {displayMods.length > 0 && (
+                <TabsContent value={ModFilter.NEEDS_REPAIR}>
                   <ModsList mods={visibleMods} viewMode={viewMode} />
                 </TabsContent>
               )}

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -94,6 +94,7 @@ import { SortType } from "@/lib/constants";
 import { ModCategory } from "@/lib/constants";
 import { getErrorMessage } from "@/lib/errors";
 import { filterStableLibraryModsByStatus } from "@/lib/mods/library-display";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -688,12 +689,14 @@ const MyMods = () => {
 
     if (selectedHeroes.length > 0) {
       filteredMods = filteredMods.filter((mod) => {
+        const resolvedHero = resolveModHero(mod, mod).hero;
         let matchesHero = false;
 
         if (selectedHeroes.includes("None")) {
-          matchesHero = !mod.hero || selectedHeroes.includes(mod.hero);
+          matchesHero = !resolvedHero || selectedHeroes.includes(resolvedHero);
         } else {
-          matchesHero = mod.hero !== null && selectedHeroes.includes(mod.hero);
+          matchesHero =
+            resolvedHero !== null && selectedHeroes.includes(resolvedHero);
         }
 
         return filterMode === "include" ? matchesHero : !matchesHero;

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -93,6 +93,7 @@ import { useThemeOverride } from "@/components/providers/theme-overrides";
 import { SortType } from "@/lib/constants";
 import { ModCategory } from "@/lib/constants";
 import { getErrorMessage } from "@/lib/errors";
+import { filterStableLibraryModsByStatus } from "@/lib/mods/library-display";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -100,7 +101,6 @@ import type {
   MapQuickFilter,
 } from "@/lib/store/slices/ui";
 import {
-  getModStatusSortRank,
   isAutomaticRepairMod,
   isInstalledModWithVpks,
   isManualRepairMod,
@@ -665,61 +665,8 @@ const MyMods = () => {
     },
   });
 
-  const filterModsByStatus = (modsToFilter: LocalMod[]) => {
-    switch (activeTab) {
-      case ModFilter.ENABLED:
-        return modsToFilter.filter(
-          (mod) =>
-            mod.status === ModStatus.Installed &&
-            mod.installedVpks &&
-            mod.installedVpks.length > 0,
-        );
-      case ModFilter.NEEDS_REPAIR:
-        return modsToFilter.filter(isRepairableMod);
-      case ModFilter.DISABLED:
-        return modsToFilter.filter(
-          (mod) =>
-            !isInstalledModWithVpks(mod) && !isRepairableMod(mod),
-        );
-      default:
-        return modsToFilter;
-    }
-  };
-
-  const sortedMods = [...mods].sort((a, b) => {
-    const aRank = getModStatusSortRank(a);
-    const bRank = getModStatusSortRank(b);
-    if (aRank !== bRank) return aRank - bRank;
-
-    const aIsInstalled =
-      a.status === ModStatus.Installed &&
-      a.installedVpks &&
-      a.installedVpks.length > 0;
-    const bIsInstalled =
-      b.status === ModStatus.Installed &&
-      b.installedVpks &&
-      b.installedVpks.length > 0;
-
-    if (aIsInstalled && bIsInstalled) {
-      const aOrder = a.installOrder ?? 999;
-      const bOrder = b.installOrder ?? 999;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-    }
-
-    const dateA = a.downloadedAt ? new Date(a.downloadedAt).getTime() : 0;
-    const dateB = b.downloadedAt ? new Date(b.downloadedAt).getTime() : 0;
-    return dateB - dateA;
-  });
-
   const displayMods = useMemo(() => {
-    const baseMods = query.trim()
-      ? [...results].sort((a, b) => {
-          const aRank = getModStatusSortRank(a);
-          const bRank = getModStatusSortRank(b);
-          if (aRank !== bRank) return aRank - bRank;
-          return 0;
-        })
-      : sortedMods;
+    const baseMods = query.trim() ? results : mods;
     const predefinedCategorySet = new Set<string>(Object.values(ModCategory));
     let filteredMods = baseMods;
 
@@ -775,7 +722,7 @@ const MyMods = () => {
       );
     }
 
-    return filterModsByStatus(filteredMods);
+    return filterStableLibraryModsByStatus(filteredMods, activeTab);
   }, [
     activeTab,
     filterMode,
@@ -787,7 +734,7 @@ const MyMods = () => {
     results,
     selectedCategories,
     selectedHeroes,
-    sortedMods,
+    mods,
   ]);
 
   const totalPages = paginationEnabled

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -5,6 +5,16 @@ import type { VpkParsed } from "@deadlock-mods/vpk-parser";
 
 // Individual download item type extracted from ModDownloadDto schema
 export type ModDownloadItem = z.infer<typeof ModDownloadDtoSchema>;
+export type RepairDownloadItem = Pick<
+  ModDownloadItem,
+  "name" | "size" | "url"
+> &
+  Partial<
+    Pick<
+      ModDownloadItem,
+      "createdAt" | "description" | "md5Checksum" | "updatedAt"
+    >
+  >;
 
 export type Progress = {
   progress: number;
@@ -26,13 +36,23 @@ export enum ModStatus {
   Removed = "removed",
   FailedToRemove = "failedToRemove",
   Error = "error",
+  NeedsRepair = "needsRepair",
 }
+
+export type RepairReason =
+  | "missingEnabledVpks"
+  | "missingPayload"
+  | "needsDownloadChoice"
+  | "needsFileSelection"
+  | "repairFailed";
 
 export interface LocalMod extends ModDto {
   status: ModStatus;
   downloadedAt?: Date;
   downloads?: ModDownloadItem[];
   selectedDownloads?: ModDownloadItem[];
+  repairDownloads?: RepairDownloadItem[];
+  repairReason?: RepairReason;
   activeVariantArchive?: string;
   installedVpks?: string[];
   installedFileTree?: ModFileTree;

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -58,6 +58,7 @@ export interface LocalMod extends ModDto {
   installedFileTree?: ModFileTree;
   installOrder?: number;
   detectedHero?: string | null;
+  heroOverride?: string | null;
   usesCriticalPaths?: boolean;
 }
 

--- a/apps/desktop/src/types/profiles.ts
+++ b/apps/desktop/src/types/profiles.ts
@@ -1,4 +1,5 @@
 import type { LocalMod } from "@/types/mods";
+import type { RepairDownloadItem } from "@/types/mods";
 
 export type ProfileId = string & { readonly __brand: unique symbol };
 
@@ -26,6 +27,15 @@ export interface VpkManifestEntry {
   currentVpks: string[];
   disabledVpks: string[];
   originalVpkNames: string[];
+  sourceDownloads?: RepairDownloadItem[];
+  vpkFingerprints?: Array<{
+    currentName: string;
+    originalName: string;
+    fileSize: number;
+    fastHash: string;
+    sha256: string;
+    manifestSha256: string;
+  }>;
 }
 
 export interface VpkManifest {

--- a/packages/shared/src/heroes.ts
+++ b/packages/shared/src/heroes.ts
@@ -1,48 +1,148 @@
 import { DeadlockHeroes, DeadlockHeroesByAlias } from "./constants";
 
+const normalizeHeroKey = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/['`]/g, "")
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const toHero = (hero: DeadlockHeroes): DeadlockHeroes =>
+  DeadlockHeroes[DeadlockHeroesByAlias[hero] as keyof typeof DeadlockHeroes];
+
+const knownAliases = new Map<string, DeadlockHeroes>();
+
+const addAliases = (hero: DeadlockHeroes, aliases: string[]) => {
+  for (const alias of [hero, DeadlockHeroesByAlias[hero], ...aliases]) {
+    knownAliases.set(normalizeHeroKey(alias), toHero(hero));
+  }
+};
+
+const escapeRegex = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const tokenPattern = (pattern: string): RegExp =>
+  new RegExp(`(?:^|[^a-z0-9])${pattern}(?:$|[^a-z0-9])`, "i");
+
+const word = (value: string): RegExp => tokenPattern(escapeRegex(value));
+
+const phrase = (...parts: string[]): RegExp =>
+  tokenPattern(parts.map(escapeRegex).join("[^a-z0-9]+"));
+
+addAliases(DeadlockHeroes.Abrams, [
+  "atlas",
+  "atlas detective",
+  "atlas detective v2",
+]);
+addAliases(DeadlockHeroes.Apollo, ["fencer"]);
+addAliases(DeadlockHeroes.Bebop, []);
+addAliases(DeadlockHeroes.Billy, ["punkgoat"]);
+addAliases(DeadlockHeroes.Calico, ["cadence", "nano"]);
+addAliases(DeadlockHeroes.Celeste, ["unicorn"]);
+addAliases(DeadlockHeroes.Doorman, ["doorman v2"]);
+addAliases(DeadlockHeroes.Drifter, []);
+addAliases(DeadlockHeroes.Dynamo, ["prof dynamo"]);
+addAliases(DeadlockHeroes.Graves, ["necro"]);
+addAliases(DeadlockHeroes.GreyTalon, ["archer", "archer v2", "greytalon"]);
+addAliases(DeadlockHeroes.Haze, ["haze v2"]);
+addAliases(DeadlockHeroes.Holliday, ["astro"]);
+addAliases(DeadlockHeroes.Infernus, ["inferno", "inferno v4"]);
+addAliases(DeadlockHeroes.Ivy, ["tengu"]);
+addAliases(DeadlockHeroes.Kelvin, ["kelvin explorer", "kelvin v2"]);
+addAliases(DeadlockHeroes.LadyGeist, ["geist", "ghost", "ladygeist"]);
+addAliases(DeadlockHeroes.Lash, ["lash v2"]);
+addAliases(DeadlockHeroes.McGinnis, ["engineer"]);
+addAliases(DeadlockHeroes.Mina, ["vampirebat"]);
+addAliases(DeadlockHeroes.Mirage, ["mirage v2"]);
+addAliases(DeadlockHeroes.MoKrill, ["digger", "mo krill", "mokrill"]);
+addAliases(DeadlockHeroes.Paige, ["bookworm"]);
+addAliases(DeadlockHeroes.Paradox, ["chrono"]);
+addAliases(DeadlockHeroes.Pocket, ["synth"]);
+addAliases(DeadlockHeroes.Rem, ["familiar"]);
+addAliases(DeadlockHeroes.Seven, ["7", "gigawatt", "gigawatt prisoner"]);
+addAliases(DeadlockHeroes.Shiv, ["shiv ult"]);
+addAliases(DeadlockHeroes.Silver, ["werewolf"]);
+addAliases(DeadlockHeroes.Sinclair, ["magician", "magician v2"]);
+addAliases(DeadlockHeroes.Venator, ["priest"]);
+addAliases(DeadlockHeroes.Victor, ["frank", "frank v2", "viktor"]);
+addAliases(DeadlockHeroes.Vindicta, ["hornet", "hornet v3"]);
+addAliases(DeadlockHeroes.Viscous, []);
+addAliases(DeadlockHeroes.Vyper, ["viper"]);
+addAliases(DeadlockHeroes.Warden, []);
+addAliases(DeadlockHeroes.Wraith, [
+  "wraith gen man",
+  "wraith magician",
+  "wraith puppeteer",
+]);
+addAliases(DeadlockHeroes.Wrecker, ["butcher"]);
+addAliases(DeadlockHeroes.Yamato, ["yamato v2"]);
+
 const knownRegexes = {
-  [DeadlockHeroes.Abrams]: [/abrams/i, /brams/i],
-  [DeadlockHeroes.Apollo]: [/apollo/i],
-  [DeadlockHeroes.Bebop]: [/bebop/i],
-  [DeadlockHeroes.Billy]: [/billy/i],
-  [DeadlockHeroes.Calico]: [/calico/i],
-  [DeadlockHeroes.Celeste]: [/celeste/i],
-  [DeadlockHeroes.Doorman]: [/doorman/i],
-  [DeadlockHeroes.Drifter]: [/drifter/i],
-  [DeadlockHeroes.Dynamo]: [/dynamo/i],
-  [DeadlockHeroes.Graves]: [/graves/i],
-  [DeadlockHeroes.GreyTalon]: [/talon/i, /grey talon/i],
-  [DeadlockHeroes.Haze]: [/haze/i],
-  [DeadlockHeroes.Holliday]: [/holliday/i],
-  [DeadlockHeroes.Infernus]: [/infernus/i, /fernus/i],
-  [DeadlockHeroes.Ivy]: [/ivy/i],
-  [DeadlockHeroes.Kelvin]: [/kelvin/i],
-  [DeadlockHeroes.LadyGeist]: [/geist/i, /gaist/i, /lady/i, /lady geist/i],
-  [DeadlockHeroes.Lash]: [/lash/i],
-  [DeadlockHeroes.McGinnis]: [/mcginnis/i],
-  [DeadlockHeroes.Mina]: [/mina/i],
-  [DeadlockHeroes.Mirage]: [/mirage/i],
-  [DeadlockHeroes.MoKrill]: [/krill/i, /mo & krill/i, /mo and krill/i],
-  [DeadlockHeroes.Paige]: [/paige/i],
-  [DeadlockHeroes.Paradox]: [/paradox/i, /dox/i],
-  [DeadlockHeroes.Pocket]: [/pocket/i],
-  [DeadlockHeroes.Rem]: [/rem/i],
-  [DeadlockHeroes.Seven]: [/seven/i],
-  [DeadlockHeroes.Shiv]: [/shiv/i],
-  [DeadlockHeroes.Silver]: [/silver/i],
-  [DeadlockHeroes.Sinclair]: [/sinclair/i],
-  [DeadlockHeroes.Venator]: [/venator/i],
-  [DeadlockHeroes.Victor]: [/victor/i],
-  [DeadlockHeroes.Vindicta]: [/vindicta/i],
-  [DeadlockHeroes.Viscous]: [/viscous/i],
-  [DeadlockHeroes.Vyper]: [/vyper/i, /viper/i],
-  [DeadlockHeroes.Warden]: [/warden/i],
-  [DeadlockHeroes.Wraith]: [/wraith/i],
-  [DeadlockHeroes.Wrecker]: [/wrecker/i],
-  [DeadlockHeroes.Yamato]: [/yamato/i],
+  [DeadlockHeroes.Abrams]: [word("abrams"), word("brams")],
+  [DeadlockHeroes.Apollo]: [word("apollo")],
+  [DeadlockHeroes.Bebop]: [word("bebop")],
+  [DeadlockHeroes.Billy]: [word("billy")],
+  [DeadlockHeroes.Calico]: [word("calico")],
+  [DeadlockHeroes.Celeste]: [word("celeste")],
+  [DeadlockHeroes.Doorman]: [word("doorman")],
+  [DeadlockHeroes.Drifter]: [word("drifter")],
+  [DeadlockHeroes.Dynamo]: [word("dynamo")],
+  [DeadlockHeroes.Graves]: [word("graves")],
+  [DeadlockHeroes.GreyTalon]: [word("talon"), phrase("grey", "talon")],
+  [DeadlockHeroes.Haze]: [word("haze")],
+  [DeadlockHeroes.Holliday]: [word("holliday")],
+  [DeadlockHeroes.Infernus]: [word("infernus"), word("fernus")],
+  [DeadlockHeroes.Ivy]: [word("ivy")],
+  [DeadlockHeroes.Kelvin]: [word("kelvin")],
+  [DeadlockHeroes.LadyGeist]: [
+    word("geist"),
+    word("gaist"),
+    phrase("lady", "geist"),
+    tokenPattern("lady[^a-z0-9]*geist"),
+  ],
+  [DeadlockHeroes.Lash]: [word("lash")],
+  [DeadlockHeroes.McGinnis]: [word("mcginnis")],
+  [DeadlockHeroes.Mina]: [word("mina")],
+  [DeadlockHeroes.Mirage]: [word("mirage")],
+  [DeadlockHeroes.MoKrill]: [
+    word("krill"),
+    phrase("mo", "krill"),
+    phrase("mo", "and", "krill"),
+    tokenPattern("mo[^a-z0-9]*krill"),
+  ],
+  [DeadlockHeroes.Paige]: [word("paige")],
+  [DeadlockHeroes.Paradox]: [word("paradox"), word("dox")],
+  [DeadlockHeroes.Pocket]: [word("pocket")],
+  [DeadlockHeroes.Rem]: [word("rem")],
+  [DeadlockHeroes.Seven]: [word("seven"), word("7")],
+  [DeadlockHeroes.Shiv]: [word("shiv")],
+  [DeadlockHeroes.Silver]: [word("silver")],
+  [DeadlockHeroes.Sinclair]: [word("sinclair")],
+  [DeadlockHeroes.Venator]: [word("venator")],
+  [DeadlockHeroes.Victor]: [word("victor"), word("viktor")],
+  [DeadlockHeroes.Vindicta]: [word("vindicta")],
+  [DeadlockHeroes.Viscous]: [word("viscous")],
+  [DeadlockHeroes.Vyper]: [word("vyper"), word("viper")],
+  [DeadlockHeroes.Warden]: [word("warden")],
+  [DeadlockHeroes.Wraith]: [word("wraith")],
+  [DeadlockHeroes.Wrecker]: [word("wrecker")],
+  [DeadlockHeroes.Yamato]: [word("yamato")],
+};
+
+export const normalizeHero = (
+  value: string | null | undefined,
+): DeadlockHeroes | null => {
+  if (!value) return null;
+  return knownAliases.get(normalizeHeroKey(value)) ?? null;
 };
 
 export const guessHero = (value: string): DeadlockHeroes | null => {
+  const exactHero = normalizeHero(value);
+  if (exactHero) return exactHero;
+
   for (const [hero, regex] of Object.entries(knownRegexes)) {
     if (regex.some((r) => r.test(value.toLowerCase()))) {
       return DeadlockHeroes[

--- a/packages/shared/src/tests/heroes.spec.ts
+++ b/packages/shared/src/tests/heroes.spec.ts
@@ -1,10 +1,35 @@
 import { expect, test } from "vitest";
 import { DeadlockHeroes } from "../constants";
-import { guessHero } from "../heroes";
+import { guessHero, normalizeHero } from "../heroes";
 
 test("guessHero", () => {
   expect(guessHero("Raiden | Yamato Skin")).toBe(DeadlockHeroes.Yamato);
   expect(guessHero("Viscous")).toBe(DeadlockHeroes.Viscous);
   expect(guessHero("Alternative Geist")).toBe(DeadlockHeroes.LadyGeist);
   expect(guessHero("Victor Skin Pack")).toBe(DeadlockHeroes.Victor);
+  expect(guessHero("Toon Viktor")).toBe(DeadlockHeroes.Victor);
+  expect(guessHero("Toon 7")).toBe(DeadlockHeroes.Seven);
+  expect(guessHero("Yoshi -> Rem")).toBe(DeadlockHeroes.Rem);
+  expect(guessHero("ZZZ Trigger Vindicta remodel")).toBe(
+    DeadlockHeroes.Vindicta,
+  );
+});
+
+test("normalizeHero", () => {
+  expect(normalizeHero("Victor")).toBe(DeadlockHeroes.Victor);
+  expect(normalizeHero("Viktor")).toBe(DeadlockHeroes.Victor);
+  expect(normalizeHero("LadyGeist")).toBe(DeadlockHeroes.LadyGeist);
+  expect(normalizeHero("MoKrill")).toBe(DeadlockHeroes.MoKrill);
+  expect(normalizeHero("gigawatt_prisoner")).toBe(DeadlockHeroes.Seven);
+  expect(normalizeHero("not a hero")).toBeNull();
+});
+
+test("guessHero avoids common substring false positives", () => {
+  expect(guessHero("ZZZ Trigger Vindicta remodel")).toBe(
+    DeadlockHeroes.Vindicta,
+  );
+  expect(guessHero("Slash effect pack")).toBeNull();
+  expect(guessHero("Seventh anniversary pack")).toBeNull();
+  expect(guessHero("Ladybug skin pack")).toBeNull();
+  expect(guessHero("Remodel pack")).toBeNull();
 });


### PR DESCRIPTION
## Description

This PR continues the VPK state-drift work from #444 by adding durable repair metadata for reconstructed/local VPK entries, then fixes hero resolution so remote mods prefer GameBanana's profile sub-category before falling back to safer title and VPK detection.

The practical user goal is: if the app can recognize or repair a local VPK, it should remember enough metadata to keep My Mods stable, and hero conflict warnings should stop coming from weak title guesses like treating a Vindicta remodel as Rem or a Viktor skin as Infernus.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [x] Tests (adding or updating tests)
- [ ] Chore (maintenance, dependency updates, etc.)

## Related Issues

- Follow-up to #444
- Related to user reports of repaired/local VPKs reappearing as unrecognized files.
- Related to wrong hero conflict warnings caused by weak title-based hero inference.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted - Tool: OpenAI Codex, Used for: codebase analysis, implementation, local validation, and PR preparation.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes in a production-like build path where practical

Manual validation:

- Built and tested the desktop app manually multiple times during the repair metadata and hero-detection work.
- Exercised the relevant mod detail, hero override, and hero conflict flows in the running desktop app while iterating.

Automated/local checks:

- `pnpm --filter @deadlock-mods/shared test -- --run src/tests/heroes.spec.ts`
- `pnpm --filter @deadlock-mods/desktop test -- src/lib/mods/hero-resolution.test.ts`
- `pnpm --filter @deadlock-mods/desktop test -- src/lib/mods/library-display.test.ts`
- `bun test apps/api/src/providers/game-banana/utils.test.ts`
- `pnpm --filter @deadlock-mods/desktop check-types`
- `pnpm --filter @deadlock-mods/desktop ui:build`
- `pnpm exec oxfmt . --check`

Known unrelated failure:

- `pnpm --filter @deadlock-mods/api check-types` still fails on the existing `apps/api/src/index.ts(75,63)` type error.

## Screenshots (if applicable)

Not included. This PR is primarily state, metadata, and detection behavior. The visible UI changes are limited to existing repair status/actions and the hero override selector, which were manually tested in the running desktop app.

## Checklist

- [x] I have read the Contributing Guidelines and AI Policy
- [x] My code follows the style guidelines of this project where locally verifiable
- [x] I have performed a self-review of my own code
- [x] I have commented my code only where it clarifies non-obvious behavior
- [x] I have made corresponding changes to the documentation where applicable
- [x] My changes generate no new warnings or errors in the checks listed above
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested the changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable)

## Additional Notes

Root cause, repair metadata: after #444, the app had a more reliable profile VPK manifest, but reconstructed or repaired local VPK entries still needed durable metadata tying the library entry back to the files on disk. Without that, later file/state reconciliation lacked enough context to identify the mod correctly.

Root cause, hero detection: the fallback title matcher was doing too much work too early. GameBanana's profile response exposes the mod sub-category, which is usually the hero for skin mods. This PR makes that category the primary remote source, then falls back to safer title matching and local/VPK detection. It also adds manual override support because upstream metadata and local filenames can still be wrong in the real world.

Concrete example checked during development: GameBanana mod `672078` reports category `Vindicta` from the profile API, while the deployed production API was still returning `Rem` from stale/incorrect inference. Once this code is deployed and cache/sync refreshes run, that class of conflict should stop reproducing from the API side.

This PR is intentionally a little larger than a pure hero-detection patch because repair metadata and hero conflict behavior both depend on trustworthy mod identity. The follow-up UI polish for the "Unrecognized VPK files found" banner should stay separate so this PR remains focused on state correctness and detection behavior.

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions