### PR TITLE
fix(desktop): preserve My Mods library order

### DIFF
--- a/.changeset/stable-library-order.md
+++ b/.changeset/stable-library-order.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Preserve My Mods library order when filtering by install status.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -13,6 +13,7 @@
   "endOfLine": "lf",
   "insertFinalNewline": true,
   "ignorePatterns": [
+    ".agents/**",
     ".cursor/**",
     "**/node_modules/**",
     "**/dist/**",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,8 @@
 {
   "extends": ["./tools/oxc/oxlintrc.base.json"],
   "ignorePatterns": [
+    ".agents/**",
+    ".cursor/**",
     "**/node_modules/**",
     "**/dist/**",
     "**/build/**",

--- a/apps/desktop/src/lib/mods/library-display.test.ts
+++ b/apps/desktop/src/lib/mods/library-display.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { filterStableLibraryModsByStatus } from "./library-display";
+import { type LocalMod, ModStatus } from "@/types/mods";
+
+const mod = (
+  remoteId: string,
+  status: ModStatus,
+  extra: Partial<LocalMod> = {},
+): LocalMod =>
+  ({
+    id: remoteId,
+    remoteId,
+    name: remoteId,
+    author: "Test Author",
+    status,
+    ...extra,
+  }) as LocalMod;
+
+const ids = (mods: LocalMod[]) => mods.map((item) => item.remoteId);
+
+describe("filterStableLibraryModsByStatus", () => {
+  it("preserves library order in the all view", () => {
+    const mods = [
+      mod("disabled-newer", ModStatus.Downloaded, {
+        downloadedAt: new Date("2026-04-03"),
+      }),
+      mod("enabled-late-load-order", ModStatus.Installed, {
+        installOrder: 99,
+        installedVpks: ["late.vpk"],
+      }),
+      mod("enabled-early-load-order", ModStatus.Installed, {
+        installOrder: 0,
+        installedVpks: ["early.vpk"],
+      }),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "all"))).toEqual([
+      "disabled-newer",
+      "enabled-late-load-order",
+      "enabled-early-load-order",
+    ]);
+  });
+
+  it("preserves library-relative order in the enabled view instead of sorting by installOrder", () => {
+    const mods = [
+      mod("enabled-load-order-10", ModStatus.Installed, {
+        installOrder: 10,
+        installedVpks: ["ten.vpk"],
+      }),
+      mod("disabled", ModStatus.Downloaded),
+      mod("enabled-load-order-1", ModStatus.Installed, {
+        installOrder: 1,
+        installedVpks: ["one.vpk"],
+      }),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "enabled"))).toEqual([
+      "enabled-load-order-10",
+      "enabled-load-order-1",
+    ]);
+  });
+
+  it("filters disabled mods without including installed mods", () => {
+    const mods = [
+      mod("installed", ModStatus.Installed, {
+        installedVpks: ["installed.vpk"],
+      }),
+      mod("downloaded", ModStatus.Downloaded),
+      mod("failed-install", ModStatus.FailedToInstall),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "disabled"))).toEqual([
+      "downloaded",
+      "failed-install",
+    ]);
+  });
+
+  it("preserves caller-provided search result order instead of regrouping by status", () => {
+    const searchResults = [
+      mod("search-hit-disabled", ModStatus.Downloaded),
+      mod("search-hit-enabled", ModStatus.Installed, {
+        installOrder: 0,
+        installedVpks: ["enabled.vpk"],
+      }),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(searchResults, "all"))).toEqual([
+      "search-hit-disabled",
+      "search-hit-enabled",
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/mods/library-display.test.ts
+++ b/apps/desktop/src/lib/mods/library-display.test.ts
@@ -2,19 +2,47 @@ import { describe, expect, it } from "bun:test";
 import { filterStableLibraryModsByStatus } from "./library-display";
 import { type LocalMod, ModStatus } from "@/types/mods";
 
+type LocalModOverrides = Partial<
+  Omit<LocalMod, "id" | "remoteId" | "name" | "author" | "status">
+>;
+
 const mod = (
   remoteId: string,
   status: ModStatus,
-  extra: Partial<LocalMod> = {},
-): LocalMod =>
-  ({
-    id: remoteId,
-    remoteId,
-    name: remoteId,
-    author: "Test Author",
-    status,
-    ...extra,
-  }) as LocalMod;
+  extra: LocalModOverrides = {},
+): LocalMod => ({
+  id: remoteId,
+  remoteId,
+  name: remoteId,
+  description: null,
+  remoteUrl: `https://example.test/mods/${remoteId}`,
+  category: "Characters",
+  likes: 0,
+  author: "Test Author",
+  downloadable: true,
+  remoteAddedAt: new Date("2026-01-01"),
+  remoteUpdatedAt: new Date("2026-01-01"),
+  tags: [],
+  images: [],
+  hero: null,
+  isAudio: false,
+  isMap: false,
+  audioUrl: null,
+  downloadCount: 0,
+  isNSFW: false,
+  isObsolete: false,
+  isBlacklisted: false,
+  blacklistReason: null,
+  blacklistedAt: null,
+  blacklistedBy: null,
+  filesUpdatedAt: null,
+  metadata: null,
+  overrides: null,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+  status,
+  ...extra,
+});
 
 const ids = (mods: LocalMod[]) => mods.map((item) => item.remoteId);
 

--- a/apps/desktop/src/lib/mods/library-display.ts
+++ b/apps/desktop/src/lib/mods/library-display.ts
@@ -1,18 +1,22 @@
 import type { LocalMod } from "@/types/mods";
 import { isInstalledModWithVpks } from "./installed-helpers";
 
-export type ModLibraryFilter = "all" | "enabled" | "disabled";
+export enum ModFilter {
+  All = "all",
+  Enabled = "enabled",
+  Disabled = "disabled",
+}
 
-export function filterStableLibraryModsByStatus(
+export function filterLibraryModsByStatus(
   mods: LocalMod[],
-  filter: ModLibraryFilter,
+  filter: ModFilter,
 ): LocalMod[] {
   switch (filter) {
-    case "enabled":
+    case ModFilter.Enabled:
       return mods.filter(isInstalledModWithVpks);
-    case "disabled":
+    case ModFilter.Disabled:
       return mods.filter((mod) => !isInstalledModWithVpks(mod));
-    case "all":
+    case ModFilter.All:
       return mods;
   }
 }

--- a/apps/desktop/src/lib/mods/library-display.ts
+++ b/apps/desktop/src/lib/mods/library-display.ts
@@ -1,0 +1,18 @@
+import type { LocalMod } from "@/types/mods";
+import { isInstalledModWithVpks } from "./installed-helpers";
+
+export type ModLibraryFilter = "all" | "enabled" | "disabled";
+
+export function filterStableLibraryModsByStatus(
+  mods: LocalMod[],
+  filter: ModLibraryFilter,
+): LocalMod[] {
+  switch (filter) {
+    case "enabled":
+      return mods.filter(isInstalledModWithVpks);
+    case "disabled":
+      return mods.filter((mod) => !isInstalledModWithVpks(mod));
+    case "all":
+      return mods;
+  }
+}

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -89,7 +89,10 @@ import { useThemeOverride } from "@/components/providers/theme-overrides";
 import { SortType } from "@/lib/constants";
 import { ModCategory } from "@/lib/constants";
 import { getErrorMessage } from "@/lib/errors";
-import { filterStableLibraryModsByStatus } from "@/lib/mods/library-display";
+import {
+  filterLibraryModsByStatus,
+  ModFilter,
+} from "@/lib/mods/library-display";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -193,12 +196,6 @@ function ModsPagination({
 enum ViewMode {
   GRID = "grid",
   LIST = "list",
-}
-
-enum ModFilter {
-  ALL = "all",
-  ENABLED = "enabled",
-  DISABLED = "disabled",
 }
 
 const GridModCard = ({ mod }: { mod: LocalMod }) => {
@@ -602,7 +599,7 @@ const MyMods = () => {
   const { disableAll, isPending: isDisablingAll } = useDisableAllMods();
 
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.GRID);
-  const [activeTab, setActiveTab] = useState<ModFilter>(ModFilter.ALL);
+  const [activeTab, setActiveTab] = useState<ModFilter>(ModFilter.All);
   const [showBatchUpdateDialog, setShowBatchUpdateDialog] = useState(false);
   const [showModOrdering, setShowModOrdering] = useState(false);
   const [page, setPage] = useState(0);
@@ -689,7 +686,7 @@ const MyMods = () => {
       );
     }
 
-    return filterStableLibraryModsByStatus(filteredMods, activeTab);
+    return filterLibraryModsByStatus(filteredMods, activeTab);
   }, [
     activeTab,
     filterMode,
@@ -972,9 +969,9 @@ const MyMods = () => {
             value={activeTab}
             onValueChange={(value) => {
               switch (value) {
-                case ModFilter.ALL:
-                case ModFilter.ENABLED:
-                case ModFilter.DISABLED:
+                case ModFilter.All:
+                case ModFilter.Enabled:
+                case ModFilter.Disabled:
                   setActiveTab(value);
                   break;
               }
@@ -1024,20 +1021,20 @@ const MyMods = () => {
                   </div>
                   <div className='flex min-w-0 flex-wrap items-center justify-start gap-2 xl:justify-end'>
                     <TabsList className='h-auto min-h-9 max-w-full flex-wrap justify-start'>
-                      <TabsTrigger value={ModFilter.ALL}>
+                      <TabsTrigger value={ModFilter.All}>
                         {t("myMods.tabs.all")}
                         <span className='ml-2 text-muted-foreground text-xs'>
                           ({mods.length})
                         </span>
                       </TabsTrigger>
-                      <TabsTrigger value={ModFilter.ENABLED}>
+                      <TabsTrigger value={ModFilter.Enabled}>
                         <Check className='mr-2 h-4 w-4' />
                         {t("myMods.tabs.installed")}
                         <span className='ml-2 text-muted-foreground text-xs'>
                           ({enabledModsCount})
                         </span>
                       </TabsTrigger>
-                      <TabsTrigger value={ModFilter.DISABLED}>
+                      <TabsTrigger value={ModFilter.Disabled}>
                         <Download className='mr-2 h-4 w-4' />
                         {t("myMods.tabs.downloaded")}
                         <span className='ml-2 text-muted-foreground text-xs'>
@@ -1111,19 +1108,19 @@ const MyMods = () => {
                 )}
 
                 {displayMods.length > 0 && (
-                  <TabsContent className='mt-0' value={ModFilter.ALL}>
+                  <TabsContent className='mt-0' value={ModFilter.All}>
                     <ModsList mods={visibleMods} viewMode={viewMode} />
                   </TabsContent>
                 )}
 
                 {displayMods.length > 0 && (
-                  <TabsContent className='mt-0' value={ModFilter.ENABLED}>
+                  <TabsContent className='mt-0' value={ModFilter.Enabled}>
                     <ModsList mods={visibleMods} viewMode={viewMode} />
                   </TabsContent>
                 )}
 
                 {displayMods.length > 0 && (
-                  <TabsContent className='mt-0' value={ModFilter.DISABLED}>
+                  <TabsContent className='mt-0' value={ModFilter.Disabled}>
                     <ModsList mods={visibleMods} viewMode={viewMode} />
                   </TabsContent>
                 )}

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -89,6 +89,7 @@ import { useThemeOverride } from "@/components/providers/theme-overrides";
 import { SortType } from "@/lib/constants";
 import { ModCategory } from "@/lib/constants";
 import { getErrorMessage } from "@/lib/errors";
+import { filterStableLibraryModsByStatus } from "@/lib/mods/library-display";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -631,53 +632,8 @@ const MyMods = () => {
     },
   });
 
-  const filterModsByStatus = (modsToFilter: LocalMod[]) => {
-    switch (activeTab) {
-      case ModFilter.ENABLED:
-        return modsToFilter.filter(
-          (mod) =>
-            mod.status === ModStatus.Installed &&
-            mod.installedVpks &&
-            mod.installedVpks.length > 0,
-        );
-      case ModFilter.DISABLED:
-        return modsToFilter.filter(
-          (mod) =>
-            mod.status !== ModStatus.Installed ||
-            !mod.installedVpks ||
-            mod.installedVpks.length === 0,
-        );
-      default:
-        return modsToFilter;
-    }
-  };
-
-  const sortedMods = [...mods].sort((a, b) => {
-    const aIsInstalled =
-      a.status === ModStatus.Installed &&
-      a.installedVpks &&
-      a.installedVpks.length > 0;
-    const bIsInstalled =
-      b.status === ModStatus.Installed &&
-      b.installedVpks &&
-      b.installedVpks.length > 0;
-
-    if (aIsInstalled && !bIsInstalled) return -1;
-    if (!aIsInstalled && bIsInstalled) return 1;
-
-    if (aIsInstalled && bIsInstalled) {
-      const aOrder = a.installOrder ?? 999;
-      const bOrder = b.installOrder ?? 999;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-    }
-
-    const dateA = a.downloadedAt ? new Date(a.downloadedAt).getTime() : 0;
-    const dateB = b.downloadedAt ? new Date(b.downloadedAt).getTime() : 0;
-    return dateB - dateA;
-  });
-
   const displayMods = useMemo(() => {
-    const baseMods = query.trim() ? results : sortedMods;
+    const baseMods = query.trim() ? results : mods;
     const predefinedCategorySet = new Set<string>(Object.values(ModCategory));
     let filteredMods = baseMods;
 
@@ -733,7 +689,7 @@ const MyMods = () => {
       );
     }
 
-    return filterModsByStatus(filteredMods);
+    return filterStableLibraryModsByStatus(filteredMods, activeTab);
   }, [
     activeTab,
     filterMode,
@@ -745,7 +701,7 @@ const MyMods = () => {
     results,
     selectedCategories,
     selectedHeroes,
-    sortedMods,
+    mods,
   ]);
 
   const totalPages = paginationEnabled

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -89,6 +89,7 @@ import { useThemeOverride } from "@/components/providers/theme-overrides";
 import { SortType } from "@/lib/constants";
 import { ModCategory } from "@/lib/constants";
 import { getErrorMessage } from "@/lib/errors";
+import { filterStableLibraryModsByStatus } from "@/lib/mods/library-display";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -645,53 +646,8 @@ const MyMods = () => {
     },
   });
 
-  const filterModsByStatus = (modsToFilter: LocalMod[]) => {
-    switch (activeTab) {
-      case ModFilter.ENABLED:
-        return modsToFilter.filter(
-          (mod) =>
-            mod.status === ModStatus.Installed &&
-            mod.installedVpks &&
-            mod.installedVpks.length > 0,
-        );
-      case ModFilter.DISABLED:
-        return modsToFilter.filter(
-          (mod) =>
-            mod.status !== ModStatus.Installed ||
-            !mod.installedVpks ||
-            mod.installedVpks.length === 0,
-        );
-      default:
-        return modsToFilter;
-    }
-  };
-
-  const sortedMods = [...mods].sort((a, b) => {
-    const aIsInstalled =
-      a.status === ModStatus.Installed &&
-      a.installedVpks &&
-      a.installedVpks.length > 0;
-    const bIsInstalled =
-      b.status === ModStatus.Installed &&
-      b.installedVpks &&
-      b.installedVpks.length > 0;
-
-    if (aIsInstalled && !bIsInstalled) return -1;
-    if (!aIsInstalled && bIsInstalled) return 1;
-
-    if (aIsInstalled && bIsInstalled) {
-      const aOrder = a.installOrder ?? 999;
-      const bOrder = b.installOrder ?? 999;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-    }
-
-    const dateA = a.downloadedAt ? new Date(a.downloadedAt).getTime() : 0;
-    const dateB = b.downloadedAt ? new Date(b.downloadedAt).getTime() : 0;
-    return dateB - dateA;
-  });
-
   const displayMods = useMemo(() => {
-    const baseMods = query.trim() ? results : sortedMods;
+    const baseMods = query.trim() ? results : mods;
     const predefinedCategorySet = new Set<string>(Object.values(ModCategory));
     let filteredMods = baseMods;
 
@@ -747,7 +703,7 @@ const MyMods = () => {
       );
     }
 
-    return filterModsByStatus(filteredMods);
+    return filterStableLibraryModsByStatus(filteredMods, activeTab);
   }, [
     activeTab,
     filterMode,
@@ -759,7 +715,7 @@ const MyMods = () => {
     results,
     selectedCategories,
     selectedHeroes,
-    sortedMods,
+    mods,
   ]);
 
   const totalPages = paginationEnabled


### PR DESCRIPTION
## Summary

Stops the My Mods page from regrouping library/search results by install status or load order before applying the selected tab filter. This keeps the caller-provided library/search ordering stable while still supporting All, Installed, and Downloaded tabs.

## Testing

- pnpm --filter @deadlock-mods/desktop test -- src/lib/mods/library-display.test.ts
- pnpm --filter @deadlock-mods/desktop check-types

## Stack

First PR in the replacement stack for #468.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Functional Impact

**Affected packages/apps:** `@deadlock-mods/desktop`

This PR stops the My Mods page from regrouping or re-sorting library/search results by install status or load order before applying the active tab filter. Caller-provided ordering (library or search result order) is preserved while still supporting the All, Installed (enabled), and Downloaded/disabled tabs.

## Changes

- New module: `apps/desktop/src/lib/mods/library-display.ts`
  - Exports `ModLibraryFilter = "all" | "enabled" | "disabled"`
  - Exports `filterStableLibraryModsByStatus(mods, filter)` which filters mods by status but preserves the input array's relative order

- Tests: `apps/desktop/src/lib/mods/library-display.test.ts`
  - Adds tests that validate order-preserving behavior across `"all"`, `"enabled"`, and `"disabled"` modes, including preserving caller-provided search result order

- Updated: `apps/desktop/src/pages/my-mods.tsx`
  - Uses raw `mods` as the base list (when search is empty) instead of `sortedMods`
  - Delegates status-tab filtering to `filterStableLibraryModsByStatus`
  - Adjusts memo dependencies accordingly

- Release tracking: `.changeset/stable-library-order.md`
  - Adds a patch changeset for `@deadlock-mods/desktop`

## Notes

- No changes to other packages (api, bot, www, docs, shared) and no cross-package dependency changes.
- No database migrations, Tauri plugin changes, or Rust FFI boundary changes.
- This PR is the first upstream-mergeable slice of a larger refactor originally staged in PR `#468`; the author has additional dependent slices in their fork.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deadlock-mod-manager/deadlock-mod-manager/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->