### PR TITLE
feat(desktop): resolve mod heroes consistently

### DIFF
--- a/.changeset/calm-foxes-open.md
+++ b/.changeset/calm-foxes-open.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix slow mod detail loads by showing cached mod data immediately

--- a/apps/desktop/src/components/dashboard/featured-mod-card.tsx
+++ b/apps/desktop/src/components/dashboard/featured-mod-card.tsx
@@ -8,6 +8,7 @@ import {
   HeartIcon,
   SparkleIcon,
 } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Markup } from "interweave";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -15,6 +16,7 @@ import NSFWBlur, { NSFWBadge } from "@/components/mod-browsing/nsfw-blur";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { shouldShowNsfwBadgeAlongsideBlurPreview } from "@/lib/nsfw-blur-display";
 import { getModCategoryDisplayName } from "@/lib/constants";
+import { prefetchModDetail } from "@/lib/mods/mod-detail-prefetch";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -31,6 +33,7 @@ const FeaturedModCardSkeleton = () => (
 export const FeaturedModCard = ({ mod, isLoading }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { shouldBlur, handleNSFWToggle, nsfwSettings } = useNSFWBlur(mod);
 
   if (isLoading || !mod) {
@@ -38,7 +41,10 @@ export const FeaturedModCard = ({ mod, isLoading }: Props) => {
   }
 
   const heroImage = mod.images[0];
-  const handleClick = () => navigate(`/mods/${mod.remoteId}`);
+  const handleClick = () => {
+    void prefetchModDetail(queryClient, mod.remoteId);
+    navigate(`/mods/${mod.remoteId}`);
+  };
 
   return (
     <div

--- a/apps/desktop/src/components/dashboard/trending-mod-card.tsx
+++ b/apps/desktop/src/components/dashboard/trending-mod-card.tsx
@@ -1,4 +1,5 @@
 import type { ModDto } from "@deadlock-mods/shared";
+import { useQueryClient } from "@tanstack/react-query";
 import { DownloadIcon } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -6,6 +7,7 @@ import NSFWBlur, { NSFWBadge } from "@/components/mod-browsing/nsfw-blur";
 import AudioPlayerPreview from "@/components/mod-management/audio-player-preview";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { shouldShowNsfwBadgeAlongsideBlurPreview } from "@/lib/nsfw-blur-display";
+import { prefetchModDetail } from "@/lib/mods/mod-detail-prefetch";
 
 type Props = {
   mod: ModDto;
@@ -14,10 +16,14 @@ type Props = {
 export const TrendingModCard = ({ mod }: Props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { shouldBlur, handleNSFWToggle, nsfwSettings } = useNSFWBlur(mod);
 
   const heroImage = mod.images[0];
-  const handleClick = () => navigate(`/mods/${mod.remoteId}`);
+  const handleClick = () => {
+    void prefetchModDetail(queryClient, mod.remoteId);
+    navigate(`/mods/${mod.remoteId}`);
+  };
 
   return (
     <div

--- a/apps/desktop/src/components/mod-browsing/hero-filter.tsx
+++ b/apps/desktop/src/components/mod-browsing/hero-filter.tsx
@@ -17,10 +17,13 @@ import {
 import { Check } from "@deadlock-mods/ui/icons";
 import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { resolveLocalModHero } from "@/lib/mods/hero-resolution";
 import { cn } from "@/lib/utils";
 
 type HeroFilterProps = {
-  mods: ModDto[];
+  mods: Array<
+    ModDto & { detectedHero?: string | null; heroOverride?: string | null }
+  >;
   selectedHeroes: string[];
   onHeroesChange: (heroes: string[]) => void;
 };
@@ -37,12 +40,15 @@ const HeroFilter = ({
     const heroes = Array.from(
       new Set(
         mods
-          .map((mod) => mod.hero)
+          .map((mod) => resolveLocalModHero(mod).hero)
           .filter((hero): hero is string => Boolean(hero)),
       ),
     ).sort((a, b) => a.localeCompare(b));
     // Add "None" option for mods without specific heroes
-    if (mods.some((mod) => !mod.hero) && !heroes.includes("None")) {
+    if (
+      mods.some((mod) => !resolveLocalModHero(mod).hero) &&
+      !heroes.includes("None")
+    ) {
       heroes.unshift("None");
     }
     return heroes;

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -33,6 +33,7 @@ import useInstallWithCollection from "@/hooks/use-install-with-collection";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
 import useUninstall from "@/hooks/use-uninstall";
 import logger from "@/lib/logger";
+import { resolveLocalModHero } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { type LocalMod, ModStatus } from "@/types/mods";
@@ -235,17 +236,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           break;
         case ModStatus.Downloaded:
         case ModStatus.FailedToInstall: {
-          const detectedHero = localMod.detectedHero;
-          if (detectedHero) {
+          const resolvedHero = resolveLocalModHero(localMod).hero;
+          if (resolvedHero) {
             const conflictingMod = localMods.find(
               (m) =>
                 m.remoteId !== localMod.remoteId &&
                 m.status === ModStatus.Installed &&
-                m.detectedHero === detectedHero,
+                resolveLocalModHero(m).hero === resolvedHero,
             );
             if (conflictingMod) {
               const resolution = await askHeroConflict(
-                detectedHero,
+                resolvedHero,
                 conflictingMod,
                 localMod,
               );

--- a/apps/desktop/src/components/mod-browsing/mod-card.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-card.tsx
@@ -2,6 +2,7 @@ import type { ModDto } from "@deadlock-mods/shared";
 import { Badge } from "@deadlock-mods/ui/components/badge";
 import { Card, CardHeader, CardTitle } from "@deadlock-mods/ui/components/card";
 import { CalendarIcon, DownloadIcon, HeartIcon } from "@deadlock-mods/ui/icons";
+import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,6 +17,7 @@ import { OutdatedModWarning } from "@/components/mod-management/outdated-mod-war
 import { useThemeOverride } from "@/components/providers/theme-overrides";
 import ModCardSkeleton from "@/components/skeletons/mod-card";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
+import { prefetchModDetail } from "@/lib/mods/mod-detail-prefetch";
 import { usePersistedStore } from "@/lib/store";
 import {
   cn,
@@ -42,11 +44,17 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
 
   const status = localMod?.status;
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { shouldBlur, handleNSFWToggle, nsfwSettings } = useNSFWBlur(mod);
 
   if (!mod) {
     return <ModCardSkeleton />;
   }
+
+  const openModDetail = () => {
+    void prefetchModDetail(queryClient, mod.remoteId);
+    navigate(`/mods/${mod.remoteId}`);
+  };
 
   const cardContent = (
     <Card
@@ -59,7 +67,7 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
           ? undefined
           : (e) => {
               e.stopPropagation();
-              navigate(`/mods/${mod.remoteId}`);
+              openModDetail();
             }
       }>
       <div className='relative'>

--- a/apps/desktop/src/components/mod-detail/hero-override-picker.tsx
+++ b/apps/desktop/src/components/mod-detail/hero-override-picker.tsx
@@ -1,0 +1,127 @@
+import { DeadlockHeroes } from "@deadlock-mods/shared";
+import { Button } from "@deadlock-mods/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@deadlock-mods/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deadlock-mods/ui/components/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deadlock-mods/ui/components/tooltip";
+import { Check, RotateCcw, Settings } from "@deadlock-mods/ui/icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { ResolvedModHero } from "@/lib/mods/hero-resolution";
+import { usePersistedStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
+
+const HERO_OVERRIDE_OPTIONS = Object.values(DeadlockHeroes).sort((a, b) =>
+  a.localeCompare(b),
+);
+const GENERAL_OTHER_HERO_LABEL = "General/Other";
+
+interface HeroOverridePickerProps {
+  remoteId: string;
+  resolvedHero: ResolvedModHero;
+}
+
+export const HeroOverridePicker = ({
+  remoteId,
+  resolvedHero,
+}: HeroOverridePickerProps) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const setHeroOverride = usePersistedStore((state) => state.setHeroOverride);
+  const selectedValue =
+    resolvedHero.hasOverride && resolvedHero.hero === null
+      ? null
+      : resolvedHero.hero;
+
+  const handleOverride = (heroOverride: string | null | undefined) => {
+    setHeroOverride(remoteId, heroOverride);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              aria-label={t("modDetail.changeHero", {
+                defaultValue: "Change hero",
+              })}
+              className='ml-auto h-7 w-7 shrink-0 opacity-80 group-hover:opacity-100'
+              size='icon'
+              variant='ghost'>
+              <Settings className='h-3.5 w-3.5' />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {t("modDetail.changeHero", { defaultValue: "Change hero" })}
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent align='start' className='w-[260px] p-0'>
+        <Command>
+          <CommandInput placeholder={t("filters.searchHeroes")} />
+          <CommandList>
+            <CommandEmpty>{t("filters.noHeroesFound")}</CommandEmpty>
+            <CommandGroup>
+              <CommandItem onSelect={() => handleOverride(undefined)}>
+                <RotateCcw className='mr-2 h-4 w-4 flex-shrink-0' />
+                <span>
+                  {t("modDetail.heroOverrideAutomatic", {
+                    defaultValue: "Use automatic",
+                  })}
+                </span>
+              </CommandItem>
+              <CommandItem onSelect={() => handleOverride(null)}>
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4 flex-shrink-0",
+                    resolvedHero.hasOverride && selectedValue === null
+                      ? "opacity-100"
+                      : "opacity-0",
+                  )}
+                />
+                <span>{GENERAL_OTHER_HERO_LABEL}</span>
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              {HERO_OVERRIDE_OPTIONS.map((heroName) => (
+                <CommandItem
+                  key={heroName}
+                  onSelect={() => handleOverride(heroName)}>
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4 flex-shrink-0",
+                      resolvedHero.hasOverride && selectedValue === heroName
+                        ? "opacity-100"
+                        : "opacity-0",
+                    )}
+                  />
+                  <span className='truncate'>{heroName}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export { GENERAL_OTHER_HERO_LABEL };

--- a/apps/desktop/src/components/mod-detail/hero-override-picker.tsx
+++ b/apps/desktop/src/components/mod-detail/hero-override-picker.tsx
@@ -29,7 +29,6 @@ import { cn } from "@/lib/utils";
 const HERO_OVERRIDE_OPTIONS = Object.values(DeadlockHeroes).sort((a, b) =>
   a.localeCompare(b),
 );
-const GENERAL_OTHER_HERO_LABEL = "General/Other";
 
 interface HeroOverridePickerProps {
   remoteId: string;
@@ -96,7 +95,11 @@ export const HeroOverridePicker = ({
                       : "opacity-0",
                   )}
                 />
-                <span>{GENERAL_OTHER_HERO_LABEL}</span>
+                <span>
+                  {t("modDetail.generalOther", {
+                    defaultValue: "General/Other",
+                  })}
+                </span>
               </CommandItem>
             </CommandGroup>
             <CommandSeparator />
@@ -123,5 +126,3 @@ export const HeroOverridePicker = ({
     </Popover>
   );
 };
-
-export { GENERAL_OTHER_HERO_LABEL };

--- a/apps/desktop/src/components/mod-detail/hero-source-badge.tsx
+++ b/apps/desktop/src/components/mod-detail/hero-source-badge.tsx
@@ -1,0 +1,24 @@
+import { useTranslation } from "react-i18next";
+import type { ResolvedHeroSource } from "@/lib/mods/hero-resolution";
+
+interface HeroSourceBadgeProps {
+  source: ResolvedHeroSource;
+}
+
+export const HeroSourceBadge = ({ source }: HeroSourceBadgeProps) => {
+  const { t } = useTranslation();
+
+  const labelBySource: Record<ResolvedHeroSource, string> = {
+    api: t("modDetail.heroSource.api", { defaultValue: "API" }),
+    manual: t("modDetail.heroSource.manual", { defaultValue: "Manual" }),
+    name: t("modDetail.heroSource.name", { defaultValue: "Name" }),
+    none: t("modDetail.heroSource.none", { defaultValue: "Unset" }),
+    vpk: t("modDetail.heroSource.vpk", { defaultValue: "VPK" }),
+  };
+
+  return (
+    <span className='shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] leading-none normal-case'>
+      {labelBySource[source]}
+    </span>
+  );
+};

--- a/apps/desktop/src/components/mod-detail/mod-info.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-info.tsx
@@ -35,10 +35,7 @@ import {
 } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import { DateDisplay } from "../date-display";
-import {
-  GENERAL_OTHER_HERO_LABEL,
-  HeroOverridePicker,
-} from "./hero-override-picker";
+import { HeroOverridePicker } from "./hero-override-picker";
 import { HeroSourceBadge } from "./hero-source-badge";
 
 interface ModInfoProps {
@@ -198,7 +195,9 @@ interface HeroDisplayProps {
 
 const HeroDisplay = ({ mod, resolvedHero, canOverride }: HeroDisplayProps) => {
   const { t } = useTranslation();
-  const name = resolvedHero.hero ?? GENERAL_OTHER_HERO_LABEL;
+  const name =
+    resolvedHero.hero ??
+    t("modDetail.generalOther", { defaultValue: "General/Other" });
   const { data: hero } = useHero(resolvedHero.hero ?? "");
   const imageSrc =
     hero?.images.icon_hero_card_webp ??

--- a/apps/desktop/src/components/mod-detail/mod-info.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-info.tsx
@@ -39,6 +39,7 @@ import {
   GENERAL_OTHER_HERO_LABEL,
   HeroOverridePicker,
 } from "./hero-override-picker";
+import { HeroSourceBadge } from "./hero-source-badge";
 
 interface ModInfoProps {
   mod: ModDto;
@@ -205,13 +206,6 @@ const HeroDisplay = ({ mod, resolvedHero, canOverride }: HeroDisplayProps) => {
     hero?.images.icon_image_small_webp ??
     hero?.images.icon_image_small;
   const initial = name.charAt(0).toUpperCase();
-  const sourceLabel = {
-    api: t("modDetail.heroSource.api", { defaultValue: "API" }),
-    manual: t("modDetail.heroSource.manual", { defaultValue: "Manual" }),
-    name: t("modDetail.heroSource.name", { defaultValue: "Name" }),
-    none: t("modDetail.heroSource.none", { defaultValue: "Unset" }),
-    vpk: t("modDetail.heroSource.vpk", { defaultValue: "VPK" }),
-  }[resolvedHero.source];
 
   return (
     <div className='group flex items-center gap-3 rounded-lg border border-border/50 bg-muted/30 px-3 py-2.5 transition-colors hover:bg-muted/60'>
@@ -222,9 +216,7 @@ const HeroDisplay = ({ mod, resolvedHero, canOverride }: HeroDisplayProps) => {
       <div className='flex min-w-0 flex-col'>
         <span className='flex items-center gap-1.5 text-muted-foreground text-xs uppercase tracking-wide'>
           {t("modDetail.detectedHero")}
-          <span className='shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] leading-none normal-case'>
-            {sourceLabel}
-          </span>
+          <HeroSourceBadge source={resolvedHero.source} />
         </span>
         <span className='truncate font-medium text-foreground text-sm'>
           {name}

--- a/apps/desktop/src/components/mod-detail/mod-info.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-info.tsx
@@ -29,8 +29,16 @@ import {
 import { useTranslation } from "react-i18next";
 import { useHero } from "@/hooks/use-hero";
 import { getModCategoryDisplayName } from "@/lib/constants";
+import {
+  type ResolvedModHero,
+  resolveModHero,
+} from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import { DateDisplay } from "../date-display";
+import {
+  GENERAL_OTHER_HERO_LABEL,
+  HeroOverridePicker,
+} from "./hero-override-picker";
 
 interface ModInfoProps {
   mod: ModDto;
@@ -40,22 +48,25 @@ interface ModInfoProps {
 }
 
 const formatNumber = (value: number) => new Intl.NumberFormat().format(value);
+const EMPTY_ARCHIVE_NAMES = new Set<string>();
 
 export const ModInfo = ({
   mod,
   hasHero = false,
-  activeArchiveNames = new Set<string>(),
+  activeArchiveNames = EMPTY_ARCHIVE_NAMES,
   totalDownloads = 0,
 }: ModInfoProps) => {
   const { t } = useTranslation();
   const showHeader = hasHero ? false : !mod.isAudio;
-  const localMods = usePersistedStore((state) => state.localMods);
-  const localMod = localMods.find((m) => m.remoteId === mod.remoteId);
+  const localMod = usePersistedStore((state) =>
+    state.localMods.find((m) => m.remoteId === mod.remoteId),
+  );
 
-  const heroLabel = localMod?.detectedHero ?? null;
+  const resolvedHero = resolveModHero(mod, localMod);
+  const showHeroStat = resolvedHero.hero !== null || localMod !== undefined;
   const hasTags = mod.tags && mod.tags.length > 0;
   const hasFileInfo = activeArchiveNames.size > 0 && totalDownloads > 1;
-  const statCount = (heroLabel ? 1 : 0) + 3 + (hasFileInfo ? 1 : 0);
+  const statCount = (showHeroStat ? 1 : 0) + 3 + (hasFileInfo ? 1 : 0);
   const gridCols =
     statCount <= 3
       ? "grid grid-cols-1 gap-3 sm:grid-cols-3"
@@ -77,7 +88,13 @@ export const ModInfo = ({
       <CardContent className={hasHero || mod.isAudio ? "" : "pt-6"}>
         <div className='space-y-5'>
           <div className={gridCols}>
-            {heroLabel && <HeroDisplay name={heroLabel} />}
+            {showHeroStat && (
+              <HeroDisplay
+                mod={mod}
+                resolvedHero={resolvedHero}
+                canOverride={localMod !== undefined}
+              />
+            )}
             <PrimaryStat
               icon={<User className='h-4 w-4' />}
               label={t("modDetail.authorLabel")}
@@ -173,18 +190,28 @@ export const ModInfo = ({
 };
 
 interface HeroDisplayProps {
-  name: string;
+  mod: ModDto;
+  resolvedHero: ResolvedModHero;
+  canOverride: boolean;
 }
 
-const HeroDisplay = ({ name }: HeroDisplayProps) => {
+const HeroDisplay = ({ mod, resolvedHero, canOverride }: HeroDisplayProps) => {
   const { t } = useTranslation();
-  const { data: hero } = useHero(name);
+  const name = resolvedHero.hero ?? GENERAL_OTHER_HERO_LABEL;
+  const { data: hero } = useHero(resolvedHero.hero ?? "");
   const imageSrc =
     hero?.images.icon_hero_card_webp ??
     hero?.images.icon_hero_card ??
     hero?.images.icon_image_small_webp ??
     hero?.images.icon_image_small;
   const initial = name.charAt(0).toUpperCase();
+  const sourceLabel = {
+    api: t("modDetail.heroSource.api", { defaultValue: "API" }),
+    manual: t("modDetail.heroSource.manual", { defaultValue: "Manual" }),
+    name: t("modDetail.heroSource.name", { defaultValue: "Name" }),
+    none: t("modDetail.heroSource.none", { defaultValue: "Unset" }),
+    vpk: t("modDetail.heroSource.vpk", { defaultValue: "VPK" }),
+  }[resolvedHero.source];
 
   return (
     <div className='group flex items-center gap-3 rounded-lg border border-border/50 bg-muted/30 px-3 py-2.5 transition-colors hover:bg-muted/60'>
@@ -193,13 +220,22 @@ const HeroDisplay = ({ name }: HeroDisplayProps) => {
         <AvatarFallback className='text-xs'>{initial}</AvatarFallback>
       </Avatar>
       <div className='flex min-w-0 flex-col'>
-        <span className='text-muted-foreground text-xs uppercase tracking-wide'>
+        <span className='flex items-center gap-1.5 text-muted-foreground text-xs uppercase tracking-wide'>
           {t("modDetail.detectedHero")}
+          <span className='shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] leading-none normal-case'>
+            {sourceLabel}
+          </span>
         </span>
         <span className='truncate font-medium text-foreground text-sm'>
           {name}
         </span>
       </div>
+      {canOverride && (
+        <HeroOverridePicker
+          remoteId={mod.remoteId}
+          resolvedHero={resolvedHero}
+        />
+      )}
     </div>
   );
 };

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -1,4 +1,5 @@
 import type { ModDto } from "@deadlock-mods/shared";
+import { resolveDetectedHeroLabel } from "@deadlock-mods/hero-parser";
 import type { z } from "zod";
 import { ModDownloadDtoSchema } from "@deadlock-mods/shared";
 import { toast } from "@deadlock-mods/ui/components/sonner";
@@ -61,7 +62,7 @@ export const useDownload = (
           .then((result) => {
             setDetectedHero(
               mod.remoteId,
-              result.hero ?? null,
+              resolveDetectedHeroLabel(result),
               result.usesCriticalPaths,
             );
           })

--- a/apps/desktop/src/hooks/use-hero-detection.ts
+++ b/apps/desktop/src/hooks/use-hero-detection.ts
@@ -1,4 +1,7 @@
-import type { HeroDetectionResult } from "@deadlock-mods/hero-parser";
+import {
+  type HeroDetectionResult,
+  resolveDetectedHeroLabel,
+} from "@deadlock-mods/hero-parser";
 import { useQuery } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef } from "react";
@@ -144,7 +147,7 @@ const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {
       for (const resp of responses) {
         setDetectedHero(
           resp.modId,
-          resp.result.hero ?? null,
+          resolveDetectedHeroLabel(resp.result),
           resp.result.usesCriticalPaths,
         );
       }
@@ -166,7 +169,7 @@ const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {
           });
           setDetectedHero(
             mod.remoteId,
-            result.hero ?? null,
+            resolveDetectedHeroLabel(result),
             result.usesCriticalPaths,
           );
         } catch {

--- a/apps/desktop/src/hooks/use-mod-downloads.ts
+++ b/apps/desktop/src/hooks/use-mod-downloads.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getModDownloads } from "@/lib/api-client";
+import { usePersistedStore } from "@/lib/store";
 import type { ModDownloadItem } from "@/types/mods";
 
 const EMPTY_DOWNLOADS: ModDownloadItem[] = [];
@@ -30,6 +31,14 @@ export const useModDownloads = ({
   isDownloadable = true,
   enabled = true,
 }: UseModDownloadsOptions) => {
+  const localDownloads = usePersistedStore((state) => {
+    if (!remoteId) {
+      return undefined;
+    }
+    const localMod = state.localMods.find((mod) => mod.remoteId === remoteId);
+    return localMod?.downloads;
+  });
+
   const query = useQuery({
     queryKey: ["mod-downloads", remoteId],
     queryFn: () => {
@@ -39,12 +48,18 @@ export const useModDownloads = ({
       return getModDownloads(remoteId);
     },
     enabled: enabled && !!remoteId && isDownloadable,
-    // Cache for 5 minutes to reduce unnecessary requests
     staleTime: 5 * 60 * 1000,
-    // Keep in cache for 10 minutes after component unmounts
     gcTime: 10 * 60 * 1000,
-    // Avoid noisy repeated requests for missing download metadata
     retry: false,
+    placeholderData: () => {
+      if (!localDownloads || localDownloads.length === 0) {
+        return undefined;
+      }
+      return {
+        downloads: localDownloads,
+        count: localDownloads.length,
+      };
+    },
     meta: {
       skipGlobalErrorHandler: true,
     },

--- a/apps/desktop/src/hooks/use-mod-processor.ts
+++ b/apps/desktop/src/hooks/use-mod-processor.ts
@@ -1,5 +1,8 @@
 import type { ModDto } from "@deadlock-mods/shared";
-import type { HeroDetectionResult } from "@deadlock-mods/hero-parser";
+import {
+  type HeroDetectionResult,
+  resolveDetectedHeroLabel,
+} from "@deadlock-mods/hero-parser";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { invoke } from "@tauri-apps/api/core";
 import { appLocalDataDir, join } from "@tauri-apps/api/path";
@@ -311,7 +314,11 @@ export const useModProcessor = () => {
 
     invoke<HeroDetectionResult>("detect_mod_hero", { modId })
       .then((result) =>
-        setDetectedHero(modId, result.hero ?? null, result.usesCriticalPaths),
+        setDetectedHero(
+          modId,
+          resolveDetectedHeroLabel(result),
+          result.usesCriticalPaths,
+        ),
       )
       .catch(() => setDetectedHero(modId, null));
 
@@ -416,7 +423,11 @@ export const useModProcessor = () => {
 
     invoke<HeroDetectionResult>("detect_mod_hero", { modId })
       .then((result) =>
-        setDetectedHero(modId, result.hero ?? null, result.usesCriticalPaths),
+        setDetectedHero(
+          modId,
+          resolveDetectedHeroLabel(result),
+          result.usesCriticalPaths,
+        ),
       )
       .catch(() => setDetectedHero(modId, null));
 

--- a/apps/desktop/src/hooks/use-mod.ts
+++ b/apps/desktop/src/hooks/use-mod.ts
@@ -1,5 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getMod } from "@/lib/api-client";
+import {
+  findModInModsListCache,
+  modDetailQueryKey,
+} from "@/lib/mods/mod-query-cache";
+import { STALE_TIME_API } from "@/lib/query-constants";
 import { usePersistedStore } from "@/lib/store";
 
 interface UseModOptions {
@@ -12,13 +17,14 @@ export const useMod = (
   options: UseModOptions = {},
 ) => {
   const { enabled = true, retry = 1 } = options;
+  const queryClient = useQueryClient();
   const isLocal = modId?.includes("local") ?? false;
   const localMod = usePersistedStore((state) =>
-    isLocal ? state.localMods.find((m) => m.remoteId === modId) : undefined,
+    modId ? state.localMods.find((m) => m.remoteId === modId) : undefined,
   );
 
   const query = useQuery({
-    queryKey: ["mod", modId],
+    queryKey: modDetailQueryKey(modId ?? ""),
     queryFn: () => {
       if (!modId) {
         throw new Error("Mod ID is required");
@@ -27,6 +33,15 @@ export const useMod = (
     },
     enabled: !!modId && !isLocal && enabled,
     retry,
+    staleTime: STALE_TIME_API,
+    placeholderData: () => {
+      if (!modId || isLocal) {
+        return undefined;
+      }
+      return (
+        findModInModsListCache(queryClient, modId) ?? localMod ?? undefined
+      );
+    },
     throwOnError: false,
   });
 
@@ -37,11 +52,13 @@ export const useMod = (
       mod: localMod,
       isLoading: false,
       error: null,
+      isPlaceholderData: false,
     };
   }
 
   return {
     ...query,
     mod: query.data,
+    isPlaceholderData: query.isPlaceholderData,
   };
 };

--- a/apps/desktop/src/lib/mods/hero-resolution.test.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { LocalMod } from "@/types/mods";
+import {
+  matchesHeroFilter,
+  resolveLocalModHero,
+  resolveModHero,
+} from "./hero-resolution";
+
+const mod = (values: {
+  name: string;
+  hero?: string | null;
+  detectedHero?: string | null;
+  heroOverride?: string | null;
+}) =>
+  ({
+    name: values.name,
+    hero: values.hero ?? null,
+    detectedHero: values.detectedHero,
+    heroOverride: values.heroOverride,
+  }) as LocalMod;
+
+describe("resolveModHero", () => {
+  it("prefers manual overrides over all automatic sources", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+      heroOverride: "Victor",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Victor",
+      source: "manual",
+      hasOverride: true,
+    });
+  });
+
+  it("prefers API heroes over stale local VPK detection", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Seven",
+      source: "api",
+    });
+  });
+
+  it("uses name aliases before VPK detection when the API is missing a hero", () => {
+    const localMod = mod({
+      name: "Toon Viktor",
+      hero: null,
+      detectedHero: "Infernus",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Victor",
+      source: "name",
+    });
+  });
+
+  it("can manually mark a local mod as general or other", () => {
+    const localMod = mod({
+      name: "Mystery Pack",
+      hero: "Seven",
+      heroOverride: null,
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: null,
+      source: "manual",
+      hasOverride: true,
+    });
+  });
+});
+
+describe("resolveLocalModHero", () => {
+  it("matches resolveModHero for local mods", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+    });
+
+    expect(resolveLocalModHero(localMod)).toEqual(
+      resolveModHero(localMod, localMod),
+    );
+  });
+});
+
+describe("matchesHeroFilter", () => {
+  it("matches general or other mods when None is selected", () => {
+    expect(matchesHeroFilter(null, ["None"])).toBe(true);
+    expect(matchesHeroFilter("Seven", ["None", "Seven"])).toBe(true);
+    expect(matchesHeroFilter("Victor", ["None"])).toBe(false);
+  });
+
+  it("matches specific heroes when None is not selected", () => {
+    expect(matchesHeroFilter("Seven", ["Seven"])).toBe(true);
+    expect(matchesHeroFilter(null, ["Seven"])).toBe(false);
+    expect(matchesHeroFilter("Victor", ["Seven"])).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/mods/hero-resolution.test.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.test.ts
@@ -1,3 +1,4 @@
+import type { ModDto } from "@deadlock-mods/shared";
 import { describe, expect, it } from "vitest";
 import type { LocalMod } from "@/types/mods";
 import {
@@ -6,18 +7,20 @@ import {
   resolveModHero,
 } from "./hero-resolution";
 
+type HeroTestMod = Pick<ModDto, "hero" | "name"> &
+  Pick<LocalMod, "detectedHero" | "heroOverride">;
+
 const mod = (values: {
   name: string;
   hero?: string | null;
   detectedHero?: string | null;
   heroOverride?: string | null;
-}) =>
-  ({
-    name: values.name,
-    hero: values.hero ?? null,
-    detectedHero: values.detectedHero,
-    heroOverride: values.heroOverride,
-  }) as LocalMod;
+}): HeroTestMod => ({
+  name: values.name,
+  hero: values.hero ?? null,
+  detectedHero: values.detectedHero,
+  heroOverride: values.heroOverride,
+});
 
 describe("resolveModHero", () => {
   it("prefers manual overrides over all automatic sources", () => {
@@ -58,6 +61,20 @@ describe("resolveModHero", () => {
     expect(resolveModHero(localMod, localMod)).toMatchObject({
       hero: "Victor",
       source: "name",
+    });
+  });
+
+  it("falls back to VPK detection when override, API hero, and name alias are unavailable", () => {
+    const localMod = mod({
+      name: "Unmapped Cosmetic",
+      hero: null,
+      detectedHero: "Infernus",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Infernus",
+      source: "vpk",
+      hasOverride: false,
     });
   });
 

--- a/apps/desktop/src/lib/mods/hero-resolution.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.ts
@@ -1,0 +1,79 @@
+import type { ModDto } from "@deadlock-mods/shared";
+import { guessHero, normalizeHero } from "@deadlock-mods/shared";
+import type { LocalMod } from "@/types/mods";
+
+export type ResolvedHeroSource = "manual" | "api" | "name" | "vpk" | "none";
+
+export type ResolvedModHero = {
+  hero: string | null;
+  source: ResolvedHeroSource;
+  hasOverride: boolean;
+};
+
+type HeroResolvableMod = Pick<ModDto, "hero" | "name">;
+type HeroResolvableLocalMod = Pick<LocalMod, "detectedHero" | "heroOverride">;
+type LocalHeroMod = HeroResolvableMod & HeroResolvableLocalMod;
+
+export function resolveModHero(
+  mod: HeroResolvableMod,
+  localMod?: HeroResolvableLocalMod | null,
+): ResolvedModHero {
+  if (localMod && "heroOverride" in localMod) {
+    const { heroOverride } = localMod;
+    if (heroOverride !== undefined) {
+      // Preserve unknown manual overrides so imported or future hero values remain visible.
+      return {
+        hero: normalizeHero(heroOverride) ?? heroOverride,
+        source: "manual",
+        hasOverride: true,
+      };
+    }
+  }
+
+  const apiHero = normalizeHero(mod.hero);
+  if (apiHero) {
+    return {
+      hero: apiHero,
+      source: "api",
+      hasOverride: false,
+    };
+  }
+
+  const nameHero = guessHero(mod.name);
+  if (nameHero) {
+    return {
+      hero: nameHero,
+      source: "name",
+      hasOverride: false,
+    };
+  }
+
+  const vpkHero = normalizeHero(localMod?.detectedHero);
+  if (vpkHero) {
+    return {
+      hero: vpkHero,
+      source: "vpk",
+      hasOverride: false,
+    };
+  }
+
+  return {
+    hero: null,
+    source: "none",
+    hasOverride: false,
+  };
+}
+
+export function resolveLocalModHero(mod: LocalHeroMod): ResolvedModHero {
+  return resolveModHero(mod, mod);
+}
+
+export function matchesHeroFilter(
+  resolvedHero: string | null,
+  selectedHeroes: string[],
+): boolean {
+  if (selectedHeroes.includes("None")) {
+    return !resolvedHero || selectedHeroes.includes(resolvedHero);
+  }
+  return !!resolvedHero && selectedHeroes.includes(resolvedHero);
+}

--- a/apps/desktop/src/lib/mods/mod-detail-prefetch.ts
+++ b/apps/desktop/src/lib/mods/mod-detail-prefetch.ts
@@ -1,0 +1,15 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { getMod } from "@/lib/api-client";
+import { modDetailQueryKey } from "@/lib/mods/mod-query-cache";
+import { STALE_TIME_API } from "@/lib/query-constants";
+
+export const prefetchModDetail = (
+  queryClient: QueryClient,
+  remoteId: string,
+): Promise<void> => {
+  return queryClient.prefetchQuery({
+    queryKey: modDetailQueryKey(remoteId),
+    queryFn: () => getMod(remoteId),
+    staleTime: STALE_TIME_API,
+  });
+};

--- a/apps/desktop/src/lib/mods/mod-query-cache.test.ts
+++ b/apps/desktop/src/lib/mods/mod-query-cache.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import type { ModDto } from "@deadlock-mods/shared";
+import { ModDtoSchema } from "@deadlock-mods/shared";
+import { QueryClient } from "@tanstack/react-query";
+import { findModInModsListCache, MODS_LIST_QUERY_KEY } from "./mod-query-cache";
+
+function makeMod(remoteId: string): ModDto {
+  const remoteUpdatedAt = new Date("2026-01-23T00:00:00.000Z");
+  return ModDtoSchema.parse({
+    id: remoteId,
+    remoteId,
+    name: `Mod ${remoteId}`,
+    description: null,
+    remoteUrl: "https://example.com",
+    category: "test",
+    likes: 0,
+    author: "author",
+    downloadable: true,
+    remoteAddedAt: remoteUpdatedAt,
+    remoteUpdatedAt,
+    tags: [],
+    images: [],
+    hero: null,
+    isAudio: false,
+    isMap: false,
+    audioUrl: null,
+    downloadCount: 0,
+    isNSFW: false,
+    filesUpdatedAt: null,
+    metadata: null,
+    createdAt: null,
+    updatedAt: null,
+  });
+}
+
+describe("findModInModsListCache", () => {
+  it("returns undefined when mods list is not cached", () => {
+    const queryClient = new QueryClient();
+    expect(findModInModsListCache(queryClient, "123")).toBeUndefined();
+  });
+
+  it("returns undefined when remote id is not in cached list", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(MODS_LIST_QUERY_KEY, [makeMod("111")]);
+    expect(findModInModsListCache(queryClient, "222")).toBeUndefined();
+  });
+
+  it("returns the matching mod from cached list", () => {
+    const queryClient = new QueryClient();
+    const target = makeMod("222");
+    queryClient.setQueryData(MODS_LIST_QUERY_KEY, [makeMod("111"), target]);
+    expect(findModInModsListCache(queryClient, "222")).toEqual(target);
+  });
+});

--- a/apps/desktop/src/lib/mods/mod-query-cache.ts
+++ b/apps/desktop/src/lib/mods/mod-query-cache.ts
@@ -1,0 +1,15 @@
+import type { ModDto } from "@deadlock-mods/shared";
+import type { QueryClient } from "@tanstack/react-query";
+
+export const MODS_LIST_QUERY_KEY = ["mods"] as const;
+
+export const modDetailQueryKey = (remoteId: string) =>
+  ["mod", remoteId] as const;
+
+export const findModInModsListCache = (
+  queryClient: QueryClient,
+  remoteId: string,
+): ModDto | undefined => {
+  const mods = queryClient.getQueryData<ModDto[]>(MODS_LIST_QUERY_KEY);
+  return mods?.find((mod) => mod.remoteId === remoteId);
+};

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -471,10 +471,9 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         mod.installedVpks.length > 0,
     );
 
-    const modsWithOrder = installedMods.map((mod, index) => ({
-      ...mod,
-      installOrder: mod.installOrder ?? index,
-    }));
+    const modsWithOrder = installedMods.map((mod, index) =>
+      Object.assign({}, mod, { installOrder: mod.installOrder ?? index }),
+    );
 
     return modsWithOrder.sort((a, b) => {
       if (a.installOrder !== b.installOrder) {
@@ -561,7 +560,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     usesCriticalPaths?: boolean,
   ) =>
     set((state) => {
-      const updateMods = (mods: typeof state.localMods) =>
+      const updateMods = (mods: LocalMod[]) =>
         mods.map((mod) =>
           mod.remoteId === remoteId
             ? {
@@ -577,7 +576,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   setHeroOverride: (remoteId, heroOverride) =>
     set((state) => {
-      const updateMods = (mods: typeof state.localMods) =>
+      const updateMods = (mods: LocalMod[]) =>
         mods.map((mod) => {
           if (mod.remoteId !== remoteId) return mod;
 
@@ -597,7 +596,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   clearAllDetectedHeroes: () =>
     set((state) => {
-      const updateMods = (mods: typeof state.localMods) =>
+      // oxlint-disable-next-line unicorn/consistent-function-scoping
+      const updateMods = (mods: LocalMod[]) =>
         mods.map((mod) => ({
           ...mod,
           detectedHero: undefined,

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -12,46 +12,10 @@ import {
   type Progress,
 } from "@/types/mods";
 import type { State } from "..";
-
-type ModSliceState = Pick<State, "localMods" | "profiles" | "activeProfileId">;
-
-function applyToModsAndActiveProfile(
-  state: ModSliceState,
-  updateMods: (mods: LocalMod[]) => LocalMod[],
-) {
-  const activeProfile = state.profiles[state.activeProfileId];
-
-  return {
-    localMods: updateMods(state.localMods),
-    profiles: activeProfile
-      ? {
-          ...state.profiles,
-          [state.activeProfileId]: {
-            ...activeProfile,
-            mods: updateMods(activeProfile.mods),
-          },
-        }
-      : state.profiles,
-  };
-}
-
-function applyToModsAndAllProfiles(
-  state: ModSliceState,
-  updateMods: (mods: LocalMod[]) => LocalMod[],
-) {
-  return {
-    localMods: updateMods(state.localMods),
-    profiles: Object.fromEntries(
-      Object.entries(state.profiles).map(([profileId, profile]) => [
-        profileId,
-        {
-          ...profile,
-          mods: updateMods(profile.mods),
-        },
-      ]),
-    ),
-  };
-}
+import {
+  applyToModsAndActiveProfile,
+  applyToModsAndAllProfiles,
+} from "../utils/mod-slice";
 
 export type ModProgress = {
   percentage: number;

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -13,6 +13,46 @@ import {
 } from "@/types/mods";
 import type { State } from "..";
 
+type ModSliceState = Pick<State, "localMods" | "profiles" | "activeProfileId">;
+
+function applyToModsAndActiveProfile(
+  state: ModSliceState,
+  updateMods: (mods: LocalMod[]) => LocalMod[],
+) {
+  const activeProfile = state.profiles[state.activeProfileId];
+
+  return {
+    localMods: updateMods(state.localMods),
+    profiles: activeProfile
+      ? {
+          ...state.profiles,
+          [state.activeProfileId]: {
+            ...activeProfile,
+            mods: updateMods(activeProfile.mods),
+          },
+        }
+      : state.profiles,
+  };
+}
+
+function applyToModsAndAllProfiles(
+  state: ModSliceState,
+  updateMods: (mods: LocalMod[]) => LocalMod[],
+) {
+  return {
+    localMods: updateMods(state.localMods),
+    profiles: Object.fromEntries(
+      Object.entries(state.profiles).map(([profileId, profile]) => [
+        profileId,
+        {
+          ...profile,
+          mods: updateMods(profile.mods),
+        },
+      ]),
+    ),
+  };
+}
+
 export type ModProgress = {
   percentage: number;
   speed?: number;
@@ -72,6 +112,10 @@ export type ModsState = {
     remoteId: string,
     hero: string | null,
     usesCriticalPaths?: boolean,
+  ) => void;
+  setHeroOverride: (
+    remoteId: string,
+    heroOverride: string | null | undefined,
   ) => void;
   clearAllDetectedHeroes: () => void;
   setHeroDetection: (progress: Partial<HeroDetectionProgress>) => void;
@@ -413,20 +457,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
           }
           return mod;
         });
-      const activeProfile = state.profiles[state.activeProfileId];
 
-      return {
-        localMods: updateMods(state.localMods),
-        profiles: activeProfile
-          ? {
-              ...state.profiles,
-              [state.activeProfileId]: {
-                ...activeProfile,
-                mods: updateMods(activeProfile.mods),
-              },
-            }
-          : state.profiles,
-      };
+      return applyToModsAndActiveProfile(state, updateMods);
     }),
 
   getOrderedMods: () => {
@@ -528,25 +560,51 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     hero: string | null,
     usesCriticalPaths?: boolean,
   ) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) =>
-        mod.remoteId === remoteId
-          ? {
-              ...mod,
-              detectedHero: hero,
-              usesCriticalPaths: usesCriticalPaths ?? mod.usesCriticalPaths,
-            }
-          : mod,
-      ),
-    })),
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) =>
+          mod.remoteId === remoteId
+            ? {
+                ...mod,
+                detectedHero: hero,
+                usesCriticalPaths: usesCriticalPaths ?? mod.usesCriticalPaths,
+              }
+            : mod,
+        );
+
+      return applyToModsAndAllProfiles(state, updateMods);
+    }),
+
+  setHeroOverride: (remoteId, heroOverride) =>
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => {
+          if (mod.remoteId !== remoteId) return mod;
+
+          if (heroOverride === undefined) {
+            const { heroOverride: _heroOverride, ...nextMod } = mod;
+            return nextMod;
+          }
+
+          return {
+            ...mod,
+            heroOverride,
+          };
+        });
+
+      return applyToModsAndAllProfiles(state, updateMods);
+    }),
 
   clearAllDetectedHeroes: () =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        detectedHero: undefined,
-      })),
-    })),
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => ({
+          ...mod,
+          detectedHero: undefined,
+        }));
+
+      return applyToModsAndAllProfiles(state, updateMods);
+    }),
 
   setHeroDetection: (progress) =>
     set((state) => ({

--- a/apps/desktop/src/lib/store/utils/mod-slice.ts
+++ b/apps/desktop/src/lib/store/utils/mod-slice.ts
@@ -1,0 +1,45 @@
+import type { LocalMod } from "@/types/mods";
+import type { State } from "..";
+
+export type ModSliceState = Pick<
+  State,
+  "localMods" | "profiles" | "activeProfileId"
+>;
+
+export const applyToModsAndActiveProfile = (
+  state: ModSliceState,
+  updateMods: (mods: LocalMod[]) => LocalMod[],
+) => {
+  const activeProfile = state.profiles[state.activeProfileId];
+
+  return {
+    localMods: updateMods(state.localMods),
+    profiles: activeProfile
+      ? {
+          ...state.profiles,
+          [state.activeProfileId]: {
+            ...activeProfile,
+            mods: updateMods(activeProfile.mods),
+          },
+        }
+      : state.profiles,
+  };
+};
+
+export const applyToModsAndAllProfiles = (
+  state: ModSliceState,
+  updateMods: (mods: LocalMod[]) => LocalMod[],
+) => {
+  return {
+    localMods: updateMods(state.localMods),
+    profiles: Object.fromEntries(
+      Object.entries(state.profiles).map(([profileId, profile]) => [
+        profileId,
+        {
+          ...profile,
+          mods: updateMods(profile.mods),
+        },
+      ]),
+    ),
+  };
+};

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1816,6 +1816,15 @@
     "likesLabel": "Likes",
     "modStatusLabel": "Status",
     "detectedHero": "Hero",
+    "changeHero": "Change hero",
+    "heroOverrideAutomatic": "Use automatic",
+    "heroSource": {
+      "manual": "Manual",
+      "api": "API",
+      "name": "Name",
+      "vpk": "VPK",
+      "none": "Unset"
+    },
     "viewOriginalPost": "View Post on GameBanana",
     "updateMod": "Update Mod",
     "forceUpdate": "Force Update",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1818,6 +1818,7 @@
     "detectedHero": "Hero",
     "changeHero": "Change hero",
     "heroOverrideAutomatic": "Use automatic",
+    "generalOther": "General/Other",
     "heroSource": {
       "manual": "Manual",
       "api": "API",

--- a/apps/desktop/src/pages/mods.tsx
+++ b/apps/desktop/src/pages/mods.tsx
@@ -39,6 +39,7 @@ import { useScrollPosition } from "@/hooks/use-scroll-position";
 import { useSearch } from "@/hooks/use-search";
 import { getMods } from "@/lib/api-client";
 import { ModCategory, TimePeriod } from "@/lib/constants";
+import { matchesHeroFilter, resolveModHero } from "@/lib/mods/hero-resolution";
 import { STALE_TIME_API } from "@/lib/query-constants";
 import { usePersistedStore } from "@/lib/store";
 import { getTimePeriodCutoff } from "@/lib/utils";
@@ -178,6 +179,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     showFavoritesOnly = false,
   } = modsFilters;
   const favorites = usePersistedStore((state) => state.favorites);
+  const localMods = usePersistedStore((state) => state.localMods);
   const effectiveMapQuickFilter: MapQuickFilter = mapsOnly
     ? "only"
     : isCustomMapsEnabled
@@ -209,81 +211,63 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     data: deferredData,
     keys: SEARCH_KEYS,
   });
+  const localModsByRemoteId = useMemo(
+    () => new Map(localMods.map((mod) => [mod.remoteId, mod])),
+    [localMods],
+  );
   const filteredResults = useMemo(() => {
-    let filtered = results;
+    const predefinedCategorySet =
+      selectedCategories.length > 0
+        ? new Set<string>(Object.values(ModCategory))
+        : null;
+    const cutoff = getTimePeriodCutoff(timePeriod);
+    const cutoffTime = cutoff?.getTime();
+    const favSet =
+      showFavoritesOnly && favorites.length > 0 ? new Set(favorites) : null;
+    const shouldHideNSFW = nsfwSettings.hideNSFW || hideNSFW;
 
-    // Filter by categories
-    const predefinedCategorySet = new Set<string>(Object.values(ModCategory));
-
-    if (selectedCategories.length > 0) {
-      filtered = filtered.filter((mod) => {
+    return results.filter((mod) => {
+      if (selectedCategories.length > 0 && predefinedCategorySet) {
         let matchesCategory = selectedCategories.includes(mod.category);
-
         if (
           !matchesCategory &&
           selectedCategories.includes(ModCategory.OTHER_MISC)
         ) {
           matchesCategory = !predefinedCategorySet.has(mod.category);
         }
+        if (filterMode === "include" ? !matchesCategory : matchesCategory)
+          return false;
+      }
 
-        return filterMode === "include" ? matchesCategory : !matchesCategory;
-      });
-    }
+      if (selectedHeroes.length > 0) {
+        const resolvedHero = resolveModHero(
+          mod,
+          localModsByRemoteId.get(mod.remoteId),
+        ).hero;
+        const matchesHero = matchesHeroFilter(resolvedHero, selectedHeroes);
+        if (filterMode === "include" ? !matchesHero : matchesHero) return false;
+      }
 
-    if (selectedHeroes.length > 0) {
-      filtered = filtered.filter((mod) => {
-        let matchesHero = false;
+      if (shouldHideNSFW && mod.isNSFW) return false;
 
-        if (selectedHeroes.includes("None")) {
-          matchesHero =
-            !mod.hero ||
-            (mod.hero !== null && selectedHeroes.includes(mod.hero));
-        } else {
-          matchesHero = mod.hero !== null && selectedHeroes.includes(mod.hero);
-        }
+      if (audioQuickFilter === "only" && !mod.isAudio) return false;
+      if (audioQuickFilter === "exclude" && mod.isAudio) return false;
 
-        return filterMode === "include" ? matchesHero : !matchesHero;
-      });
-    }
+      if (effectiveMapQuickFilter === "only" && !mod.isMap) return false;
+      if (effectiveMapQuickFilter === "exclude" && mod.isMap) return false;
 
-    if (nsfwSettings.hideNSFW || hideNSFW) {
-      filtered = filtered.filter((mod) => !mod.isNSFW);
-    }
+      if (hideOutdated && (mod.isObsolete || isModOutdated(mod))) return false;
 
-    if (audioQuickFilter === "only") {
-      filtered = filtered.filter((mod) => mod.isAudio);
-    } else if (audioQuickFilter === "exclude") {
-      filtered = filtered.filter((mod) => !mod.isAudio);
-    }
+      if (cutoffTime && new Date(mod.remoteUpdatedAt).getTime() < cutoffTime)
+        return false;
 
-    if (effectiveMapQuickFilter === "only") {
-      filtered = filtered.filter((mod) => mod.isMap);
-    } else if (effectiveMapQuickFilter === "exclude") {
-      filtered = filtered.filter((mod) => !mod.isMap);
-    }
+      if (favSet && !favSet.has(mod.remoteId)) return false;
 
-    if (hideOutdated) {
-      filtered = filtered.filter(
-        (mod) => !mod.isObsolete && !isModOutdated(mod),
-      );
-    }
-
-    const cutoff = getTimePeriodCutoff(timePeriod);
-    if (cutoff) {
-      const cutoffTime = cutoff.getTime();
-      filtered = filtered.filter(
-        (mod) => new Date(mod.remoteUpdatedAt).getTime() >= cutoffTime,
-      );
-    }
-
-    if (showFavoritesOnly && favorites.length > 0) {
-      const favSet = new Set(favorites);
-      filtered = filtered.filter((mod) => favSet.has(mod.remoteId));
-    }
-
-    return filtered;
+      return true;
+    });
   }, [
     results,
+    localModsByRemoteId,
     selectedCategories,
     selectedHeroes,
     filterMode,

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -93,6 +93,10 @@ import {
   filterLibraryModsByStatus,
   ModFilter,
 } from "@/lib/mods/library-display";
+import {
+  matchesHeroFilter,
+  resolveLocalModHero,
+} from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -631,60 +635,43 @@ const MyMods = () => {
 
   const displayMods = useMemo(() => {
     const baseMods = query.trim() ? results : mods;
-    const predefinedCategorySet = new Set<string>(Object.values(ModCategory));
-    let filteredMods = baseMods;
+    const predefinedCategorySet =
+      selectedCategories.length > 0
+        ? new Set<string>(Object.values(ModCategory))
+        : null;
 
-    if (selectedCategories.length > 0) {
-      filteredMods = filteredMods.filter((mod) => {
+    const filteredMods = baseMods.filter((mod) => {
+      if (selectedCategories.length > 0 && predefinedCategorySet) {
         const category = mod.category ?? "";
         let matchesCategory = selectedCategories.includes(category);
-
         if (
           !matchesCategory &&
           selectedCategories.includes(ModCategory.OTHER_MISC)
         ) {
           matchesCategory = !predefinedCategorySet.has(category);
         }
+        if (filterMode === "include" ? !matchesCategory : matchesCategory)
+          return false;
+      }
 
-        return filterMode === "include" ? matchesCategory : !matchesCategory;
-      });
-    }
+      if (selectedHeroes.length > 0) {
+        const resolvedHero = resolveLocalModHero(mod).hero;
+        const matchesHero = matchesHeroFilter(resolvedHero, selectedHeroes);
+        if (filterMode === "include" ? !matchesHero : matchesHero) return false;
+      }
 
-    if (selectedHeroes.length > 0) {
-      filteredMods = filteredMods.filter((mod) => {
-        let matchesHero = false;
+      if (hideNSFW && mod.isNSFW) return false;
 
-        if (selectedHeroes.includes("None")) {
-          matchesHero = !mod.hero || selectedHeroes.includes(mod.hero);
-        } else {
-          matchesHero = mod.hero !== null && selectedHeroes.includes(mod.hero);
-        }
+      if (audioQuickFilter === "only" && !mod.isAudio) return false;
+      if (audioQuickFilter === "exclude" && mod.isAudio) return false;
 
-        return filterMode === "include" ? matchesHero : !matchesHero;
-      });
-    }
+      if (effectiveMapQuickFilter === "only" && !mod.isMap) return false;
+      if (effectiveMapQuickFilter === "exclude" && mod.isMap) return false;
 
-    if (hideNSFW) {
-      filteredMods = filteredMods.filter((mod) => !mod.isNSFW);
-    }
+      if (hideOutdated && (mod.isObsolete || isModOutdated(mod))) return false;
 
-    if (audioQuickFilter === "only") {
-      filteredMods = filteredMods.filter((mod) => mod.isAudio);
-    } else if (audioQuickFilter === "exclude") {
-      filteredMods = filteredMods.filter((mod) => !mod.isAudio);
-    }
-
-    if (effectiveMapQuickFilter === "only") {
-      filteredMods = filteredMods.filter((mod) => mod.isMap);
-    } else if (effectiveMapQuickFilter === "exclude") {
-      filteredMods = filteredMods.filter((mod) => !mod.isMap);
-    }
-
-    if (hideOutdated) {
-      filteredMods = filteredMods.filter(
-        (mod) => !mod.isObsolete && !isModOutdated(mod),
-      );
-    }
+      return true;
+    });
 
     return filterLibraryModsByStatus(filteredMods, activeTab);
   }, [

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -38,6 +38,7 @@ export interface LocalMod extends ModDto {
   installedFileTree?: ModFileTree;
   installOrder?: number;
   detectedHero?: string | null;
+  heroOverride?: string | null;
   usesCriticalPaths?: boolean;
 }
 

--- a/packages/hero-parser/src/detect-hero.ts
+++ b/packages/hero-parser/src/detect-hero.ts
@@ -25,6 +25,12 @@ function findCriticalPaths(paths: string[]): string[] {
   return found;
 }
 
+export function resolveDetectedHeroLabel(
+  result: HeroDetectionResult,
+): string | null {
+  return result.heroDisplay ?? result.hero ?? null;
+}
+
 export function detectHero(entryPaths: string[]): HeroDetectionResult {
   const heroCounts = new Map<string, number>();
   const internalNames: string[] = [];

--- a/packages/hero-parser/src/index.ts
+++ b/packages/hero-parser/src/index.ts
@@ -1,3 +1,3 @@
-export { detectHero } from "./detect-hero";
+export { detectHero, resolveDetectedHeroLabel } from "./detect-hero";
 export type { HeroDetectionResult } from "./detect-hero";
 export { extractInternalName, lookupHero } from "./mapping";


### PR DESCRIPTION
## Summary
- add desktop \esolveModHero\ with tests for API, name, VPK, and manual overrides
- use resolved heroes in browsing filters, My Mods filters, conflict detection, downloads, and hero detection sync
- add Mod Info hero override controls and include CodeRabbit's manual override preservation note/filter simplification

## Stack
Base: \codex/gamebanana-hero-category-resolution\

Depends on:
- merged #470
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/483
- Next: \codex/vpk-repair-metadata-foundation\

## Tests
- \pnpm --filter @deadlock-mods/desktop test -- src/lib/mods/hero-resolution.test.ts\
- \pnpm --filter @deadlock-mods/desktop check-types\

Recreated from https://github.com/oldreceipt/deadlock-mod-manager/pull/2
Original author: @oldreceipt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR implements consistent hero resolution across the desktop app by establishing a prioritized resolution strategy and integrating it throughout the mod management UI and filtering logic. The changes affect the **`@deadlock-mods/desktop`** app and add a shared helper to the **`@deadlock-mods/hero-parser`** package.

## Affected Packages
- **`@deadlock-mods/desktop`** (primary)
- **`@deadlock-mods/hero-parser`** (new export)

## Functional Changes

### Core Hero Resolution Logic (`hero-resolution.ts`)
Added new utilities that establish a consistent priority order for determining a mod's effective hero:
1. Manual override (if set via `heroOverride`)
2. API-provided hero
3. Name-based hero guessing
4. Detected hero (from VPK analysis)
5. Null (no hero detected)

Each resolved hero includes the resolution source (`manual` | `api` | `name` | `vpk` | `none`) and a `hasOverride` flag for UI state.

### State Management Updates
Extended `LocalMod` interface with optional `heroOverride?: string | null` field to persist manual hero selections. Added `setHeroOverride()` method to `ModsState` that propagates changes across all profiles, not just the active one.

### UI Components
- **New `HeroOverridePicker` component**: Allows users to manually override a mod's detected hero via a searchable popover with three modes: automatic (clear override), "General/Other" (explicit null), or specific hero selection.
- **Updated `ModInfo` component**: Refactored to display `HeroDisplay` with override controls and source badges indicating resolution origin.
- **Updated `HeroFilter`**: Now derives hero options from resolved heroes instead of raw mod data.

### Filtering & Detection Integration
- **`mods.tsx` (browsing page)**: Updated hero filtering to resolve each mod's hero using the new `resolveModHero()` with corresponding local mod metadata before applying hero filter matching.
- **`my-mods.tsx` (installed mods)**: Refactored filtering chain to use `resolveLocalModHero()` for hero resolution in the single-pass filter predicate.
- **`mod-button.tsx` (conflict detection)**: Updated to use resolved heroes when detecting hero conflicts during the install flow.
- **`use-download.ts`, `use-hero-detection.ts`, `use-mod-processor.ts`**: Updated to call `resolveDetectedHeroLabel()` from hero-parser when storing detected hero data, ensuring consistent label handling across the app.

### Cross-Package Changes
**`@deadlock-mods/hero-parser`**: Added and exported `resolveDetectedHeroLabel()` helper that returns the prioritized hero display label (preferring `heroDisplay` over `hero`), enabling consistent hero label resolution across both core detection and desktop app state management.

### Testing
Added comprehensive test suite (`hero-resolution.test.ts`) validating resolution priority, override handling, and filter matching including the special `"None"` sentinel behavior.

## No Breaking Changes to Public APIs
All new exports are additive; existing functions and component signatures remain compatible with optional props.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deadlock-mod-manager/deadlock-mod-manager/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->