### PR TITLE
fix(desktop): make VPK operations more consistent

### DIFF
--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -304,7 +304,7 @@ impl ModManager {
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     let manifest_entry = manifest.mods.get(&mod_id).cloned();
 
-    let (installed_vpks, original_vpk_names) = if let Some(entry) = manifest_entry.as_ref()
+    let (mut installed_vpks, mut original_vpk_names) = if let Some(entry) = manifest_entry.as_ref()
       && !entry.current_vpks.is_empty()
     {
       log::info!("Using manifest VPK state for mod {mod_id}");
@@ -343,6 +343,53 @@ impl ModManager {
         "Cannot disable mod {mod_id}: no enabled VPK files are recorded for this profile"
       )));
     };
+
+    let existing_vpk_pairs = installed_vpks
+      .iter()
+      .enumerate()
+      .filter_map(|(index, vpk_name)| {
+        if addons_path.join(vpk_name).exists() {
+          Some((
+            vpk_name.clone(),
+            original_vpk_names
+              .get(index)
+              .cloned()
+              .unwrap_or_else(|| vpk_name.clone()),
+          ))
+        } else {
+          None
+        }
+      })
+      .collect::<Vec<_>>();
+
+    if existing_vpk_pairs.len() != installed_vpks.len() {
+      if existing_vpk_pairs.is_empty() {
+        log::warn!(
+          "Mod {mod_id} is marked enabled but none of its enabled VPK files exist; marking it disabled without renaming files"
+        );
+        manifest.mark_disabled(&mod_id, Vec::new(), original_vpk_names);
+        manifest.save(&addons_path)?;
+
+        if let Some(mut local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
+          local_mod.installed_vpks = Vec::new();
+          self.mod_repository.add_mod(local_mod);
+        }
+
+        return Ok(());
+      }
+
+      log::warn!(
+        "Mod {mod_id} is missing some enabled VPK files; disabling only the files that still exist"
+      );
+      installed_vpks = existing_vpk_pairs
+        .iter()
+        .map(|(vpk_name, _)| vpk_name.clone())
+        .collect();
+      original_vpk_names = existing_vpk_pairs
+        .into_iter()
+        .map(|(_, original_name)| original_name)
+        .collect();
+    }
 
     let prefixed_vpks =
       self

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -3,8 +3,14 @@ use crate::mod_manager::filesystem_helper::FileSystemHelper;
 use log;
 use regex::Regex;
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::sync::LazyLock;
+use std::thread;
+use std::time::Duration;
+
+const VPK_FILE_OPERATION_RETRIES: usize = 5;
+const VPK_FILE_OPERATION_RETRY_DELAY: Duration = Duration::from_millis(150);
 
 /// Manages VPK file operations and installation
 pub struct VpkManager {
@@ -183,12 +189,13 @@ impl VpkManager {
       let vpk_name = vpk_name.as_ref();
       let vpk_path = addons_path.join(vpk_name);
       if vpk_path.exists()
-        && let Err(e) = fs::OpenOptions::new().write(true).open(&vpk_path) {
-          log::error!(
-            "Cannot access {label_for_log} for removal (file may be in use): {vpk_name}: {e}"
-          );
-          locked_files.push(vpk_name.to_string());
-        }
+        && let Err(e) = fs::OpenOptions::new().write(true).open(&vpk_path)
+      {
+        log::error!(
+          "Cannot access {label_for_log} for removal (file may be in use): {vpk_name}: {e}"
+        );
+        locked_files.push(vpk_name.to_string());
+      }
     }
 
     if !locked_files.is_empty() {
@@ -202,6 +209,8 @@ impl VpkManager {
     addons_path: &Path,
     renamed: Vec<(String, String)>,
     original_error: std::io::Error,
+    operation: &str,
+    vpk_name: &str,
   ) -> Error {
     let mut rollback_failures = Vec::new();
     for (from_name, to_name) in renamed.into_iter().rev() {
@@ -220,7 +229,66 @@ impl VpkManager {
         rollback_failures.join(", ")
       ))
     } else {
-      original_error.into()
+      Self::vpk_file_operation_error(operation, vpk_name, original_error)
+    }
+  }
+
+  fn is_transient_vpk_file_lock_error(error: &io::Error) -> bool {
+    matches!(
+      error.raw_os_error(),
+      // Windows sharing violation, lock violation, and access denied.
+      Some(32 | 33 | 5)
+    ) || matches!(
+      error.kind(),
+      io::ErrorKind::PermissionDenied | io::ErrorKind::WouldBlock
+    )
+  }
+
+  fn retry_vpk_file_operation(
+    operation: &str,
+    vpk_name: &str,
+    mut run: impl FnMut() -> io::Result<()>,
+  ) -> io::Result<()> {
+    let mut last_error = None;
+
+    for attempt in 0..=VPK_FILE_OPERATION_RETRIES {
+      match run() {
+        Ok(()) => return Ok(()),
+        Err(error) => {
+          let should_retry =
+            attempt < VPK_FILE_OPERATION_RETRIES && Self::is_transient_vpk_file_lock_error(&error);
+          if should_retry {
+            log::warn!(
+              "VPK {operation} for {vpk_name} failed because the file may be temporarily locked; retrying ({}/{}) after {}ms: {error}",
+              attempt + 1,
+              VPK_FILE_OPERATION_RETRIES,
+              VPK_FILE_OPERATION_RETRY_DELAY.as_millis()
+            );
+            last_error = Some(error);
+            thread::sleep(VPK_FILE_OPERATION_RETRY_DELAY);
+          } else {
+            return Err(error);
+          }
+        }
+      }
+    }
+
+    Err(last_error.unwrap_or_else(|| io::Error::other("VPK file operation failed")))
+  }
+
+  fn retry_vpk_rename(from: &Path, to: &Path, vpk_name: &str) -> io::Result<()> {
+    Self::retry_vpk_file_operation("rename", vpk_name, || fs::rename(from, to))
+  }
+
+  fn retry_vpk_remove(path: &Path, vpk_name: &str) -> io::Result<()> {
+    Self::retry_vpk_file_operation("remove", vpk_name, || fs::remove_file(path))
+  }
+
+  fn vpk_file_operation_error(operation: &str, vpk_name: &str, error: io::Error) -> Error {
+    if Self::is_transient_vpk_file_lock_error(&error) {
+      Error::VpkInUse(format!("{vpk_name} ({operation} failed: {error})"))
+    } else {
+      Error::Io(error)
     }
   }
 
@@ -447,7 +515,7 @@ impl VpkManager {
       let new_name = format!("pak{next_number:02}_dir.vpk");
       let new_path = addons_path.join(&new_name);
 
-      if let Err(e) = fs::rename(&old_path, &new_path) {
+      if let Err(e) = Self::retry_vpk_rename(&old_path, &new_path, prefixed_name) {
         log::error!(
           "Failed to enable VPK {prefixed_name}: {e}, rolling back {count} already-renamed file(s)",
           count = renamed.len()
@@ -456,6 +524,8 @@ impl VpkManager {
           addons_path,
           renamed,
           e,
+          "enable",
+          prefixed_name,
         ));
       }
 
@@ -518,7 +588,7 @@ impl VpkManager {
         log::info!(
           "Prefixed destination already exists (newly staged variant), removing old active VPK: {vpk_name}"
         );
-        if let Err(e) = fs::remove_file(&old_path) {
+        if let Err(e) = Self::retry_vpk_remove(&old_path, &vpk_name) {
           log::error!(
             "Failed to remove old active VPK {vpk_name}: {e}, rolling back {count} already-renamed file(s)",
             count = renamed.len()
@@ -527,9 +597,11 @@ impl VpkManager {
             addons_path,
             renamed,
             e,
+            "disable",
+            &vpk_name,
           ));
         }
-      } else if let Err(e) = fs::rename(&old_path, &new_path) {
+      } else if let Err(e) = Self::retry_vpk_rename(&old_path, &new_path, &vpk_name) {
         log::error!(
           "Failed to disable VPK {vpk_name}: {e}, rolling back {count} already-renamed file(s)",
           count = renamed.len()
@@ -538,6 +610,8 @@ impl VpkManager {
           addons_path,
           renamed,
           e,
+          "disable",
+          &vpk_name,
         ));
       }
 
@@ -657,13 +731,10 @@ impl VpkManager {
           "Selected VPK not found for mod {mod_id}: {prefixed}, restoring previous state"
         );
         if !previously_prefixed.is_empty()
-          && let Err(restore_err) =
-            self.enable_vpks(addons_path, mod_id, &previously_prefixed)
-          {
-            log::error!(
-              "Failed to restore previous state for mod {mod_id}: {restore_err}"
-            );
-          }
+          && let Err(restore_err) = self.enable_vpks(addons_path, mod_id, &previously_prefixed)
+        {
+          log::error!("Failed to restore previous state for mod {mod_id}: {restore_err}");
+        }
         return Err(Error::ModFileNotFound);
       }
     }
@@ -675,13 +746,10 @@ impl VpkManager {
           "Failed to enable selected VPKs for mod {mod_id}: {e}, restoring previous state"
         );
         if !previously_prefixed.is_empty()
-          && let Err(restore_err) =
-            self.enable_vpks(addons_path, mod_id, &previously_prefixed)
-          {
-            log::error!(
-              "Failed to restore previous state for mod {mod_id}: {restore_err}"
-            );
-          }
+          && let Err(restore_err) = self.enable_vpks(addons_path, mod_id, &previously_prefixed)
+        {
+          log::error!("Failed to restore previous state for mod {mod_id}: {restore_err}");
+        }
         Err(e)
       }
     }

--- a/apps/desktop/src/hooks/use-uninstall.ts
+++ b/apps/desktop/src/hooks/use-uninstall.ts
@@ -82,9 +82,11 @@ const useUninstall = () => {
     } catch (error) {
       logger.errorOnly(error);
 
-      if (remove && isTauriError(error) && error.kind === "vpkInUse") {
-        toast.error(t("mods.deleteError"), {
-          description: t("mods.deleteErrorVpkInUse"),
+      if (isTauriError(error) && error.kind === "vpkInUse") {
+        toast.error(remove ? t("mods.deleteError") : t("mods.disableError"), {
+          description: remove
+            ? t("mods.deleteErrorVpkInUse")
+            : t("mods.disableErrorVpkInUse"),
         });
         return;
       }


### PR DESCRIPTION
## Summary
- retry transient Windows VPK rename/remove lock failures before surfacing an error
- preserve rollback behavior while classifying transient file lock failures as VPK-in-use errors
- handle enabled mods whose recorded VPK files are missing during disable/uninstall flows
- show VPK-in-use messaging for both delete and disable actions

## Stack
Base: \codex/vpk-repair-metadata-foundation\

Depends on:
- merged #470
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/483
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/484
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/485
- Next: \codex/broken-mod-repair-ux\

## Tests
- \cargo check\ from \pps/desktop/src-tauri\
- \pnpm --filter @deadlock-mods/desktop check-types\

Recreated from https://github.com/oldreceipt/deadlock-mod-manager/pull/4
Original author: @oldreceipt