### PR TITLE
feat(desktop): persist VPK repair metadata

### DIFF
--- a/.changeset/gamebanana-hero-categories.md
+++ b/.changeset/gamebanana-hero-categories.md
@@ -1,0 +1,6 @@
+---
+"@deadlock-mods/api": patch
+"@deadlock-mods/shared": patch
+---
+
+Resolve GameBanana heroes from profile categories.

--- a/.changeset/repair-manifest-metadata.md
+++ b/.changeset/repair-manifest-metadata.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Add profile manifest repair metadata and surface broken VPK state as repairable instead of silently treating missing files as disabled.

--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -6,11 +6,7 @@ import {
   ModRepository,
   type NewMod,
 } from "@deadlock-mods/database";
-import {
-  GameBanana,
-  type FileserverDto,
-  guessHero,
-} from "@deadlock-mods/shared";
+import { GameBanana, type FileserverDto } from "@deadlock-mods/shared";
 import { cache } from "../../lib/redis";
 import { wideEventContext } from "../../lib/logger";
 import { resolveFileserverGeo } from "../../services/geo";
@@ -28,6 +24,7 @@ import {
   buildMetadata,
   categoryFromGameBananaProfile,
   classifyNSFW,
+  heroFromGameBananaProfile,
   mapGameBananaFileserverState,
   parseTags,
   submitterDisplayName,
@@ -35,6 +32,43 @@ import {
 
 const modRepository = new ModRepository(db);
 const modDownloadRepository = new ModDownloadRepository(db);
+
+const arraysEqualIgnoringOrder = (
+  left: readonly string[] | null | undefined,
+  right: readonly string[] | null | undefined,
+): boolean => {
+  const sortedLeft = [...(left ?? [])].sort();
+  const sortedRight = [...(right ?? [])].sort();
+
+  return (
+    sortedLeft.length === sortedRight.length &&
+    sortedLeft.every((value, index) => value === sortedRight[index])
+  );
+};
+
+const hasCachedModFieldChanges = (
+  existing: Mod | null,
+  payload: NewMod,
+): boolean =>
+  !existing ||
+  existing.name !== payload.name ||
+  existing.description !== payload.description ||
+  existing.author !== payload.author ||
+  existing.likes !== payload.likes ||
+  existing.hero !== payload.hero ||
+  existing.downloadCount !== payload.downloadCount ||
+  existing.remoteUrl !== payload.remoteUrl ||
+  existing.category !== payload.category ||
+  existing.downloadable !== payload.downloadable ||
+  existing.isNSFW !== payload.isNSFW ||
+  existing.isObsolete !== payload.isObsolete ||
+  existing.isMap !== payload.isMap ||
+  existing.isAudio !== payload.isAudio ||
+  existing.audioUrl !== payload.audioUrl ||
+  existing.remoteAddedAt.getTime() !== payload.remoteAddedAt.getTime() ||
+  existing.remoteUpdatedAt.getTime() !== payload.remoteUpdatedAt.getTime() ||
+  !arraysEqualIgnoringOrder(existing.tags, payload.tags) ||
+  !arraysEqualIgnoringOrder(existing.images, payload.images);
 
 export class GameBananaProvider extends Provider<GameBananaSubmission> {
   async getAllSubmissions(
@@ -355,7 +389,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       tags: parseTags(profile._aTags),
       author: submitterDisplayName(profile),
       likes: profile._nLikeCount ?? 0,
-      hero: guessHero(profile._sName),
+      hero: heroFromGameBananaProfile(profile),
       downloadCount: profile._nDownloadCount ?? 0,
       remoteUrl: profile._sProfileUrl,
       category: categoryFromGameBananaProfile(profile),
@@ -399,7 +433,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       tags: parseTags(profile._aTags),
       author: submitterDisplayName(profile),
       likes: profile._nLikeCount ?? 0,
-      hero: guessHero(profile._sName),
+      hero: heroFromGameBananaProfile(profile),
       downloadCount: profile._nDownloadCount ?? 0,
       remoteUrl: profile._sProfileUrl,
       category,
@@ -500,6 +534,14 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
         };
       }
 
+      const existingMod =
+        await modRepository.findByRemoteIdIncludingBlacklisted(
+          payload.remoteId,
+        );
+      const cachedFieldsChanged = hasCachedModFieldChanges(
+        existingMod,
+        payload,
+      );
       const dbMod = await modRepository.upsertByRemoteId(payload);
 
       this.logger
@@ -517,6 +559,10 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
           dbMod,
           filesUpdatedAt,
         );
+      }
+      if (cachedFieldsChanged) {
+        await cache.del(`mod:${dbMod.remoteId}`);
+        await cache.del("mods:listing");
       }
 
       return { mod: dbMod, filesChanged };

--- a/apps/api/src/providers/game-banana/utils.test.ts
+++ b/apps/api/src/providers/game-banana/utils.test.ts
@@ -6,7 +6,30 @@ import {
   donationLinksFromMethods,
   extractDonationLinksFromDescription,
   extractMapName,
+  heroFromGameBananaProfile,
 } from "./utils";
+
+describe("heroFromGameBananaProfile", () => {
+  it("prefers the GameBanana sub-category when the public category is Skins", () => {
+    const profile = {
+      _sName: "Toon Seven",
+      _aCategory: { _sName: "Seven" },
+      _aSuperCategory: { _sName: "Skins" },
+    } as GameBanana.GameBananaModProfile;
+
+    expect(heroFromGameBananaProfile(profile)).toBe("Seven");
+  });
+
+  it("falls back to mod name aliases when GameBanana does not provide a hero category", () => {
+    const profile = {
+      _sName: "Toon Viktor",
+      _aCategory: { _sName: "Skins" },
+      _aSuperCategory: { _sName: "Skins" },
+    } as GameBanana.GameBananaModProfile;
+
+    expect(heroFromGameBananaProfile(profile)).toBe("Victor");
+  });
+});
 
 describe("extractMapName", () => {
   it("returns undefined for empty description", () => {

--- a/apps/api/src/providers/game-banana/utils.ts
+++ b/apps/api/src/providers/game-banana/utils.ts
@@ -5,6 +5,7 @@ import type {
   GameBanana,
   ModMetadata,
 } from "@deadlock-mods/shared";
+import { guessHero, normalizeHero } from "@deadlock-mods/shared";
 import { NSFW_CONTENT_RATINGS, NSFW_KEYWORDS } from "./constants";
 import type { GameBananaSubmission } from "./types";
 
@@ -24,6 +25,12 @@ export function categoryFromGameBananaProfile(
     return rootName;
   }
   return profile._aCategory?._sName ?? "Other";
+}
+
+export function heroFromGameBananaProfile(
+  profile: GameBananaProfileForCategory,
+): string | null {
+  return normalizeHero(profile._aCategory?._sName) ?? guessHero(profile._sName);
 }
 
 export function submitterDisplayName(

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -1,7 +1,8 @@
 use crate::download_manager::DownloadTask;
 use crate::errors::Error;
-use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use crate::mod_manager::Mod;
+use crate::mod_manager::ProfileVpkManifestSourceDownload;
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -571,9 +572,7 @@ pub async fn get_profile_vpk_manifest(
 }
 
 #[tauri::command]
-pub async fn hydrate_mods_from_manifest(
-  profile_folder: Option<String>,
-) -> Result<usize, Error> {
+pub async fn hydrate_mods_from_manifest(profile_folder: Option<String>) -> Result<usize, Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
   mod_manager.hydrate_mods_from_manifest(profile_folder)
 }
@@ -628,6 +627,25 @@ pub async fn seed_profile_vpk_manifest_entries(
   if changed {
     manifest.save(&addons_path)?;
   }
+
+  Ok(())
+}
+
+#[tauri::command]
+pub async fn update_profile_vpk_manifest_repair_metadata(
+  profile_folder: Option<String>,
+  mod_id: String,
+  source_downloads: Vec<ProfileVpkManifestSourceDownload>,
+) -> Result<(), Error> {
+  log::info!("Updating VPK repair metadata for mod {mod_id} in profile {profile_folder:?}");
+
+  let addons_path = {
+    let mod_manager = MANAGER.lock().unwrap();
+    mod_manager.get_addons_path(profile_folder.as_deref())?
+  };
+  let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+  manifest.update_repair_metadata(&addons_path, &mod_id, source_downloads)?;
+  manifest.save(&addons_path)?;
 
   Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -202,6 +202,7 @@ pub fn run() {
       commands::profiles::get_profile_vpk_manifest,
       commands::profiles::hydrate_mods_from_manifest,
       commands::profiles::seed_profile_vpk_manifest_entries,
+      commands::profiles::update_profile_vpk_manifest_repair_metadata,
       commands::profiles::delete_profile_vpk,
       commands::profiles::show_profile_vpk_in_folder,
       commands::profiles::import_profile_batch,

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -457,17 +457,22 @@ impl ModManager {
       .vpk_manager
       .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
 
+    let mut updated_mod_ids = Vec::new();
     for (mod_id, new_vpk_names) in updated_vpk_mappings {
       if let Some(entry) = manifest.mods.get_mut(&mod_id) {
         entry.enabled = true;
         entry.current_vpks = new_vpk_names.clone();
         entry.disabled_vpks.clear();
       }
+      updated_mod_ids.push(mod_id.clone());
 
       if let Some(mut mod_entry) = self.mod_repository.remove_mod(&mod_id) {
         mod_entry.installed_vpks = new_vpk_names;
         self.mod_repository.add_mod(mod_entry);
       }
+    }
+    for mod_id in updated_mod_ids {
+      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, &mod_id);
     }
 
     manifest.save(&addons_path)?;
@@ -554,6 +559,9 @@ impl ModManager {
         self.mod_repository.add_mod(mod_entry);
       }
     }
+    for (remote_id, _) in &updated_mappings {
+      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, remote_id);
+    }
 
     manifest.save(&addons_path)?;
 
@@ -620,12 +628,14 @@ impl ModManager {
 
     // Update mod data with new VPK names and re-add to repository
     let mut result_mods = Vec::new();
+    let mut updated_mod_ids = Vec::new();
     for (mod_id, new_vpk_names) in updated_vpk_mappings {
       if let Some(entry) = manifest.mods.get_mut(&mod_id) {
         entry.enabled = true;
         entry.current_vpks = new_vpk_names.clone();
         entry.disabled_vpks.clear();
       }
+      updated_mod_ids.push(mod_id.clone());
 
       if let Some(index) = updated_mods
         .iter()
@@ -637,6 +647,9 @@ impl ModManager {
         result_mods.push(deadlock_mod);
       }
     }
+    for mod_id in updated_mod_ids {
+      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, &mod_id);
+    }
 
     for deadlock_mod in updated_mods {
       self.mod_repository.add_mod(deadlock_mod);
@@ -646,6 +659,22 @@ impl ModManager {
 
     log::info!("Successfully reordered {} mods", result_mods.len());
     Ok(result_mods)
+  }
+
+  fn refresh_repair_metadata_after_reorder(
+    manifest: &mut ProfileVpkManifest,
+    addons_path: &Path,
+    mod_id: &str,
+  ) {
+    let source_downloads = manifest
+      .mods
+      .get(mod_id)
+      .map(|entry| entry.source_downloads.clone())
+      .unwrap_or_default();
+
+    if let Err(e) = manifest.update_repair_metadata(addons_path, mod_id, source_downloads) {
+      log::warn!("Failed to refresh repair metadata for {mod_id} after reorder: {e}");
+    }
   }
 
   pub fn clear_mods(&mut self, profile_folder: Option<String>) -> Result<(), Error> {

--- a/apps/desktop/src-tauri/src/mod_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod.rs
@@ -21,3 +21,4 @@ pub use file_tree::ModFileTree;
 pub use font_manager::{FontInfo, FontManager};
 pub use manager::ModManager;
 pub use mod_repository::Mod;
+pub use vpk_manifest::ProfileVpkManifestSourceDownload;

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -1,9 +1,10 @@
 use crate::errors::Error;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, io::ErrorKind, path::Path};
+use vpk_parser::{VpkParseOptions, VpkParser};
 
 const MANIFEST_FILENAME: &str = ".dmm.json";
-const CURRENT_MANIFEST_VERSION: u32 = 1;
+const CURRENT_MANIFEST_VERSION: u32 = 2;
 
 const fn current_manifest_version() -> u32 {
   CURRENT_MANIFEST_VERSION
@@ -31,6 +32,32 @@ pub struct ProfileVpkManifestEntry {
   pub disabled_vpks: Vec<String>,
   #[serde(default)]
   pub original_vpk_names: Vec<String>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub source_downloads: Vec<ProfileVpkManifestSourceDownload>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub vpk_fingerprints: Vec<ProfileVpkManifestVpkFingerprint>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkManifestSourceDownload {
+  pub name: String,
+  pub size: u64,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub url: Option<String>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub md5_checksum: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkManifestVpkFingerprint {
+  pub current_name: String,
+  pub original_name: String,
+  pub file_size: u64,
+  pub fast_hash: String,
+  pub sha256: String,
+  pub manifest_sha256: String,
 }
 
 impl Default for ProfileVpkManifest {
@@ -76,7 +103,7 @@ impl ProfileVpkManifest {
       ))
     })?;
 
-    if manifest.version == 0 {
+    if manifest.version < CURRENT_MANIFEST_VERSION {
       manifest.version = CURRENT_MANIFEST_VERSION;
     }
 
@@ -144,6 +171,78 @@ impl ProfileVpkManifest {
 
   pub fn remove_mod(&mut self, mod_id: &str) {
     self.mods.remove(mod_id);
+  }
+
+  pub fn update_repair_metadata(
+    &mut self,
+    addons_path: &Path,
+    mod_id: &str,
+    source_downloads: Vec<ProfileVpkManifestSourceDownload>,
+  ) -> Result<(), Error> {
+    let Some(entry) = self.mods.get_mut(mod_id) else {
+      return Ok(());
+    };
+
+    entry.source_downloads = source_downloads;
+    entry.vpk_fingerprints =
+      Self::fingerprints_for_entry(addons_path, &entry.current_vpks, &entry.original_vpk_names)?;
+    Ok(())
+  }
+
+  fn fingerprints_for_entry(
+    addons_path: &Path,
+    current_vpks: &[String],
+    original_vpk_names: &[String],
+  ) -> Result<Vec<ProfileVpkManifestVpkFingerprint>, Error> {
+    let mut fingerprints = Vec::new();
+    for (index, current_name) in current_vpks.iter().enumerate() {
+      let path = addons_path.join(current_name);
+      if !path.exists() {
+        log::warn!(
+          "Skipping VPK fingerprint for missing manifest file: {}",
+          path.display()
+        );
+        continue;
+      }
+
+      let vpk_data = fs::read(&path)?;
+      let metadata = fs::metadata(&path)?;
+      let last_modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|duration| chrono::DateTime::from_timestamp(duration.as_secs() as i64, 0));
+      let parsed = VpkParser::parse(
+        vpk_data,
+        VpkParseOptions {
+          include_full_file_hash: true,
+          file_path: path.to_string_lossy().to_string(),
+          last_modified,
+          include_merkle: false,
+          include_entries: false,
+        },
+      )
+      .map_err(|e| {
+        Error::InvalidInput(format!(
+          "Failed to fingerprint VPK file {}: {e}",
+          path.display()
+        ))
+      })?;
+
+      fingerprints.push(ProfileVpkManifestVpkFingerprint {
+        current_name: current_name.clone(),
+        original_name: original_vpk_names
+          .get(index)
+          .cloned()
+          .unwrap_or_else(|| current_name.clone()),
+        file_size: parsed.fingerprint.file_size as u64,
+        fast_hash: parsed.fingerprint.fast_hash,
+        sha256: parsed.fingerprint.sha256,
+        manifest_sha256: parsed.manifest_sha256,
+      });
+    }
+
+    Ok(fingerprints)
   }
 }
 
@@ -229,5 +328,14 @@ mod tests {
     assert_eq!(entry.original_vpk_names, vec!["cool_mod.vpk".to_string()]);
     assert_eq!(entry.current_vpks, vec!["pak02_dir.vpk".to_string()]);
     assert_eq!(entry.order, Some(1));
+  }
+
+  #[test]
+  fn source_downloads_are_omitted_when_empty() {
+    let manifest = ProfileVpkManifest::default();
+    let json = serde_json::to_string(&manifest).unwrap();
+
+    assert!(!json.contains("sourceDownloads"));
+    assert!(!json.contains("vpkFingerprints"));
   }
 }

--- a/apps/desktop/src/components/mod-browsing/hero-filter.tsx
+++ b/apps/desktop/src/components/mod-browsing/hero-filter.tsx
@@ -17,10 +17,13 @@ import {
 import { Check } from "@deadlock-mods/ui/icons";
 import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { cn } from "@/lib/utils";
 
 type HeroFilterProps = {
-  mods: ModDto[];
+  mods: Array<
+    ModDto & { detectedHero?: string | null; heroOverride?: string | null }
+  >;
   selectedHeroes: string[];
   onHeroesChange: (heroes: string[]) => void;
 };
@@ -37,12 +40,15 @@ const HeroFilter = ({
     const heroes = Array.from(
       new Set(
         mods
-          .map((mod) => mod.hero)
+          .map((mod) => resolveModHero(mod, mod).hero)
           .filter((hero): hero is string => Boolean(hero)),
       ),
     ).sort((a, b) => a.localeCompare(b));
     // Add "None" option for mods without specific heroes
-    if (mods.some((mod) => !mod.hero) && !heroes.includes("None")) {
+    if (
+      mods.some((mod) => !resolveModHero(mod, mod).hero) &&
+      !heroes.includes("None")
+    ) {
       heroes.unshift("None");
     }
     return heroes;

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -33,6 +33,7 @@ import useInstallWithCollection from "@/hooks/use-install-with-collection";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
 import useUninstall from "@/hooks/use-uninstall";
 import logger from "@/lib/logger";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { type LocalMod, ModStatus } from "@/types/mods";
@@ -235,17 +236,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           break;
         case ModStatus.Downloaded:
         case ModStatus.FailedToInstall: {
-          const detectedHero = localMod.detectedHero;
-          if (detectedHero) {
+          const resolvedHero = resolveModHero(localMod, localMod).hero;
+          if (resolvedHero) {
             const conflictingMod = localMods.find(
               (m) =>
                 m.remoteId !== localMod.remoteId &&
                 m.status === ModStatus.Installed &&
-                m.detectedHero === detectedHero,
+                resolveModHero(m, m).hero === resolvedHero,
             );
             if (conflictingMod) {
               const resolution = await askHeroConflict(
-                detectedHero,
+                resolvedHero,
                 conflictingMod,
                 localMod,
               );

--- a/apps/desktop/src/components/mod-detail/mod-info.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-info.tsx
@@ -1,16 +1,31 @@
-import type { ModDto } from "@deadlock-mods/shared";
+import { DeadlockHeroes, type ModDto } from "@deadlock-mods/shared";
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@deadlock-mods/ui/components/avatar";
 import { Badge } from "@deadlock-mods/ui/components/badge";
+import { Button } from "@deadlock-mods/ui/components/button";
 import {
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
 } from "@deadlock-mods/ui/components/card";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@deadlock-mods/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deadlock-mods/ui/components/popover";
 import { Separator } from "@deadlock-mods/ui/components/separator";
 import {
   Tooltip,
@@ -20,16 +35,25 @@ import {
 import {
   Calendar,
   CalendarPlus,
+  Check,
   Download,
   Heart,
   Package,
+  RotateCcw,
+  Settings,
   Tag,
   User,
 } from "@deadlock-mods/ui/icons";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHero } from "@/hooks/use-hero";
 import { getModCategoryDisplayName } from "@/lib/constants";
+import {
+  type ResolvedModHero,
+  resolveModHero,
+} from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
 import { DateDisplay } from "../date-display";
 
 interface ModInfoProps {
@@ -52,10 +76,11 @@ export const ModInfo = ({
   const localMods = usePersistedStore((state) => state.localMods);
   const localMod = localMods.find((m) => m.remoteId === mod.remoteId);
 
-  const heroLabel = localMod?.detectedHero ?? null;
+  const resolvedHero = resolveModHero(mod, localMod);
+  const showHeroStat = resolvedHero.hero !== null || localMod !== undefined;
   const hasTags = mod.tags && mod.tags.length > 0;
   const hasFileInfo = activeArchiveNames.size > 0 && totalDownloads > 1;
-  const statCount = (heroLabel ? 1 : 0) + 3 + (hasFileInfo ? 1 : 0);
+  const statCount = (showHeroStat ? 1 : 0) + 3 + (hasFileInfo ? 1 : 0);
   const gridCols =
     statCount <= 3
       ? "grid grid-cols-1 gap-3 sm:grid-cols-3"
@@ -77,7 +102,13 @@ export const ModInfo = ({
       <CardContent className={hasHero || mod.isAudio ? "" : "pt-6"}>
         <div className='space-y-5'>
           <div className={gridCols}>
-            {heroLabel && <HeroDisplay name={heroLabel} />}
+            {showHeroStat && (
+              <HeroDisplay
+                mod={mod}
+                resolvedHero={resolvedHero}
+                canOverride={localMod !== undefined}
+              />
+            )}
             <PrimaryStat
               icon={<User className='h-4 w-4' />}
               label={t("modDetail.authorLabel")}
@@ -173,18 +204,44 @@ export const ModInfo = ({
 };
 
 interface HeroDisplayProps {
-  name: string;
+  mod: ModDto;
+  resolvedHero: ResolvedModHero;
+  canOverride: boolean;
 }
 
-const HeroDisplay = ({ name }: HeroDisplayProps) => {
+const HERO_OVERRIDE_OPTIONS = Object.values(DeadlockHeroes).sort((a, b) =>
+  a.localeCompare(b),
+);
+const GENERAL_OTHER_HERO_LABEL = "General/Other";
+
+const HeroDisplay = ({ mod, resolvedHero, canOverride }: HeroDisplayProps) => {
   const { t } = useTranslation();
-  const { data: hero } = useHero(name);
+  const [open, setOpen] = useState(false);
+  const setHeroOverride = usePersistedStore((state) => state.setHeroOverride);
+  const name = resolvedHero.hero ?? GENERAL_OTHER_HERO_LABEL;
+  const { data: hero } = useHero(resolvedHero.hero ?? "");
   const imageSrc =
     hero?.images.icon_hero_card_webp ??
     hero?.images.icon_hero_card ??
     hero?.images.icon_image_small_webp ??
     hero?.images.icon_image_small;
   const initial = name.charAt(0).toUpperCase();
+  const sourceLabel = {
+    api: t("modDetail.heroSource.api", { defaultValue: "API" }),
+    manual: t("modDetail.heroSource.manual", { defaultValue: "Manual" }),
+    name: t("modDetail.heroSource.name", { defaultValue: "Name" }),
+    none: t("modDetail.heroSource.none", { defaultValue: "Unset" }),
+    vpk: t("modDetail.heroSource.vpk", { defaultValue: "VPK" }),
+  }[resolvedHero.source];
+  const selectedValue =
+    resolvedHero.hasOverride && resolvedHero.hero === null
+      ? null
+      : resolvedHero.hero;
+
+  const handleOverride = (heroOverride: string | null | undefined) => {
+    setHeroOverride(mod.remoteId, heroOverride);
+    setOpen(false);
+  };
 
   return (
     <div className='group flex items-center gap-3 rounded-lg border border-border/50 bg-muted/30 px-3 py-2.5 transition-colors hover:bg-muted/60'>
@@ -196,10 +253,84 @@ const HeroDisplay = ({ name }: HeroDisplayProps) => {
         <span className='text-muted-foreground text-xs uppercase tracking-wide'>
           {t("modDetail.detectedHero")}
         </span>
-        <span className='truncate font-medium text-foreground text-sm'>
-          {name}
+        <span className='flex min-w-0 items-center gap-1.5'>
+          <span className='truncate font-medium text-foreground text-sm'>
+            {name}
+          </span>
+          <span className='shrink-0 rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-muted-foreground leading-none'>
+            {sourceLabel}
+          </span>
         </span>
       </div>
+      {canOverride && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <Button
+                  aria-label={t("modDetail.changeHero", {
+                    defaultValue: "Change hero",
+                  })}
+                  className='ml-auto h-7 w-7 shrink-0 opacity-80 group-hover:opacity-100'
+                  size='icon'
+                  variant='ghost'>
+                  <Settings className='h-3.5 w-3.5' />
+                </Button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t("modDetail.changeHero", { defaultValue: "Change hero" })}
+            </TooltipContent>
+          </Tooltip>
+          <PopoverContent align='start' className='w-[260px] p-0'>
+            <Command>
+              <CommandInput placeholder={t("filters.searchHeroes")} />
+              <CommandList>
+                <CommandEmpty>{t("filters.noHeroesFound")}</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem onSelect={() => handleOverride(undefined)}>
+                    <RotateCcw className='mr-2 h-4 w-4 flex-shrink-0' />
+                    <span>
+                      {t("modDetail.heroOverrideAutomatic", {
+                        defaultValue: "Use automatic",
+                      })}
+                    </span>
+                  </CommandItem>
+                  <CommandItem onSelect={() => handleOverride(null)}>
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4 flex-shrink-0",
+                        resolvedHero.hasOverride && selectedValue === null
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                    <span>{GENERAL_OTHER_HERO_LABEL}</span>
+                  </CommandItem>
+                </CommandGroup>
+                <CommandSeparator />
+                <CommandGroup>
+                  {HERO_OVERRIDE_OPTIONS.map((heroName) => (
+                    <CommandItem
+                      key={heroName}
+                      onSelect={() => handleOverride(heroName)}>
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4 flex-shrink-0",
+                          resolvedHero.hasOverride && selectedValue === heroName
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      <span className='truncate'>{heroName}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      )}
     </div>
   );
 };

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -61,7 +61,7 @@ export const useDownload = (
           .then((result) => {
             setDetectedHero(
               mod.remoteId,
-              result.hero ?? null,
+              result.heroDisplay ?? result.hero ?? null,
               result.usesCriticalPaths,
             );
           })

--- a/apps/desktop/src/hooks/use-hero-detection.ts
+++ b/apps/desktop/src/hooks/use-hero-detection.ts
@@ -144,7 +144,7 @@ const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {
       for (const resp of responses) {
         setDetectedHero(
           resp.modId,
-          resp.result.hero ?? null,
+          resp.result.heroDisplay ?? resp.result.hero ?? null,
           resp.result.usesCriticalPaths,
         );
       }
@@ -166,7 +166,7 @@ const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {
           });
           setDetectedHero(
             mod.remoteId,
-            result.hero ?? null,
+            result.heroDisplay ?? result.hero ?? null,
             result.usesCriticalPaths,
           );
         } catch {

--- a/apps/desktop/src/hooks/use-mod-processor.ts
+++ b/apps/desktop/src/hooks/use-mod-processor.ts
@@ -311,7 +311,11 @@ export const useModProcessor = () => {
 
     invoke<HeroDetectionResult>("detect_mod_hero", { modId })
       .then((result) =>
-        setDetectedHero(modId, result.hero ?? null, result.usesCriticalPaths),
+        setDetectedHero(
+          modId,
+          result.heroDisplay ?? result.hero ?? null,
+          result.usesCriticalPaths,
+        ),
       )
       .catch(() => setDetectedHero(modId, null));
 
@@ -416,7 +420,11 @@ export const useModProcessor = () => {
 
     invoke<HeroDetectionResult>("detect_mod_hero", { modId })
       .then((result) =>
-        setDetectedHero(modId, result.hero ?? null, result.usesCriticalPaths),
+        setDetectedHero(
+          modId,
+          result.heroDisplay ?? result.hero ?? null,
+          result.usesCriticalPaths,
+        ),
       )
       .catch(() => setDetectedHero(modId, null));
 

--- a/apps/desktop/src/lib/mods/hero-resolution.test.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { LocalMod } from "@/types/mods";
+import { resolveModHero } from "./hero-resolution";
+
+const mod = (values: {
+  name: string;
+  hero?: string | null;
+  detectedHero?: string | null;
+  heroOverride?: string | null;
+}) =>
+  ({
+    name: values.name,
+    hero: values.hero ?? null,
+    detectedHero: values.detectedHero,
+    heroOverride: values.heroOverride,
+  }) as LocalMod;
+
+describe("resolveModHero", () => {
+  it("prefers manual overrides over all automatic sources", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+      heroOverride: "Victor",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Victor",
+      source: "manual",
+      hasOverride: true,
+    });
+  });
+
+  it("prefers API heroes over stale local VPK detection", () => {
+    const localMod = mod({
+      name: "Toon Seven",
+      hero: "Seven",
+      detectedHero: "Calico",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Seven",
+      source: "api",
+    });
+  });
+
+  it("uses name aliases before VPK detection when the API is missing a hero", () => {
+    const localMod = mod({
+      name: "Toon Viktor",
+      hero: null,
+      detectedHero: "Infernus",
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: "Victor",
+      source: "name",
+    });
+  });
+
+  it("can manually mark a local mod as general or other", () => {
+    const localMod = mod({
+      name: "Mystery Pack",
+      hero: "Seven",
+      heroOverride: null,
+    });
+
+    expect(resolveModHero(localMod, localMod)).toMatchObject({
+      hero: null,
+      source: "manual",
+      hasOverride: true,
+    });
+  });
+});

--- a/apps/desktop/src/lib/mods/hero-resolution.ts
+++ b/apps/desktop/src/lib/mods/hero-resolution.ts
@@ -1,0 +1,70 @@
+import type { ModDto } from "@deadlock-mods/shared";
+import { guessHero, normalizeHero } from "@deadlock-mods/shared";
+import type { LocalMod } from "@/types/mods";
+
+export type ResolvedHeroSource = "manual" | "api" | "name" | "vpk" | "none";
+
+export type ResolvedModHero = {
+  hero: string | null;
+  source: ResolvedHeroSource;
+  isManual: boolean;
+  hasOverride: boolean;
+};
+
+type HeroResolvableMod = Pick<ModDto, "hero" | "name">;
+type HeroResolvableLocalMod = Pick<LocalMod, "detectedHero" | "heroOverride">;
+
+export function resolveModHero(
+  mod: HeroResolvableMod,
+  localMod?: HeroResolvableLocalMod | null,
+): ResolvedModHero {
+  if (localMod && "heroOverride" in localMod) {
+    const { heroOverride } = localMod;
+    if (heroOverride !== undefined) {
+      // Preserve unknown manual overrides so imported or future hero values remain visible.
+      return {
+        hero: normalizeHero(heroOverride) ?? heroOverride,
+        source: "manual",
+        isManual: true,
+        hasOverride: true,
+      };
+    }
+  }
+
+  const apiHero = normalizeHero(mod.hero);
+  if (apiHero) {
+    return {
+      hero: apiHero,
+      source: "api",
+      isManual: false,
+      hasOverride: false,
+    };
+  }
+
+  const nameHero = guessHero(mod.name);
+  if (nameHero) {
+    return {
+      hero: nameHero,
+      source: "name",
+      isManual: false,
+      hasOverride: false,
+    };
+  }
+
+  const vpkHero = normalizeHero(localMod?.detectedHero);
+  if (vpkHero) {
+    return {
+      hero: vpkHero,
+      source: "vpk",
+      isManual: false,
+      hasOverride: false,
+    };
+  }
+
+  return {
+    hero: null,
+    source: "none",
+    isManual: false,
+    hasOverride: false,
+  };
+}

--- a/apps/desktop/src/lib/state-machines/mod-status.ts
+++ b/apps/desktop/src/lib/state-machines/mod-status.ts
@@ -20,24 +20,32 @@ const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
     ModStatus.Downloaded,
     ModStatus.FailedToDownload,
     ModStatus.Paused,
+    ModStatus.NeedsRepair,
   ],
-  [ModStatus.Extracting]: [ModStatus.Downloaded, ModStatus.FailedToDownload],
+  [ModStatus.Extracting]: [
+    ModStatus.Downloaded,
+    ModStatus.FailedToDownload,
+    ModStatus.NeedsRepair,
+  ],
   [ModStatus.Paused]: [ModStatus.Downloading, ModStatus.FailedToDownload],
   [ModStatus.Downloaded]: [
     ModStatus.Installing,
     ModStatus.Removing,
     ModStatus.Installed,
+    ModStatus.NeedsRepair,
   ],
   [ModStatus.Installing]: [
     ModStatus.Installed,
     ModStatus.FailedToInstall,
     ModStatus.Downloaded,
+    ModStatus.NeedsRepair,
   ],
   [ModStatus.Installed]: [
     ModStatus.Downloading,
     ModStatus.Extracting,
     ModStatus.Removing,
     ModStatus.Downloaded,
+    ModStatus.NeedsRepair,
   ],
   [ModStatus.Removing]: [ModStatus.Removed, ModStatus.FailedToRemove],
   [ModStatus.Removed]: [ModStatus.Error],
@@ -49,6 +57,12 @@ const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
     ModStatus.Error,
   ],
   [ModStatus.Error]: [],
+  [ModStatus.NeedsRepair]: [
+    ModStatus.Downloading,
+    ModStatus.Installing,
+    ModStatus.Downloaded,
+    ModStatus.Error,
+  ],
 };
 
 /**

--- a/apps/desktop/src/lib/store/index.ts
+++ b/apps/desktop/src/lib/store/index.ts
@@ -111,6 +111,7 @@ export const usePersistedStore = create<State>()(
       partialize: (state) => {
         const {
           modProgress: _modProgress,
+          isRepairingMods: _isRepairingMods,
           isSwitching: _isSwitching,
           showWhatsNew: _showWhatsNew,
           lastSeenVersion: _lastSeenVersion,

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -73,6 +73,10 @@ export type ModsState = {
     hero: string | null,
     usesCriticalPaths?: boolean,
   ) => void;
+  setHeroOverride: (
+    remoteId: string,
+    heroOverride: string | null | undefined,
+  ) => void;
   clearAllDetectedHeroes: () => void;
   setHeroDetection: (progress: Partial<HeroDetectionProgress>) => void;
 };
@@ -528,25 +532,90 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     hero: string | null,
     usesCriticalPaths?: boolean,
   ) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) =>
-        mod.remoteId === remoteId
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) =>
+          mod.remoteId === remoteId
+            ? {
+                ...mod,
+                detectedHero: hero,
+                usesCriticalPaths: usesCriticalPaths ?? mod.usesCriticalPaths,
+              }
+            : mod,
+        );
+
+      const activeProfile = state.profiles[state.activeProfileId];
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: activeProfile
           ? {
-              ...mod,
-              detectedHero: hero,
-              usesCriticalPaths: usesCriticalPaths ?? mod.usesCriticalPaths,
+              ...state.profiles,
+              [state.activeProfileId]: {
+                ...activeProfile,
+                mods: updateMods(activeProfile.mods),
+              },
             }
-          : mod,
-      ),
-    })),
+          : state.profiles,
+      };
+    }),
+
+  setHeroOverride: (remoteId, heroOverride) =>
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => {
+          if (mod.remoteId !== remoteId) return mod;
+
+          if (heroOverride === undefined) {
+            const { heroOverride: _heroOverride, ...nextMod } = mod;
+            return nextMod;
+          }
+
+          return {
+            ...mod,
+            heroOverride,
+          };
+        });
+
+      const updatedProfiles = Object.fromEntries(
+        Object.entries(state.profiles).map(([profileId, profile]) => [
+          profileId,
+          {
+            ...profile,
+            mods: updateMods(profile.mods),
+          },
+        ]),
+      );
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: updatedProfiles,
+      };
+    }),
 
   clearAllDetectedHeroes: () =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        detectedHero: undefined,
-      })),
-    })),
+    set((state) => {
+      const updateMods = (mods: typeof state.localMods) =>
+        mods.map((mod) => ({
+          ...mod,
+          detectedHero: undefined,
+        }));
+
+      const updatedProfiles = Object.fromEntries(
+        Object.entries(state.profiles).map(([profileId, profile]) => [
+          profileId,
+          {
+            ...profile,
+            mods: updateMods(profile.mods),
+          },
+        ]),
+      );
+
+      return {
+        localMods: updateMods(state.localMods),
+        profiles: updatedProfiles,
+      };
+    }),
 
   setHeroDetection: (progress) =>
     set((state) => ({

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -10,6 +10,7 @@ import {
   type ModFileTree,
   ModStatus,
   type Progress,
+  type RepairReason,
 } from "@/types/mods";
 import type { State } from "..";
 
@@ -28,6 +29,7 @@ export type HeroDetectionProgress = {
 export type ModsState = {
   localMods: LocalMod[];
   modProgress: Record<string, ModProgress>;
+  isRepairingMods: boolean;
   defaultSort: SortType;
   // Analysis dialog state
   analysisResult: AnalyzeAddonsResult | null;
@@ -46,6 +48,11 @@ export type ModsState = {
   setMods: (mods: LocalMod[]) => void;
   setModStatus: (remoteId: string, status: ModStatus) => void;
   setModProgress: (remoteId: string, progress: Progress) => void;
+  setIsRepairingMods: (isRepairing: boolean) => void;
+  setModRepairReason: (
+    remoteId: string,
+    repairReason: RepairReason | undefined,
+  ) => void;
   clearMods: () => void;
   setInstalledVpks: (
     remoteId: string,
@@ -90,6 +97,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 ) => ({
   localMods: [],
   modProgress: {},
+  isRepairingMods: false,
   analysisResult: null,
   analysisDialogOpen: false,
   heroDetection: { status: "idle", current: 0, total: 0, currentModName: null },
@@ -259,6 +267,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         return {
           ...mod,
           status,
+          repairReason:
+            status === ModStatus.NeedsRepair ? mod.repairReason : undefined,
           downloadedAt:
             (status === ModStatus.Downloaded &&
               mod.status !== ModStatus.Installed) ||
@@ -316,6 +326,18 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       },
     })),
 
+  setIsRepairingMods: (isRepairing) =>
+    set(() => ({
+      isRepairingMods: isRepairing,
+    })),
+
+  setModRepairReason: (remoteId, repairReason) =>
+    set((state) => ({
+      localMods: state.localMods.map((mod) =>
+        mod.remoteId === remoteId ? { ...mod, repairReason } : mod,
+      ),
+    })),
+
   getModProgress: (remoteId) => get().modProgress[remoteId],
 
   setInstalledVpks: (
@@ -333,6 +355,10 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         installedVpks: mod.remoteId === remoteId ? vpks : mod.installedVpks,
         installedFileTree:
           mod.remoteId === remoteId ? fileTree : mod.installedFileTree,
+        repairReason:
+          mod.remoteId === remoteId && vpks.length > 0
+            ? undefined
+            : mod.repairReason,
       })),
     })),
 

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -782,6 +782,7 @@ export const createProfilesSlice: StateCreator<
       const enabledVpkSet = new Set(
         allVpks.filter((vpk) => enabledVpkPattern.test(vpk)),
       );
+      const allVpkSet = new Set(allVpks);
 
       const updatedEnabledMods: Record<string, ModProfileEntry> = {};
       const updatedLocalMods: LocalMod[] = [];
@@ -792,9 +793,15 @@ export const createProfilesSlice: StateCreator<
 
         if (manifestEntry) {
           const currentVpks = manifestEntry.currentVpks ?? [];
+          const disabledVpks = manifestEntry.disabledVpks ?? [];
           const hasEnabledVpks =
             manifestEntry.enabled &&
             currentVpks.some((vpk) => enabledVpkSet.has(vpk));
+          const hasDisabledVpks =
+            !manifestEntry.enabled &&
+            disabledVpks.some((vpk) => allVpkSet.has(vpk));
+          const existingRepairReason =
+            mod.status === ModStatus.NeedsRepair ? mod.repairReason : undefined;
 
           if (hasEnabledVpks) {
             updatedEnabledMods[mod.remoteId] = {
@@ -806,8 +813,11 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Installed,
+              repairReason: undefined,
               installedVpks: currentVpks,
               installOrder: manifestEntry.order ?? mod.installOrder,
+              repairDownloads:
+                manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
           } else {
             if (manifestEntry.enabled) {
@@ -826,9 +836,20 @@ export const createProfilesSlice: StateCreator<
 
             updatedLocalMods.push({
               ...mod,
-              status: ModStatus.Downloaded,
+              status: manifestEntry.enabled
+                ? ModStatus.NeedsRepair
+                : hasDisabledVpks
+                  ? ModStatus.Downloaded
+                  : ModStatus.NeedsRepair,
+              repairReason: manifestEntry.enabled
+                ? (existingRepairReason ?? "missingEnabledVpks")
+                : hasDisabledVpks
+                  ? undefined
+                  : (existingRepairReason ?? "missingPayload"),
               installedVpks: [],
               installOrder: manifestEntry.order ?? mod.installOrder,
+              repairDownloads:
+                manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
           }
 
@@ -848,8 +869,54 @@ export const createProfilesSlice: StateCreator<
           disabledVpksForMod.length > 0 || enabledVpksForMod.length > 0;
 
         if (!hasVpksInProfile) {
-          // Mod doesn't have any VPKs in this profile
-          updatedLocalMods.push(mod);
+          const staleEnabledState =
+            mod.status === ModStatus.Installed ||
+            profile.enabledMods[mod.remoteId]?.enabled === true;
+
+          if (staleEnabledState) {
+            logger
+              .withMetadata({ profileId, remoteId: mod.remoteId })
+              .warn(
+                "Profile thinks mod is enabled but no manifest entry or VPK files exist; marking repairable",
+              );
+
+            updatedLocalMods.push({
+              ...mod,
+              status: ModStatus.NeedsRepair,
+              repairReason:
+                mod.status === ModStatus.NeedsRepair
+                  ? (mod.repairReason ?? "missingPayload")
+                  : "missingPayload",
+              installedVpks: [],
+            });
+
+            seedEntries.push({
+              modId: mod.remoteId,
+              enabled: true,
+              currentVpks: [],
+              disabledVpks: [],
+              originalVpkNames: [],
+              order: mod.installOrder ?? null,
+            });
+          } else {
+            const missingDownloadedPayload =
+              mod.status === ModStatus.Downloaded ||
+              mod.status === ModStatus.FailedToInstall;
+
+            updatedLocalMods.push(
+              missingDownloadedPayload
+                ? {
+                    ...mod,
+                    status: ModStatus.NeedsRepair,
+                    repairReason:
+                      mod.status === ModStatus.NeedsRepair
+                        ? (mod.repairReason ?? "missingPayload")
+                        : "missingPayload",
+                    installedVpks: [],
+                  }
+                : mod,
+            );
+          }
           continue;
         }
 
@@ -868,11 +935,13 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Installed,
+              repairReason: undefined,
               installedVpks: enabledVpksForMod,
             });
           } else {
             updatedLocalMods.push({
               ...mod,
+              repairReason: undefined,
               installedVpks: enabledVpksForMod,
             });
           }
@@ -891,9 +960,13 @@ export const createProfilesSlice: StateCreator<
             updatedLocalMods.push({
               ...mod,
               status: ModStatus.Downloaded,
+              repairReason: undefined,
             });
           } else {
-            updatedLocalMods.push(mod);
+            updatedLocalMods.push({
+              ...mod,
+              repairReason: undefined,
+            });
           }
 
           seedEntries.push({
@@ -952,6 +1025,7 @@ export const createProfilesSlice: StateCreator<
   restoreModsFromManifest: async () => {
     const { localMods, activeProfileId, profiles } = get();
     if (localMods.length > 0) {
+      await get().syncProfileEnabledMods(activeProfileId);
       return;
     }
 
@@ -961,8 +1035,12 @@ export const createProfilesSlice: StateCreator<
     }
 
     let manifest: VpkManifest = { version: 0, mods: {} };
+    let allVpks: string[] = [];
     try {
       manifest = await invoke<VpkManifest>("get_profile_vpk_manifest", {
+        profileFolder: profile.folderName,
+      });
+      allVpks = await invoke<string[]>("get_profile_installed_vpks", {
         profileFolder: profile.folderName,
       });
     } catch (error) {
@@ -984,24 +1062,35 @@ export const createProfilesSlice: StateCreator<
 
     const restoredMods: LocalMod[] = [];
     const enabledMods: Record<string, ModProfileEntry> = {};
+    const enabledVpkSet = new Set(
+      allVpks.filter((vpk) => /^pak\d+_dir\.vpk$/i.test(vpk)),
+    );
 
     for (const [modId, entry] of manifestEntries) {
       try {
         const modDetails = await getMod(modId);
         const currentVpks = entry.currentVpks ?? [];
-        const isEnabled = entry.enabled && currentVpks.length > 0;
+        const hasEnabledVpks =
+          entry.enabled && currentVpks.some((vpk) => enabledVpkSet.has(vpk));
+        const needsRepair = entry.enabled && !hasEnabledVpks;
 
         const restoredMod: LocalMod = {
           ...modDetails,
-          status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
-          installedVpks: isEnabled ? currentVpks : [],
+          status: hasEnabledVpks
+            ? ModStatus.Installed
+            : needsRepair
+              ? ModStatus.NeedsRepair
+              : ModStatus.Downloaded,
+          repairReason: needsRepair ? "missingEnabledVpks" : undefined,
+          installedVpks: hasEnabledVpks ? currentVpks : [],
           installOrder: entry.order ?? restoredMods.length,
           downloadedAt: new Date(),
+          repairDownloads: entry.sourceDownloads,
         };
 
         restoredMods.push(restoredMod);
 
-        if (isEnabled) {
+        if (hasEnabledVpks) {
           enabledMods[modId] = {
             remoteId: modId,
             enabled: true,
@@ -1010,7 +1099,12 @@ export const createProfilesSlice: StateCreator<
         }
 
         logger
-          .withMetadata({ modId, name: modDetails.name, isEnabled })
+          .withMetadata({
+            modId,
+            name: modDetails.name,
+            hasEnabledVpks,
+            needsRepair,
+          })
           .info("Restored mod from manifest");
       } catch (error) {
         logger

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1816,6 +1816,15 @@
     "likesLabel": "Likes",
     "modStatusLabel": "Status",
     "detectedHero": "Hero",
+    "changeHero": "Change hero",
+    "heroOverrideAutomatic": "Use automatic",
+    "heroSource": {
+      "manual": "Manual",
+      "api": "API",
+      "name": "Name",
+      "vpk": "VPK",
+      "none": "Unset"
+    },
     "viewOriginalPost": "View Post on GameBanana",
     "updateMod": "Update Mod",
     "forceUpdate": "Force Update",

--- a/apps/desktop/src/pages/mods.tsx
+++ b/apps/desktop/src/pages/mods.tsx
@@ -39,6 +39,7 @@ import { useScrollPosition } from "@/hooks/use-scroll-position";
 import { useSearch } from "@/hooks/use-search";
 import { getMods } from "@/lib/api-client";
 import { ModCategory, TimePeriod } from "@/lib/constants";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { STALE_TIME_API } from "@/lib/query-constants";
 import { usePersistedStore } from "@/lib/store";
 import { getTimePeriodCutoff } from "@/lib/utils";
@@ -178,6 +179,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     showFavoritesOnly = false,
   } = modsFilters;
   const favorites = usePersistedStore((state) => state.favorites);
+  const localMods = usePersistedStore((state) => state.localMods);
   const effectiveMapQuickFilter: MapQuickFilter = mapsOnly
     ? "only"
     : isCustomMapsEnabled
@@ -209,6 +211,10 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     data: deferredData,
     keys: SEARCH_KEYS,
   });
+  const localModsByRemoteId = useMemo(
+    () => new Map(localMods.map((mod) => [mod.remoteId, mod])),
+    [localMods],
+  );
   const filteredResults = useMemo(() => {
     let filtered = results;
 
@@ -232,14 +238,16 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
 
     if (selectedHeroes.length > 0) {
       filtered = filtered.filter((mod) => {
+        const resolvedHero = resolveModHero(
+          mod,
+          localModsByRemoteId.get(mod.remoteId),
+        ).hero;
         let matchesHero = false;
 
         if (selectedHeroes.includes("None")) {
-          matchesHero =
-            !mod.hero ||
-            (mod.hero !== null && selectedHeroes.includes(mod.hero));
+          matchesHero = !resolvedHero || selectedHeroes.includes(resolvedHero);
         } else {
-          matchesHero = mod.hero !== null && selectedHeroes.includes(mod.hero);
+          matchesHero = !!resolvedHero && selectedHeroes.includes(resolvedHero);
         }
 
         return filterMode === "include" ? matchesHero : !matchesHero;
@@ -284,6 +292,7 @@ const GetModsData = ({ mapsOnly }: { mapsOnly?: boolean }) => {
     return filtered;
   }, [
     results,
+    localModsByRemoteId,
     selectedCategories,
     selectedHeroes,
     filterMode,

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -93,6 +93,7 @@ import {
   filterLibraryModsByStatus,
   ModFilter,
 } from "@/lib/mods/library-display";
+import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import type {
   AudioQuickFilter,
@@ -652,12 +653,14 @@ const MyMods = () => {
 
     if (selectedHeroes.length > 0) {
       filteredMods = filteredMods.filter((mod) => {
+        const resolvedHero = resolveModHero(mod, mod).hero;
         let matchesHero = false;
 
         if (selectedHeroes.includes("None")) {
-          matchesHero = !mod.hero || selectedHeroes.includes(mod.hero);
+          matchesHero = !resolvedHero || selectedHeroes.includes(resolvedHero);
         } else {
-          matchesHero = mod.hero !== null && selectedHeroes.includes(mod.hero);
+          matchesHero =
+            resolvedHero !== null && selectedHeroes.includes(resolvedHero);
         }
 
         return filterMode === "include" ? matchesHero : !matchesHero;

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -38,6 +38,7 @@ export interface LocalMod extends ModDto {
   installedFileTree?: ModFileTree;
   installOrder?: number;
   detectedHero?: string | null;
+  heroOverride?: string | null;
   usesCriticalPaths?: boolean;
 }
 

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -5,6 +5,16 @@ import type { VpkParsed } from "@deadlock-mods/vpk-parser";
 
 // Individual download item type extracted from ModDownloadDto schema
 export type ModDownloadItem = z.infer<typeof ModDownloadDtoSchema>;
+export type RepairDownloadItem = Pick<
+  ModDownloadItem,
+  "name" | "size" | "url"
+> &
+  Partial<
+    Pick<
+      ModDownloadItem,
+      "createdAt" | "description" | "md5Checksum" | "updatedAt"
+    >
+  >;
 
 export type Progress = {
   progress: number;
@@ -26,13 +36,23 @@ export enum ModStatus {
   Removed = "removed",
   FailedToRemove = "failedToRemove",
   Error = "error",
+  NeedsRepair = "needsRepair",
 }
+
+export type RepairReason =
+  | "missingEnabledVpks"
+  | "missingPayload"
+  | "needsDownloadChoice"
+  | "needsFileSelection"
+  | "repairFailed";
 
 export interface LocalMod extends ModDto {
   status: ModStatus;
   downloadedAt?: Date;
   downloads?: ModDownloadItem[];
   selectedDownloads?: ModDownloadItem[];
+  repairDownloads?: RepairDownloadItem[];
+  repairReason?: RepairReason;
   activeVariantArchive?: string;
   installedVpks?: string[];
   installedFileTree?: ModFileTree;

--- a/apps/desktop/src/types/profiles.ts
+++ b/apps/desktop/src/types/profiles.ts
@@ -1,4 +1,5 @@
 import type { LocalMod } from "@/types/mods";
+import type { RepairDownloadItem } from "@/types/mods";
 
 export type ProfileId = string & { readonly __brand: unique symbol };
 
@@ -26,6 +27,15 @@ export interface VpkManifestEntry {
   currentVpks: string[];
   disabledVpks: string[];
   originalVpkNames: string[];
+  sourceDownloads?: RepairDownloadItem[];
+  vpkFingerprints?: Array<{
+    currentName: string;
+    originalName: string;
+    fileSize: number;
+    fastHash: string;
+    sha256: string;
+    manifestSha256: string;
+  }>;
 }
 
 export interface VpkManifest {

--- a/packages/shared/src/heroes.ts
+++ b/packages/shared/src/heroes.ts
@@ -1,48 +1,148 @@
 import { DeadlockHeroes, DeadlockHeroesByAlias } from "./constants";
 
+const normalizeHeroKey = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/['`]/g, "")
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const toHero = (hero: DeadlockHeroes): DeadlockHeroes =>
+  DeadlockHeroes[DeadlockHeroesByAlias[hero] as keyof typeof DeadlockHeroes];
+
+const knownAliases = new Map<string, DeadlockHeroes>();
+
+const addAliases = (hero: DeadlockHeroes, aliases: string[]) => {
+  for (const alias of [hero, DeadlockHeroesByAlias[hero], ...aliases]) {
+    knownAliases.set(normalizeHeroKey(alias), toHero(hero));
+  }
+};
+
+const escapeRegex = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const tokenPattern = (pattern: string): RegExp =>
+  new RegExp(`(?:^|[^a-z0-9])${pattern}(?:$|[^a-z0-9])`, "i");
+
+const word = (value: string): RegExp => tokenPattern(escapeRegex(value));
+
+const phrase = (...parts: string[]): RegExp =>
+  tokenPattern(parts.map(escapeRegex).join("[^a-z0-9]+"));
+
+addAliases(DeadlockHeroes.Abrams, [
+  "atlas",
+  "atlas detective",
+  "atlas detective v2",
+]);
+addAliases(DeadlockHeroes.Apollo, ["fencer"]);
+addAliases(DeadlockHeroes.Bebop, []);
+addAliases(DeadlockHeroes.Billy, ["punkgoat"]);
+addAliases(DeadlockHeroes.Calico, ["cadence", "nano"]);
+addAliases(DeadlockHeroes.Celeste, ["unicorn"]);
+addAliases(DeadlockHeroes.Doorman, ["doorman v2"]);
+addAliases(DeadlockHeroes.Drifter, []);
+addAliases(DeadlockHeroes.Dynamo, ["prof dynamo"]);
+addAliases(DeadlockHeroes.Graves, ["necro"]);
+addAliases(DeadlockHeroes.GreyTalon, ["archer", "archer v2", "greytalon"]);
+addAliases(DeadlockHeroes.Haze, ["haze v2"]);
+addAliases(DeadlockHeroes.Holliday, ["astro"]);
+addAliases(DeadlockHeroes.Infernus, ["inferno", "inferno v4"]);
+addAliases(DeadlockHeroes.Ivy, ["tengu"]);
+addAliases(DeadlockHeroes.Kelvin, ["kelvin explorer", "kelvin v2"]);
+addAliases(DeadlockHeroes.LadyGeist, ["geist", "ghost", "ladygeist"]);
+addAliases(DeadlockHeroes.Lash, ["lash v2"]);
+addAliases(DeadlockHeroes.McGinnis, ["engineer"]);
+addAliases(DeadlockHeroes.Mina, ["vampirebat"]);
+addAliases(DeadlockHeroes.Mirage, ["mirage v2"]);
+addAliases(DeadlockHeroes.MoKrill, ["digger", "mo krill", "mokrill"]);
+addAliases(DeadlockHeroes.Paige, ["bookworm"]);
+addAliases(DeadlockHeroes.Paradox, ["chrono"]);
+addAliases(DeadlockHeroes.Pocket, ["synth"]);
+addAliases(DeadlockHeroes.Rem, ["familiar"]);
+addAliases(DeadlockHeroes.Seven, ["7", "gigawatt", "gigawatt prisoner"]);
+addAliases(DeadlockHeroes.Shiv, ["shiv ult"]);
+addAliases(DeadlockHeroes.Silver, ["werewolf"]);
+addAliases(DeadlockHeroes.Sinclair, ["magician", "magician v2"]);
+addAliases(DeadlockHeroes.Venator, ["priest"]);
+addAliases(DeadlockHeroes.Victor, ["frank", "frank v2", "viktor"]);
+addAliases(DeadlockHeroes.Vindicta, ["hornet", "hornet v3"]);
+addAliases(DeadlockHeroes.Viscous, []);
+addAliases(DeadlockHeroes.Vyper, ["viper"]);
+addAliases(DeadlockHeroes.Warden, []);
+addAliases(DeadlockHeroes.Wraith, [
+  "wraith gen man",
+  "wraith magician",
+  "wraith puppeteer",
+]);
+addAliases(DeadlockHeroes.Wrecker, ["butcher"]);
+addAliases(DeadlockHeroes.Yamato, ["yamato v2"]);
+
 const knownRegexes = {
-  [DeadlockHeroes.Abrams]: [/abrams/i, /brams/i],
-  [DeadlockHeroes.Apollo]: [/apollo/i],
-  [DeadlockHeroes.Bebop]: [/bebop/i],
-  [DeadlockHeroes.Billy]: [/billy/i],
-  [DeadlockHeroes.Calico]: [/calico/i],
-  [DeadlockHeroes.Celeste]: [/celeste/i],
-  [DeadlockHeroes.Doorman]: [/doorman/i],
-  [DeadlockHeroes.Drifter]: [/drifter/i],
-  [DeadlockHeroes.Dynamo]: [/dynamo/i],
-  [DeadlockHeroes.Graves]: [/graves/i],
-  [DeadlockHeroes.GreyTalon]: [/talon/i, /grey talon/i],
-  [DeadlockHeroes.Haze]: [/haze/i],
-  [DeadlockHeroes.Holliday]: [/holliday/i],
-  [DeadlockHeroes.Infernus]: [/infernus/i, /fernus/i],
-  [DeadlockHeroes.Ivy]: [/ivy/i],
-  [DeadlockHeroes.Kelvin]: [/kelvin/i],
-  [DeadlockHeroes.LadyGeist]: [/geist/i, /gaist/i, /lady/i, /lady geist/i],
-  [DeadlockHeroes.Lash]: [/lash/i],
-  [DeadlockHeroes.McGinnis]: [/mcginnis/i],
-  [DeadlockHeroes.Mina]: [/mina/i],
-  [DeadlockHeroes.Mirage]: [/mirage/i],
-  [DeadlockHeroes.MoKrill]: [/krill/i, /mo & krill/i, /mo and krill/i],
-  [DeadlockHeroes.Paige]: [/paige/i],
-  [DeadlockHeroes.Paradox]: [/paradox/i, /dox/i],
-  [DeadlockHeroes.Pocket]: [/pocket/i],
-  [DeadlockHeroes.Rem]: [/rem/i],
-  [DeadlockHeroes.Seven]: [/seven/i],
-  [DeadlockHeroes.Shiv]: [/shiv/i],
-  [DeadlockHeroes.Silver]: [/silver/i],
-  [DeadlockHeroes.Sinclair]: [/sinclair/i],
-  [DeadlockHeroes.Venator]: [/venator/i],
-  [DeadlockHeroes.Victor]: [/victor/i],
-  [DeadlockHeroes.Vindicta]: [/vindicta/i],
-  [DeadlockHeroes.Viscous]: [/viscous/i],
-  [DeadlockHeroes.Vyper]: [/vyper/i, /viper/i],
-  [DeadlockHeroes.Warden]: [/warden/i],
-  [DeadlockHeroes.Wraith]: [/wraith/i],
-  [DeadlockHeroes.Wrecker]: [/wrecker/i],
-  [DeadlockHeroes.Yamato]: [/yamato/i],
+  [DeadlockHeroes.Abrams]: [word("abrams"), word("brams")],
+  [DeadlockHeroes.Apollo]: [word("apollo")],
+  [DeadlockHeroes.Bebop]: [word("bebop")],
+  [DeadlockHeroes.Billy]: [word("billy")],
+  [DeadlockHeroes.Calico]: [word("calico")],
+  [DeadlockHeroes.Celeste]: [word("celeste")],
+  [DeadlockHeroes.Doorman]: [word("doorman")],
+  [DeadlockHeroes.Drifter]: [word("drifter")],
+  [DeadlockHeroes.Dynamo]: [word("dynamo")],
+  [DeadlockHeroes.Graves]: [word("graves")],
+  [DeadlockHeroes.GreyTalon]: [word("talon"), phrase("grey", "talon")],
+  [DeadlockHeroes.Haze]: [word("haze")],
+  [DeadlockHeroes.Holliday]: [word("holliday")],
+  [DeadlockHeroes.Infernus]: [word("infernus"), word("fernus")],
+  [DeadlockHeroes.Ivy]: [word("ivy")],
+  [DeadlockHeroes.Kelvin]: [word("kelvin")],
+  [DeadlockHeroes.LadyGeist]: [
+    word("geist"),
+    word("gaist"),
+    phrase("lady", "geist"),
+    tokenPattern("lady[^a-z0-9]*geist"),
+  ],
+  [DeadlockHeroes.Lash]: [word("lash")],
+  [DeadlockHeroes.McGinnis]: [word("mcginnis")],
+  [DeadlockHeroes.Mina]: [word("mina")],
+  [DeadlockHeroes.Mirage]: [word("mirage")],
+  [DeadlockHeroes.MoKrill]: [
+    word("krill"),
+    phrase("mo", "krill"),
+    phrase("mo", "and", "krill"),
+    tokenPattern("mo[^a-z0-9]*krill"),
+  ],
+  [DeadlockHeroes.Paige]: [word("paige")],
+  [DeadlockHeroes.Paradox]: [word("paradox"), word("dox")],
+  [DeadlockHeroes.Pocket]: [word("pocket")],
+  [DeadlockHeroes.Rem]: [word("rem")],
+  [DeadlockHeroes.Seven]: [word("seven"), word("7")],
+  [DeadlockHeroes.Shiv]: [word("shiv")],
+  [DeadlockHeroes.Silver]: [word("silver")],
+  [DeadlockHeroes.Sinclair]: [word("sinclair")],
+  [DeadlockHeroes.Venator]: [word("venator")],
+  [DeadlockHeroes.Victor]: [word("victor"), word("viktor")],
+  [DeadlockHeroes.Vindicta]: [word("vindicta")],
+  [DeadlockHeroes.Viscous]: [word("viscous")],
+  [DeadlockHeroes.Vyper]: [word("vyper"), word("viper")],
+  [DeadlockHeroes.Warden]: [word("warden")],
+  [DeadlockHeroes.Wraith]: [word("wraith")],
+  [DeadlockHeroes.Wrecker]: [word("wrecker")],
+  [DeadlockHeroes.Yamato]: [word("yamato")],
+};
+
+export const normalizeHero = (
+  value: string | null | undefined,
+): DeadlockHeroes | null => {
+  if (!value) return null;
+  return knownAliases.get(normalizeHeroKey(value)) ?? null;
 };
 
 export const guessHero = (value: string): DeadlockHeroes | null => {
+  const exactHero = normalizeHero(value);
+  if (exactHero) return exactHero;
+
   for (const [hero, regex] of Object.entries(knownRegexes)) {
     if (regex.some((r) => r.test(value.toLowerCase()))) {
       return DeadlockHeroes[

--- a/packages/shared/src/tests/heroes.spec.ts
+++ b/packages/shared/src/tests/heroes.spec.ts
@@ -1,10 +1,35 @@
 import { expect, test } from "vitest";
 import { DeadlockHeroes } from "../constants";
-import { guessHero } from "../heroes";
+import { guessHero, normalizeHero } from "../heroes";
 
 test("guessHero", () => {
   expect(guessHero("Raiden | Yamato Skin")).toBe(DeadlockHeroes.Yamato);
   expect(guessHero("Viscous")).toBe(DeadlockHeroes.Viscous);
   expect(guessHero("Alternative Geist")).toBe(DeadlockHeroes.LadyGeist);
   expect(guessHero("Victor Skin Pack")).toBe(DeadlockHeroes.Victor);
+  expect(guessHero("Toon Viktor")).toBe(DeadlockHeroes.Victor);
+  expect(guessHero("Toon 7")).toBe(DeadlockHeroes.Seven);
+  expect(guessHero("Yoshi -> Rem")).toBe(DeadlockHeroes.Rem);
+  expect(guessHero("ZZZ Trigger Vindicta remodel")).toBe(
+    DeadlockHeroes.Vindicta,
+  );
+});
+
+test("normalizeHero", () => {
+  expect(normalizeHero("Victor")).toBe(DeadlockHeroes.Victor);
+  expect(normalizeHero("Viktor")).toBe(DeadlockHeroes.Victor);
+  expect(normalizeHero("LadyGeist")).toBe(DeadlockHeroes.LadyGeist);
+  expect(normalizeHero("MoKrill")).toBe(DeadlockHeroes.MoKrill);
+  expect(normalizeHero("gigawatt_prisoner")).toBe(DeadlockHeroes.Seven);
+  expect(normalizeHero("not a hero")).toBeNull();
+});
+
+test("guessHero avoids common substring false positives", () => {
+  expect(guessHero("ZZZ Trigger Vindicta remodel")).toBe(
+    DeadlockHeroes.Vindicta,
+  );
+  expect(guessHero("Slash effect pack")).toBeNull();
+  expect(guessHero("Seventh anniversary pack")).toBeNull();
+  expect(guessHero("Ladybug skin pack")).toBeNull();
+  expect(guessHero("Remodel pack")).toBeNull();
 });


### PR DESCRIPTION
## Summary
- add manifest v2 repair metadata, source downloads, and fingerprinting support
- expose a Tauri command to refresh repair metadata with a narrower manager lock scope
- classify restored/synced profile entries as repairable and persist repair state through desktop store/types/state machine
- refresh repair metadata best-effort after VPK reorder operations

## Stack
Base: \codex/desktop-hero-resolution-ui\

Depends on:
- merged #470
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/483
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/484
- Next: \codex/vpk-file-operation-consistency\

## Tests
- \cargo check\ from \pps/desktop/src-tauri\
- \pnpm --filter @deadlock-mods/desktop check-types\

## Notes
- Retry/rollback/uninstall file-operation consistency is intentionally split into the next PR.

Recreated from https://github.com/oldreceipt/deadlock-mod-manager/pull/3
Original author: @oldreceipt