### PR TITLE
feat(desktop): add broken mod repair UX

### DIFF
--- a/.changeset/quiet-pans-guard.md
+++ b/.changeset/quiet-pans-guard.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Validate manifest VPK fingerprints before reorder so stale slot names cannot remap one mod to another mod's payload.

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
 use crate::errors::Error;
+use crate::mod_manager::Mod;
 use crate::mod_manager::archive_extractor::ArchiveExtractor;
 use crate::mod_manager::file_tree::{ModFile, ModFileTree};
 use crate::mod_manager::filesystem_helper::FileSystemHelper;
 use crate::mod_manager::vpk_manager::VpkManager;
-use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
-use crate::mod_manager::Mod;
+use crate::mod_manager::vpk_manifest::{ProfileVpkManifest, ProfileVpkManifestSourceDownload};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -31,9 +31,7 @@ fn sanitize_archive_name(name: &str) -> Result<String, Error> {
   let path = std::path::Path::new(name);
   match path.file_name().and_then(|f| f.to_str()) {
     Some(f) if f == name => Ok(f.to_string()),
-    _ => Err(Error::InvalidInput(format!(
-      "Invalid archive name: {name}"
-    ))),
+    _ => Err(Error::InvalidInput(format!("Invalid archive name: {name}"))),
   }
 }
 
@@ -54,9 +52,9 @@ fn validate_download_url(url: &str) -> Result<(), Error> {
     .host_str()
     .ok_or_else(|| Error::InvalidInput(format!("Download URL has no host: {url}")))?;
 
-  let is_allowed = ALLOWED_DOWNLOAD_HOSTS.iter().any(|allowed| {
-    host == *allowed || host.ends_with(&format!(".{allowed}"))
-  });
+  let is_allowed = ALLOWED_DOWNLOAD_HOSTS
+    .iter()
+    .any(|allowed| host == *allowed || host.ends_with(&format!(".{allowed}")));
 
   if !is_allowed {
     return Err(Error::InvalidInput(format!(
@@ -395,9 +393,7 @@ pub async fn batch_update_mods(
     };
 
     let prefixed_cleanup_count = cleanup_result.unwrap_or(0);
-    if prefixed_cleanup_count == 0
-      && repo_cleanup_count == 0
-      && !mod_data.installed_vpks.is_empty()
+    if prefixed_cleanup_count == 0 && repo_cleanup_count == 0 && !mod_data.installed_vpks.is_empty()
     {
       log::info!(
         "Using frontend-provided VPK list for cleanup of mod {} ({} VPKs)",
@@ -669,16 +665,16 @@ pub async fn register_analyzed_mod(
   if let Some(entry) = manifest.mods.get_mut(&mod_id) {
     entry.original_vpk_names.clear();
   }
+  if let Err(error) = manifest.refresh_repair_metadata(&addons_path, &mod_id) {
+    log::warn!("Failed to fingerprint analyzed VPKs for mod {mod_id}: {error}");
+  }
   manifest.save(&addons_path)?;
   log::info!("Persisted analyzed mod {mod_id} to profile manifest");
 
   Ok(())
 }
 
-fn resolve_addons_path(
-  game_path: &std::path::Path,
-  profile_folder: Option<&str>,
-) -> PathBuf {
+fn resolve_addons_path(game_path: &std::path::Path, profile_folder: Option<&str>) -> PathBuf {
   let base = game_path.join("game").join("citadel").join("addons");
   match profile_folder {
     Some(folder) => base.join(folder),
@@ -762,8 +758,7 @@ pub async fn get_mod_available_options(
   }
   available.sort();
 
-  let selected_set: std::collections::HashSet<String> =
-    enabled_originals.into_iter().collect();
+  let selected_set: std::collections::HashSet<String> = enabled_originals.into_iter().collect();
   Ok(build_options_file_tree(&available, &selected_set))
 }
 
@@ -844,7 +839,15 @@ pub async fn swap_mod_options(
   }
 
   let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-  manifest.mark_enabled(&mod_id, new_installed_vpks.clone(), selected_original_names.clone(), None);
+  manifest.mark_enabled(
+    &mod_id,
+    new_installed_vpks.clone(),
+    selected_original_names.clone(),
+    None,
+  );
+  if let Err(error) = manifest.refresh_repair_metadata(&addons_path, &mod_id) {
+    log::warn!("Failed to refresh VPK fingerprints after swapping options for {mod_id}: {error}");
+  }
   manifest.save(&addons_path)?;
 
   Ok(SwapModOptionsResult {
@@ -958,10 +961,9 @@ pub async fn fetch_missing_mod_variants(
       )));
     }
 
-    let bytes = response
-      .bytes()
-      .await
-      .map_err(|e| Error::DownloadFailed(format!("Failed reading body for {}: {e}", archive.url)))?;
+    let bytes = response.bytes().await.map_err(|e| {
+      Error::DownloadFailed(format!("Failed reading body for {}: {e}", archive.url))
+    })?;
 
     let temp_dir = tempfile::tempdir()?;
     let archive_path = temp_dir.path().join(&safe_archive_name);
@@ -1022,9 +1024,7 @@ pub async fn stage_download_archive(
   archive_url: String,
   archive_name: String,
 ) -> Result<StageDownloadArchiveResult, Error> {
-  log::info!(
-    "Staging download archive for {mod_id} (profile: {profile_folder:?}): {archive_name}"
-  );
+  log::info!("Staging download archive for {mod_id} (profile: {profile_folder:?}): {archive_name}");
 
   let game_path = {
     let manager = MANAGER.lock().unwrap();
@@ -1150,7 +1150,11 @@ pub async fn switch_mod_download_variant(
   validate_download_url(&archive_url)?;
   let safe_archive_name = sanitize_archive_name(&archive_name)?;
 
-  log::info!("Downloading archive {} from {}", safe_archive_name, archive_url);
+  log::info!(
+    "Downloading archive {} from {}",
+    safe_archive_name,
+    archive_url
+  );
 
   let client = reqwest::Client::builder()
     .build()
@@ -1190,7 +1194,12 @@ pub async fn switch_mod_download_variant(
 
   let new_originals: Vec<String> = vpk_files
     .iter()
-    .filter_map(|(path, _)| path.file_name().and_then(|s| s.to_str()).map(|s| s.to_string()))
+    .filter_map(|(path, _)| {
+      path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+    })
     .collect();
 
   if new_originals.is_empty() {
@@ -1294,7 +1303,26 @@ pub async fn switch_mod_download_variant(
   }
 
   let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-  manifest.mark_enabled(&mod_id, new_installed_vpks.clone(), new_originals.clone(), None);
+  manifest.mark_enabled(
+    &mod_id,
+    new_installed_vpks.clone(),
+    new_originals.clone(),
+    None,
+  );
+  if let Err(error) = manifest.update_repair_metadata(
+    &addons_path,
+    &mod_id,
+    vec![ProfileVpkManifestSourceDownload {
+      name: archive_name,
+      size: 0,
+      url: Some(archive_url),
+      md5_checksum: None,
+    }],
+  ) {
+    log::warn!(
+      "Failed to refresh VPK fingerprints after switching download variant for {mod_id}: {error}"
+    );
+  }
   manifest.save(&addons_path)?;
 
   Ok(SwitchDownloadVariantResult {

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -662,8 +662,14 @@ pub async fn register_analyzed_mod(
   manifest.mark_enabled(&mod_id, installed_vpks, Vec::new(), install_order);
   // mark_enabled skips overwriting original_vpk_names when passed empty,
   // so explicitly clear stale originals from a previous install.
+  let assigned_order = manifest.mods.get(&mod_id).and_then(|entry| entry.order);
   if let Some(entry) = manifest.mods.get_mut(&mod_id) {
     entry.original_vpk_names.clear();
+  }
+  if let Some(existing) = mod_manager.get_mod_repository().get_mod(&mod_id).cloned() {
+    let mut updated = existing;
+    updated.install_order = assigned_order;
+    mod_manager.get_mod_repository_mut().add_mod(updated);
   }
   if let Err(error) = manifest.refresh_repair_metadata(&addons_path, &mod_id) {
     log::warn!("Failed to fingerprint analyzed VPKs for mod {mod_id}: {error}");

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -567,8 +567,9 @@ pub async fn get_profile_vpk_manifest(
   log::info!("Getting VPK manifest for profile: {profile_folder:?}");
 
   let mut mod_manager = MANAGER.lock().unwrap();
+  let manifest = mod_manager.get_profile_vpk_manifest(profile_folder.clone())?;
   mod_manager.hydrate_mods_from_manifest(profile_folder.clone())?;
-  mod_manager.get_profile_vpk_manifest(profile_folder)
+  Ok(manifest)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -620,7 +620,12 @@ pub async fn seed_profile_vpk_manifest_entries(
         entry.order,
       );
     } else {
-      manifest.mark_disabled(&entry.mod_id, entry.disabled_vpks, entry.original_vpk_names);
+      manifest.mark_disabled(
+        &entry.mod_id,
+        entry.disabled_vpks,
+        entry.original_vpk_names,
+        entry.order,
+      );
     }
     changed = true;
   }

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -267,21 +267,25 @@ impl ModManager {
       });
     }
 
-    log::info!("Adding mod to managed mods list");
-    self.mod_repository.add_mod(deadlock_mod.clone());
-
+    let requested_install_order = deadlock_mod.install_order;
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     manifest.mark_enabled(
       &deadlock_mod.id,
       deadlock_mod.installed_vpks.clone(),
       deadlock_mod.original_vpk_names.clone(),
-      deadlock_mod.install_order,
+      requested_install_order,
     );
+    deadlock_mod.install_order = manifest
+      .mods
+      .get(&deadlock_mod.id)
+      .and_then(|entry| entry.order);
+    log::info!("Adding mod to managed mods list");
+    self.mod_repository.add_mod(deadlock_mod.clone());
     Self::refresh_repair_metadata(&mut manifest, &addons_path, &deadlock_mod.id);
     manifest.save(&addons_path)?;
 
     // If the mod has an install order, trigger a reorder to maintain correct sequence
-    if deadlock_mod.install_order.is_some() {
+    if requested_install_order.is_some() {
       log::info!("Mod has install order, triggering reorder to maintain sequence");
       self.reorder_all_mods_for_profile(profile_folder)?;
     }
@@ -370,7 +374,7 @@ impl ModManager {
         log::warn!(
           "Mod {mod_id} is marked enabled but none of its enabled VPK files exist; marking it disabled without renaming files"
         );
-        manifest.mark_disabled(&mod_id, Vec::new(), original_vpk_names);
+        manifest.mark_disabled(&mod_id, Vec::new(), original_vpk_names, None);
         manifest.save(&addons_path)?;
 
         if let Some(mut local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
@@ -399,7 +403,7 @@ impl ModManager {
         .vpk_manager
         .disable_vpks(&addons_path, &mod_id, &installed_vpks, &original_vpk_names)?;
 
-    manifest.mark_disabled(&mod_id, prefixed_vpks.clone(), original_vpk_names);
+    manifest.mark_disabled(&mod_id, prefixed_vpks.clone(), original_vpk_names, None);
     manifest.save(&addons_path)?;
 
     if let Some(mut local_mod) = self.mod_repository.get_mod(&mod_id).cloned() {
@@ -487,6 +491,7 @@ impl ModManager {
     log::info!("Reordering all mods based on install order for profile: {profile_folder:?}");
 
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    let missing_order_changed = manifest.assign_missing_orders();
     let mut ordered_manifest_entries: Vec<(String, u32, Vec<String>)> = manifest
       .mods
       .iter()
@@ -505,11 +510,13 @@ impl ModManager {
       .into_iter()
       .map(|(mod_id, _, vpks)| (mod_id, vpks))
       .collect();
-    let (mod_vpk_mapping, _fingerprint_mismatch_found) =
+    let (mod_vpk_mapping, fingerprint_mismatch_found) =
       self.filter_reorder_mappings_by_fingerprint(&mut manifest, &addons_path, mod_vpk_mapping)?;
 
     if mod_vpk_mapping.is_empty() {
-      manifest.save(&addons_path)?;
+      if missing_order_changed || fingerprint_mismatch_found {
+        manifest.save(&addons_path)?;
+      }
       log::info!("No enabled manifest VPKs need reordering");
       return Ok(());
     }
@@ -566,6 +573,7 @@ impl ModManager {
     sorted_data.sort_by_key(|(_, _, order)| *order);
 
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    let mut manifest_changed = manifest.assign_missing_orders();
 
     // Log the sorted data
     log::info!("Sorted order:");
@@ -574,7 +582,6 @@ impl ModManager {
     }
 
     let mut mod_vpk_mapping = Vec::new();
-    let mut manifest_changed = false;
     for (remote_id, vpk_files, order) in sorted_data {
       let vpk_files = Self::vpk_filenames(&vpk_files);
       let was_known = manifest.mods.contains_key(&remote_id);
@@ -653,7 +660,7 @@ impl ModManager {
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     let mut mod_vpk_mapping = Vec::new();
     let mut updated_mods = Vec::new();
-    let mut manifest_changed = false;
+    let mut manifest_changed = manifest.assign_missing_orders();
 
     for (mod_id, new_order) in sorted_order {
       if let Some(entry) = manifest.mods.get_mut(&mod_id) {
@@ -921,7 +928,7 @@ impl ModManager {
   ) -> Result<ProfileVpkManifest, Error> {
     let addons_path = self.get_addons_path(profile_folder.as_deref())?;
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-    let mut changed = false;
+    let mut changed = manifest.assign_missing_orders();
     let mod_ids: Vec<String> = manifest.mods.keys().cloned().collect();
 
     for mod_id in mod_ids {
@@ -1051,7 +1058,7 @@ impl ModManager {
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     if installed_vpks.is_empty() {
       let prefixed_vpks = self.vpk_manager.find_prefixed_vpks(&addons_path, &mod_id)?;
-      manifest.mark_disabled(&mod_id, prefixed_vpks, new_original_names);
+      manifest.mark_disabled(&mod_id, prefixed_vpks, new_original_names, None);
     } else {
       manifest.mark_enabled(&mod_id, installed_vpks, new_original_names, None);
       Self::refresh_repair_metadata(&mut manifest, &addons_path, &mod_id);

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -9,16 +9,18 @@ use crate::mod_manager::{
   mod_repository::{Mod, ModRepository},
   steam_manager::SteamManager,
   vpk_manager::VpkManager,
-  vpk_manifest::ProfileVpkManifest,
+  vpk_manifest::{ProfileVpkManifest, ProfileVpkManifestDiskState},
 };
 use log;
 use std::{
   collections::HashSet,
+  fs,
   path::{Component, Path, PathBuf},
 };
 use tauri::Manager;
 
 const UNORDERED_FALLBACK_ORDER: u32 = u32::MAX;
+type ModVpkMapping = Vec<(String, Vec<String>)>;
 
 pub struct ModManager {
   steam_manager: SteamManager,
@@ -275,6 +277,7 @@ impl ModManager {
       deadlock_mod.original_vpk_names.clone(),
       deadlock_mod.install_order,
     );
+    Self::refresh_repair_metadata(&mut manifest, &addons_path, &deadlock_mod.id);
     manifest.save(&addons_path)?;
 
     // If the mod has an install order, trigger a reorder to maintain correct sequence
@@ -422,10 +425,18 @@ impl ModManager {
 
     let addons_path = self.get_addons_path(profile_folder.as_deref())?;
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-    let mut vpks_to_remove = manifest
+    let mut vpks_to_remove: Vec<String> = manifest
       .mods
       .get(&mod_id)
-      .map(|entry| entry.current_vpks.clone())
+      .map(|entry| {
+        entry
+          .current_vpks
+          .iter()
+          .chain(entry.disabled_vpks.iter())
+          .chain(entry.quarantined_vpks.iter())
+          .cloned()
+          .collect()
+      })
       .unwrap_or_default();
 
     if !addons_path.exists() {
@@ -494,8 +505,11 @@ impl ModManager {
       .into_iter()
       .map(|(mod_id, _, vpks)| (mod_id, vpks))
       .collect();
+    let (mod_vpk_mapping, _fingerprint_mismatch_found) =
+      self.filter_reorder_mappings_by_fingerprint(&mut manifest, &addons_path, mod_vpk_mapping)?;
 
     if mod_vpk_mapping.is_empty() {
+      manifest.save(&addons_path)?;
       log::info!("No enabled manifest VPKs need reordering");
       return Ok(());
     }
@@ -519,7 +533,7 @@ impl ModManager {
       }
     }
     for mod_id in updated_mod_ids {
-      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, &mod_id);
+      Self::refresh_repair_metadata(&mut manifest, &addons_path, &mod_id);
     }
 
     manifest.save(&addons_path)?;
@@ -581,8 +595,11 @@ impl ModManager {
       }
     }
 
+    let (mod_vpk_mapping, fingerprint_mismatch_found) =
+      self.filter_reorder_mappings_by_fingerprint(&mut manifest, &addons_path, mod_vpk_mapping)?;
+
     if mod_vpk_mapping.is_empty() {
-      if manifest_changed {
+      if manifest_changed || fingerprint_mismatch_found {
         manifest.save(&addons_path)?;
       }
       log::warn!("No enabled VPK mappings available to reorder");
@@ -607,7 +624,7 @@ impl ModManager {
       }
     }
     for (remote_id, _) in &updated_mappings {
-      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, remote_id);
+      Self::refresh_repair_metadata(&mut manifest, &addons_path, remote_id);
     }
 
     manifest.save(&addons_path)?;
@@ -657,8 +674,11 @@ impl ModManager {
       }
     }
 
+    let (mod_vpk_mapping, fingerprint_mismatch_found) =
+      self.filter_reorder_mappings_by_fingerprint(&mut manifest, &addons_path, mod_vpk_mapping)?;
+
     if mod_vpk_mapping.is_empty() {
-      if manifest_changed {
+      if manifest_changed || fingerprint_mismatch_found {
         manifest.save(&addons_path)?;
       }
       for deadlock_mod in updated_mods {
@@ -695,7 +715,7 @@ impl ModManager {
       }
     }
     for mod_id in updated_mod_ids {
-      Self::refresh_repair_metadata_after_reorder(&mut manifest, &addons_path, &mod_id);
+      Self::refresh_repair_metadata(&mut manifest, &addons_path, &mod_id);
     }
 
     for deadlock_mod in updated_mods {
@@ -708,20 +728,72 @@ impl ModManager {
     Ok(result_mods)
   }
 
-  fn refresh_repair_metadata_after_reorder(
+  fn refresh_repair_metadata(manifest: &mut ProfileVpkManifest, addons_path: &Path, mod_id: &str) {
+    if let Err(e) = manifest.refresh_repair_metadata(addons_path, mod_id) {
+      log::warn!("Failed to refresh repair metadata for {mod_id}: {e}");
+    }
+  }
+
+  fn filter_reorder_mappings_by_fingerprint(
+    &self,
     manifest: &mut ProfileVpkManifest,
     addons_path: &Path,
-    mod_id: &str,
-  ) {
-    let source_downloads = manifest
-      .mods
-      .get(mod_id)
-      .map(|entry| entry.source_downloads.clone())
-      .unwrap_or_default();
+    mod_vpk_mapping: ModVpkMapping,
+  ) -> Result<(ModVpkMapping, bool), Error> {
+    let mut validated_mappings = Vec::new();
+    let mut fingerprint_mismatch_found = false;
 
-    if let Err(e) = manifest.update_repair_metadata(addons_path, mod_id, source_downloads) {
-      log::warn!("Failed to refresh repair metadata for {mod_id} after reorder: {e}");
+    for (mod_id, vpks) in mod_vpk_mapping {
+      let mismatches = manifest.enabled_fingerprint_mismatches(addons_path, &mod_id)?;
+      if mismatches.is_empty() {
+        validated_mappings.push((mod_id, vpks));
+        continue;
+      }
+
+      log::warn!(
+        "Skipping reorder for mod {mod_id} because enabled VPK fingerprint validation failed: {}",
+        mismatches.join("; ")
+      );
+      let quarantined_vpks =
+        self.quarantine_mismatched_enabled_vpks(addons_path, &mod_id, &vpks)?;
+      manifest.mark_enabled_needs_repair(&mod_id, quarantined_vpks);
+      fingerprint_mismatch_found = true;
     }
+
+    Ok((validated_mappings, fingerprint_mismatch_found))
+  }
+
+  fn quarantine_mismatched_enabled_vpks(
+    &self,
+    addons_path: &Path,
+    mod_id: &str,
+    vpks: &[String],
+  ) -> Result<Vec<String>, Error> {
+    let mut quarantined = Vec::new();
+
+    for vpk in vpks {
+      let filename = Self::vpk_filenames(std::slice::from_ref(vpk))
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| vpk.clone());
+      let source = addons_path.join(&filename);
+      if !source.exists() {
+        continue;
+      }
+
+      let mut candidate = format!("{mod_id}_mismatch_{filename}");
+      let mut suffix = 1u32;
+      while addons_path.join(&candidate).exists() {
+        candidate = format!("{mod_id}_mismatch_{suffix}_{filename}");
+        suffix += 1;
+      }
+
+      fs::rename(&source, addons_path.join(&candidate))?;
+      log::warn!("Quarantined mismatched enabled VPK for mod {mod_id}: {filename} -> {candidate}");
+      quarantined.push(candidate);
+    }
+
+    Ok(quarantined)
   }
 
   pub fn clear_mods(&mut self, profile_folder: Option<String>) -> Result<(), Error> {
@@ -837,19 +909,59 @@ impl ModManager {
   }
 
   pub fn get_profile_vpk_manifest(
-    &self,
+    &mut self,
+    profile_folder: Option<String>,
+  ) -> Result<ProfileVpkManifest, Error> {
+    self.verify_profile_vpk_manifest(profile_folder)
+  }
+
+  pub fn verify_profile_vpk_manifest(
+    &mut self,
     profile_folder: Option<String>,
   ) -> Result<ProfileVpkManifest, Error> {
     let addons_path = self.get_addons_path(profile_folder.as_deref())?;
-    ProfileVpkManifest::load(&addons_path)
+    let mut manifest = ProfileVpkManifest::load(&addons_path)?;
+    let mut changed = false;
+    let mod_ids: Vec<String> = manifest.mods.keys().cloned().collect();
+
+    for mod_id in mod_ids {
+      let Some(verification) = manifest.verify_mod_disk_state(&addons_path, &mod_id)? else {
+        continue;
+      };
+
+      if verification.disk_state == ProfileVpkManifestDiskState::Mismatch {
+        let current_vpks = manifest
+          .mods
+          .get(&mod_id)
+          .map(|entry| entry.current_vpks.clone())
+          .unwrap_or_default();
+        if current_vpks.is_empty() {
+          changed |= manifest.apply_mod_verification(&mod_id, verification);
+          continue;
+        }
+
+        let quarantined_vpks =
+          self.quarantine_mismatched_enabled_vpks(&addons_path, &mod_id, &current_vpks)?;
+        manifest.mark_enabled_needs_repair(&mod_id, quarantined_vpks);
+        changed = true;
+        continue;
+      }
+
+      changed |= manifest.apply_mod_verification(&mod_id, verification);
+    }
+
+    if changed {
+      manifest.save(&addons_path)?;
+    }
+
+    Ok(manifest)
   }
 
   pub fn hydrate_mods_from_manifest(
     &mut self,
     profile_folder: Option<String>,
   ) -> Result<usize, Error> {
-    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
-    let manifest = ProfileVpkManifest::load(&addons_path)?;
+    let manifest = self.verify_profile_vpk_manifest(profile_folder.clone())?;
 
     let mut hydrated = 0usize;
     for (mod_id, entry) in &manifest.mods {
@@ -857,11 +969,12 @@ impl ModManager {
         continue;
       }
 
-      let installed_vpks = if entry.enabled {
-        entry.current_vpks.clone()
-      } else {
-        Vec::new()
-      };
+      let installed_vpks =
+        if entry.wants_enabled() && entry.disk_state == Some(ProfileVpkManifestDiskState::Active) {
+          entry.current_vpks.clone()
+        } else {
+          Vec::new()
+        };
 
       let deadlock_mod = Mod {
         id: mod_id.clone(),
@@ -877,9 +990,7 @@ impl ModManager {
     }
 
     if hydrated > 0 {
-      log::info!(
-        "Hydrated {hydrated} mods from manifest for profile {profile_folder:?}"
-      );
+      log::info!("Hydrated {hydrated} mods from manifest for profile {profile_folder:?}");
     }
 
     Ok(hydrated)
@@ -939,12 +1050,11 @@ impl ModManager {
 
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
     if installed_vpks.is_empty() {
-      let prefixed_vpks = self
-        .vpk_manager
-        .find_prefixed_vpks(&addons_path, &mod_id)?;
+      let prefixed_vpks = self.vpk_manager.find_prefixed_vpks(&addons_path, &mod_id)?;
       manifest.mark_disabled(&mod_id, prefixed_vpks, new_original_names);
     } else {
       manifest.mark_enabled(&mod_id, installed_vpks, new_original_names, None);
+      Self::refresh_repair_metadata(&mut manifest, &addons_path, &mod_id);
     }
     manifest.save(&addons_path)?;
 

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -471,6 +471,7 @@ impl VpkManager {
     }
 
     let prefix = format!("{mod_id}_");
+    let mismatch_prefix = format!("{prefix}mismatch_");
 
     for entry in fs::read_dir(addons_path)? {
       let entry = entry?;
@@ -480,6 +481,7 @@ impl VpkManager {
         && path.extension().is_some_and(|ext| ext == "vpk")
         && let Some(file_name) = path.file_name().and_then(|n| n.to_str())
         && file_name.starts_with(&prefix)
+        && !file_name.starts_with(&mismatch_prefix)
       {
         prefixed_vpks.push(file_name.to_string());
       }
@@ -956,5 +958,17 @@ mod tests {
         .to_string()
         .contains("original VPK name count (1) does not match installed VPK count (2)")
     );
+  }
+
+  #[test]
+  fn find_prefixed_vpks_excludes_mismatch_quarantine() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "123456_original.vpk");
+    write_vpk(temp.path(), "123456_mismatch_pak27_dir.vpk");
+    let manager = VpkManager::new();
+
+    let prefixed = manager.find_prefixed_vpks(temp.path(), "123456").unwrap();
+
+    assert_eq!(prefixed, vec!["123456_original.vpk".to_string()]);
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -24,12 +24,20 @@ pub struct ProfileVpkManifest {
 pub struct ProfileVpkManifestEntry {
   #[serde(default)]
   pub enabled: bool,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub desired_state: Option<ProfileVpkManifestDesiredState>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub disk_state: Option<ProfileVpkManifestDiskState>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub repair_reason: Option<ProfileVpkManifestRepairReason>,
   #[serde(default)]
   pub order: Option<u32>,
   #[serde(default)]
   pub current_vpks: Vec<String>,
   #[serde(default)]
   pub disabled_vpks: Vec<String>,
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
+  pub quarantined_vpks: Vec<String>,
   #[serde(default)]
   pub original_vpk_names: Vec<String>,
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -58,6 +66,56 @@ pub struct ProfileVpkManifestVpkFingerprint {
   pub fast_hash: String,
   pub sha256: String,
   pub manifest_sha256: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ProfileVpkManifestDesiredState {
+  Enabled,
+  Disabled,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ProfileVpkManifestDiskState {
+  Active,
+  Disabled,
+  Missing,
+  Mismatch,
+  Unverified,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ProfileVpkManifestRepairReason {
+  MissingEnabledVpks,
+  MissingPayload,
+  NeedsDownloadChoice,
+  NeedsFileSelection,
+  RepairFailed,
+  FingerprintMismatch,
+  UnverifiedManifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileVpkManifestVerification {
+  pub disk_state: ProfileVpkManifestDiskState,
+  pub repair_reason: Option<ProfileVpkManifestRepairReason>,
+  pub details: Vec<String>,
+}
+
+impl ProfileVpkManifestEntry {
+  pub fn desired_state(&self) -> ProfileVpkManifestDesiredState {
+    self.desired_state.unwrap_or(if self.enabled {
+      ProfileVpkManifestDesiredState::Enabled
+    } else {
+      ProfileVpkManifestDesiredState::Disabled
+    })
+  }
+
+  pub fn wants_enabled(&self) -> bool {
+    self.desired_state() == ProfileVpkManifestDesiredState::Enabled
+  }
 }
 
 impl Default for ProfileVpkManifest {
@@ -103,11 +161,74 @@ impl ProfileVpkManifest {
       ))
     })?;
 
+    let mut migrated = manifest.version < CURRENT_MANIFEST_VERSION;
     if manifest.version < CURRENT_MANIFEST_VERSION {
       manifest.version = CURRENT_MANIFEST_VERSION;
     }
 
+    for entry in manifest.mods.values_mut() {
+      if entry.desired_state.is_none() {
+        entry.desired_state = Some(if entry.enabled {
+          ProfileVpkManifestDesiredState::Enabled
+        } else {
+          ProfileVpkManifestDesiredState::Disabled
+        });
+        migrated = true;
+      }
+      if entry.disk_state.is_none() {
+        entry.disk_state = Some(Self::legacy_disk_state(entry));
+        entry.repair_reason = if !entry.wants_enabled()
+          && entry.disk_state == Some(ProfileVpkManifestDiskState::Missing)
+        {
+          Some(ProfileVpkManifestRepairReason::MissingPayload)
+        } else {
+          Self::repair_reason_for_disk_state(entry.disk_state.unwrap())
+        };
+        migrated = true;
+      }
+    }
+
+    if migrated {
+      log::info!(
+        "Loaded legacy VPK manifest at {}; in-memory state was migrated to version {CURRENT_MANIFEST_VERSION}",
+        manifest_path.display()
+      );
+    }
+
     Ok(manifest)
+  }
+
+  fn legacy_disk_state(entry: &ProfileVpkManifestEntry) -> ProfileVpkManifestDiskState {
+    if entry.wants_enabled() {
+      if entry.current_vpks.is_empty() {
+        ProfileVpkManifestDiskState::Missing
+      } else if entry.vpk_fingerprints.is_empty() {
+        ProfileVpkManifestDiskState::Unverified
+      } else {
+        ProfileVpkManifestDiskState::Active
+      }
+    } else if entry.disabled_vpks.is_empty() {
+      ProfileVpkManifestDiskState::Missing
+    } else {
+      ProfileVpkManifestDiskState::Disabled
+    }
+  }
+
+  fn repair_reason_for_disk_state(
+    disk_state: ProfileVpkManifestDiskState,
+  ) -> Option<ProfileVpkManifestRepairReason> {
+    match disk_state {
+      ProfileVpkManifestDiskState::Active | ProfileVpkManifestDiskState::Disabled => None,
+      ProfileVpkManifestDiskState::Missing => {
+        Some(ProfileVpkManifestRepairReason::MissingEnabledVpks)
+      }
+      ProfileVpkManifestDiskState::Mismatch => {
+        Some(ProfileVpkManifestRepairReason::FingerprintMismatch)
+      }
+      ProfileVpkManifestDiskState::Unverified => {
+        Some(ProfileVpkManifestRepairReason::UnverifiedManifest)
+      }
+    }
   }
 
   pub fn save(&self, addons_path: &Path) -> Result<(), Error> {
@@ -143,12 +264,28 @@ impl ProfileVpkManifest {
     order: Option<u32>,
   ) {
     let entry = self.mods.entry(mod_id.to_string()).or_default();
+    let payload_names_changed = entry.current_vpks != current_vpks
+      || (!original_vpk_names.is_empty() && entry.original_vpk_names != original_vpk_names);
+
     entry.enabled = true;
+    entry.desired_state = Some(ProfileVpkManifestDesiredState::Enabled);
     entry.current_vpks = current_vpks;
     entry.disabled_vpks.clear();
+    entry.quarantined_vpks.clear();
     if !original_vpk_names.is_empty() {
       entry.original_vpk_names = original_vpk_names;
     }
+    if payload_names_changed {
+      entry.vpk_fingerprints.clear();
+    }
+    entry.disk_state = Some(if entry.current_vpks.is_empty() {
+      ProfileVpkManifestDiskState::Missing
+    } else if entry.vpk_fingerprints.is_empty() {
+      ProfileVpkManifestDiskState::Unverified
+    } else {
+      ProfileVpkManifestDiskState::Active
+    });
+    entry.repair_reason = Self::repair_reason_for_disk_state(entry.disk_state.unwrap());
     if order.is_some() {
       entry.order = order;
     }
@@ -162,11 +299,23 @@ impl ProfileVpkManifest {
   ) {
     let entry = self.mods.entry(mod_id.to_string()).or_default();
     entry.enabled = false;
+    entry.desired_state = Some(ProfileVpkManifestDesiredState::Disabled);
     entry.current_vpks.clear();
     entry.disabled_vpks = disabled_vpks;
+    entry.quarantined_vpks.clear();
     if !original_vpk_names.is_empty() {
       entry.original_vpk_names = original_vpk_names;
     }
+    entry.disk_state = Some(if entry.disabled_vpks.is_empty() {
+      ProfileVpkManifestDiskState::Missing
+    } else {
+      ProfileVpkManifestDiskState::Disabled
+    });
+    entry.repair_reason = if entry.disk_state == Some(ProfileVpkManifestDiskState::Missing) {
+      Some(ProfileVpkManifestRepairReason::MissingPayload)
+    } else {
+      None
+    };
   }
 
   pub fn remove_mod(&mut self, mod_id: &str) {
@@ -186,7 +335,196 @@ impl ProfileVpkManifest {
     entry.source_downloads = source_downloads;
     entry.vpk_fingerprints =
       Self::fingerprints_for_entry(addons_path, &entry.current_vpks, &entry.original_vpk_names)?;
+    if entry.wants_enabled() {
+      entry.disk_state = Some(if entry.current_vpks.is_empty() {
+        ProfileVpkManifestDiskState::Missing
+      } else if entry.vpk_fingerprints.len() == entry.current_vpks.len() {
+        ProfileVpkManifestDiskState::Active
+      } else {
+        ProfileVpkManifestDiskState::Missing
+      });
+      entry.repair_reason = Self::repair_reason_for_disk_state(entry.disk_state.unwrap());
+    }
     Ok(())
+  }
+
+  pub fn refresh_repair_metadata(&mut self, addons_path: &Path, mod_id: &str) -> Result<(), Error> {
+    let source_downloads = self
+      .mods
+      .get(mod_id)
+      .map(|entry| entry.source_downloads.clone())
+      .unwrap_or_default();
+
+    self.update_repair_metadata(addons_path, mod_id, source_downloads)
+  }
+
+  pub fn enabled_fingerprint_mismatches(
+    &self,
+    addons_path: &Path,
+    mod_id: &str,
+  ) -> Result<Vec<String>, Error> {
+    let Some(entry) = self.mods.get(mod_id) else {
+      return Ok(Vec::new());
+    };
+
+    if !entry.wants_enabled() || entry.current_vpks.is_empty() {
+      return Ok(Vec::new());
+    }
+
+    if entry.vpk_fingerprints.is_empty() {
+      return Ok(vec![
+        "enabled VPKs have no stored fingerprints and cannot be verified".to_string(),
+      ]);
+    }
+
+    if entry.current_vpks.len() != entry.vpk_fingerprints.len() {
+      return Ok(vec![format!(
+        "expected {} VPK fingerprints, found {} enabled VPK names",
+        entry.vpk_fingerprints.len(),
+        entry.current_vpks.len()
+      )]);
+    }
+
+    let current_fingerprints =
+      Self::fingerprints_for_entry(addons_path, &entry.current_vpks, &entry.original_vpk_names)?;
+
+    let mut mismatches = Vec::new();
+    for (index, expected) in entry.vpk_fingerprints.iter().enumerate() {
+      let Some(actual) = current_fingerprints.get(index) else {
+        mismatches.push(format!(
+          "{} is missing",
+          entry
+            .current_vpks
+            .get(index)
+            .cloned()
+            .unwrap_or_else(|| format!("VPK #{index}"))
+        ));
+        continue;
+      };
+
+      if actual.file_size != expected.file_size
+        || actual.sha256 != expected.sha256
+        || actual.manifest_sha256 != expected.manifest_sha256
+      {
+        mismatches.push(format!(
+          "{} no longer matches stored fingerprint for {}",
+          actual.current_name, expected.original_name
+        ));
+      }
+    }
+
+    Ok(mismatches)
+  }
+
+  pub fn mark_enabled_needs_repair(&mut self, mod_id: &str, quarantined_vpks: Vec<String>) {
+    if let Some(entry) = self.mods.get_mut(mod_id) {
+      entry.enabled = true;
+      entry.desired_state = Some(ProfileVpkManifestDesiredState::Enabled);
+      entry.current_vpks.clear();
+      entry.quarantined_vpks = quarantined_vpks;
+      entry.disk_state = Some(if entry.quarantined_vpks.is_empty() {
+        ProfileVpkManifestDiskState::Missing
+      } else {
+        ProfileVpkManifestDiskState::Mismatch
+      });
+      entry.repair_reason = Self::repair_reason_for_disk_state(entry.disk_state.unwrap());
+    }
+  }
+
+  pub fn verify_mod_disk_state(
+    &self,
+    addons_path: &Path,
+    mod_id: &str,
+  ) -> Result<Option<ProfileVpkManifestVerification>, Error> {
+    let Some(entry) = self.mods.get(mod_id) else {
+      return Ok(None);
+    };
+
+    if entry.wants_enabled() {
+      if entry.current_vpks.is_empty() {
+        let disk_state = if entry.quarantined_vpks.is_empty() {
+          ProfileVpkManifestDiskState::Missing
+        } else {
+          ProfileVpkManifestDiskState::Mismatch
+        };
+        return Ok(Some(ProfileVpkManifestVerification {
+          disk_state,
+          repair_reason: Self::repair_reason_for_disk_state(disk_state),
+          details: Vec::new(),
+        }));
+      }
+
+      let missing: Vec<String> = entry
+        .current_vpks
+        .iter()
+        .filter(|vpk| !addons_path.join(vpk).exists())
+        .cloned()
+        .collect();
+      if !missing.is_empty() {
+        return Ok(Some(ProfileVpkManifestVerification {
+          disk_state: ProfileVpkManifestDiskState::Missing,
+          repair_reason: Some(ProfileVpkManifestRepairReason::MissingEnabledVpks),
+          details: missing,
+        }));
+      }
+
+      let mismatches = self.enabled_fingerprint_mismatches(addons_path, mod_id)?;
+      if entry.vpk_fingerprints.is_empty() {
+        return Ok(Some(ProfileVpkManifestVerification {
+          disk_state: ProfileVpkManifestDiskState::Unverified,
+          repair_reason: Some(ProfileVpkManifestRepairReason::UnverifiedManifest),
+          details: mismatches,
+        }));
+      }
+      if !mismatches.is_empty() {
+        return Ok(Some(ProfileVpkManifestVerification {
+          disk_state: ProfileVpkManifestDiskState::Mismatch,
+          repair_reason: Some(ProfileVpkManifestRepairReason::FingerprintMismatch),
+          details: mismatches,
+        }));
+      }
+
+      return Ok(Some(ProfileVpkManifestVerification {
+        disk_state: ProfileVpkManifestDiskState::Active,
+        repair_reason: None,
+        details: Vec::new(),
+      }));
+    }
+
+    let disabled_missing = entry.disabled_vpks.is_empty()
+      || entry
+        .disabled_vpks
+        .iter()
+        .any(|vpk| !addons_path.join(vpk).exists());
+    if disabled_missing {
+      return Ok(Some(ProfileVpkManifestVerification {
+        disk_state: ProfileVpkManifestDiskState::Missing,
+        repair_reason: Some(ProfileVpkManifestRepairReason::MissingPayload),
+        details: entry.disabled_vpks.clone(),
+      }));
+    }
+
+    Ok(Some(ProfileVpkManifestVerification {
+      disk_state: ProfileVpkManifestDiskState::Disabled,
+      repair_reason: None,
+      details: Vec::new(),
+    }))
+  }
+
+  pub fn apply_mod_verification(
+    &mut self,
+    mod_id: &str,
+    verification: ProfileVpkManifestVerification,
+  ) -> bool {
+    let Some(entry) = self.mods.get_mut(mod_id) else {
+      return false;
+    };
+
+    let changed = entry.disk_state != Some(verification.disk_state)
+      || entry.repair_reason != verification.repair_reason;
+    entry.disk_state = Some(verification.disk_state);
+    entry.repair_reason = verification.repair_reason;
+    changed
   }
 
   fn fingerprints_for_entry(
@@ -328,6 +666,102 @@ mod tests {
     assert_eq!(entry.original_vpk_names, vec!["cool_mod.vpk".to_string()]);
     assert_eq!(entry.current_vpks, vec!["pak02_dir.vpk".to_string()]);
     assert_eq!(entry.order, Some(1));
+  }
+
+  #[test]
+  fn mark_enabled_clears_stale_fingerprints_when_payload_changes() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["first.vpk".to_string()],
+      Some(0),
+    );
+    manifest
+      .mods
+      .get_mut("123")
+      .unwrap()
+      .vpk_fingerprints
+      .push(ProfileVpkManifestVpkFingerprint {
+        current_name: "pak01_dir.vpk".to_string(),
+        original_name: "first.vpk".to_string(),
+        file_size: 1,
+        fast_hash: "fast".to_string(),
+        sha256: "sha".to_string(),
+        manifest_sha256: "manifest".to_string(),
+      });
+
+    manifest.mark_enabled(
+      "123",
+      vec!["pak02_dir.vpk".to_string()],
+      vec!["second.vpk".to_string()],
+      Some(0),
+    );
+
+    assert!(
+      manifest
+        .mods
+        .get("123")
+        .unwrap()
+        .vpk_fingerprints
+        .is_empty()
+    );
+  }
+
+  #[test]
+  fn verify_enabled_without_fingerprints_is_unverified() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::write(
+      temp.path().join("pak01_dir.vpk"),
+      b"not parsed without expected fingerprints",
+    )
+    .unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["original.vpk".to_string()],
+      Some(0),
+    );
+
+    let verification = manifest
+      .verify_mod_disk_state(temp.path(), "123")
+      .unwrap()
+      .unwrap();
+
+    assert_eq!(
+      verification.disk_state,
+      ProfileVpkManifestDiskState::Unverified
+    );
+    assert_eq!(
+      verification.repair_reason,
+      Some(ProfileVpkManifestRepairReason::UnverifiedManifest)
+    );
+  }
+
+  #[test]
+  fn mark_enabled_needs_repair_tracks_quarantine_separately() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["original.vpk".to_string()],
+      Some(0),
+    );
+
+    manifest.mark_enabled_needs_repair("123", vec!["123_mismatch_pak01_dir.vpk".to_string()]);
+    let entry = manifest.mods.get("123").unwrap();
+
+    assert!(entry.current_vpks.is_empty());
+    assert!(entry.disabled_vpks.is_empty());
+    assert_eq!(
+      entry.quarantined_vpks,
+      vec!["123_mismatch_pak01_dir.vpk".to_string()]
+    );
+    assert_eq!(
+      entry.disk_state,
+      Some(ProfileVpkManifestDiskState::Mismatch)
+    );
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -231,6 +231,58 @@ impl ProfileVpkManifest {
     }
   }
 
+  fn next_available_order(&self) -> u32 {
+    let mut orders: Vec<u32> = self.mods.values().filter_map(|entry| entry.order).collect();
+    orders.sort_unstable();
+    orders.dedup();
+
+    if let Some(max_order) = orders.last()
+      && let Some(next_order) = max_order.checked_add(1)
+    {
+      return next_order;
+    }
+
+    let mut next_order = 0u32;
+    for order in orders {
+      if order == next_order {
+        if let Some(incremented) = next_order.checked_add(1) {
+          next_order = incremented;
+        }
+      } else if order > next_order {
+        break;
+      }
+    }
+    next_order
+  }
+
+  fn resolved_order(&self, mod_id: &str, order: Option<u32>) -> u32 {
+    order
+      .or_else(|| self.mods.get(mod_id).and_then(|entry| entry.order))
+      .unwrap_or_else(|| self.next_available_order())
+  }
+
+  pub fn assign_missing_orders(&mut self) -> bool {
+    let mod_ids_without_order: Vec<String> = self
+      .mods
+      .iter()
+      .filter(|(_, entry)| entry.order.is_none())
+      .map(|(mod_id, _)| mod_id.clone())
+      .collect();
+
+    if mod_ids_without_order.is_empty() {
+      return false;
+    }
+
+    for mod_id in mod_ids_without_order {
+      let order = self.resolved_order(&mod_id, None);
+      if let Some(entry) = self.mods.get_mut(&mod_id) {
+        entry.order = Some(order);
+      }
+    }
+
+    true
+  }
+
   pub fn save(&self, addons_path: &Path) -> Result<(), Error> {
     fs::create_dir_all(addons_path)?;
 
@@ -263,6 +315,7 @@ impl ProfileVpkManifest {
     original_vpk_names: Vec<String>,
     order: Option<u32>,
   ) {
+    let order = self.resolved_order(mod_id, order);
     let entry = self.mods.entry(mod_id.to_string()).or_default();
     let payload_names_changed = entry.current_vpks != current_vpks
       || (!original_vpk_names.is_empty() && entry.original_vpk_names != original_vpk_names);
@@ -286,9 +339,7 @@ impl ProfileVpkManifest {
       ProfileVpkManifestDiskState::Active
     });
     entry.repair_reason = Self::repair_reason_for_disk_state(entry.disk_state.unwrap());
-    if order.is_some() {
-      entry.order = order;
-    }
+    entry.order = Some(order);
   }
 
   pub fn mark_disabled(
@@ -296,7 +347,9 @@ impl ProfileVpkManifest {
     mod_id: &str,
     disabled_vpks: Vec<String>,
     original_vpk_names: Vec<String>,
+    order: Option<u32>,
   ) {
+    let order = self.resolved_order(mod_id, order);
     let entry = self.mods.entry(mod_id.to_string()).or_default();
     entry.enabled = false;
     entry.desired_state = Some(ProfileVpkManifestDesiredState::Disabled);
@@ -316,6 +369,7 @@ impl ProfileVpkManifest {
     } else {
       None
     };
+    entry.order = Some(order);
   }
 
   pub fn remove_mod(&mut self, mod_id: &str) {
@@ -328,10 +382,14 @@ impl ProfileVpkManifest {
     mod_id: &str,
     source_downloads: Vec<ProfileVpkManifestSourceDownload>,
   ) -> Result<(), Error> {
+    let order = self.resolved_order(mod_id, None);
     let Some(entry) = self.mods.get_mut(mod_id) else {
       return Ok(());
     };
 
+    if entry.order.is_none() {
+      entry.order = Some(order);
+    }
     entry.source_downloads = source_downloads;
     entry.vpk_fingerprints =
       Self::fingerprints_for_entry(addons_path, &entry.current_vpks, &entry.original_vpk_names)?;
@@ -417,6 +475,7 @@ impl ProfileVpkManifest {
   }
 
   pub fn mark_enabled_needs_repair(&mut self, mod_id: &str, quarantined_vpks: Vec<String>) {
+    let order = self.resolved_order(mod_id, None);
     if let Some(entry) = self.mods.get_mut(mod_id) {
       entry.enabled = true;
       entry.desired_state = Some(ProfileVpkManifestDesiredState::Enabled);
@@ -428,6 +487,9 @@ impl ProfileVpkManifest {
         ProfileVpkManifestDiskState::Mismatch
       });
       entry.repair_reason = Self::repair_reason_for_disk_state(entry.disk_state.unwrap());
+      if entry.order.is_none() {
+        entry.order = Some(order);
+      }
     }
   }
 
@@ -516,14 +578,19 @@ impl ProfileVpkManifest {
     mod_id: &str,
     verification: ProfileVpkManifestVerification,
   ) -> bool {
+    let order = self.resolved_order(mod_id, None);
     let Some(entry) = self.mods.get_mut(mod_id) else {
       return false;
     };
 
     let changed = entry.disk_state != Some(verification.disk_state)
-      || entry.repair_reason != verification.repair_reason;
+      || entry.repair_reason != verification.repair_reason
+      || entry.order.is_none();
     entry.disk_state = Some(verification.disk_state);
     entry.repair_reason = verification.repair_reason;
+    if entry.order.is_none() {
+      entry.order = Some(order);
+    }
     changed
   }
 
@@ -666,6 +733,104 @@ mod tests {
     assert_eq!(entry.original_vpk_names, vec!["cool_mod.vpk".to_string()]);
     assert_eq!(entry.current_vpks, vec!["pak02_dir.vpk".to_string()]);
     assert_eq!(entry.order, Some(1));
+  }
+
+  #[test]
+  fn mark_enabled_assigns_next_order_when_missing() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "existing",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["existing.vpk".to_string()],
+      Some(3),
+    );
+
+    manifest.mark_enabled(
+      "new",
+      vec!["pak02_dir.vpk".to_string()],
+      vec!["new.vpk".to_string()],
+      None,
+    );
+
+    assert_eq!(manifest.mods.get("new").unwrap().order, Some(4));
+  }
+
+  #[test]
+  fn mark_enabled_preserves_existing_order_when_order_is_missing() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["original.vpk".to_string()],
+      Some(7),
+    );
+
+    manifest.mark_enabled(
+      "123",
+      vec!["pak02_dir.vpk".to_string()],
+      vec!["replacement.vpk".to_string()],
+      None,
+    );
+
+    assert_eq!(manifest.mods.get("123").unwrap().order, Some(7));
+  }
+
+  #[test]
+  fn mark_disabled_assigns_order_when_missing() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "existing",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["existing.vpk".to_string()],
+      Some(2),
+    );
+
+    manifest.mark_disabled(
+      "disabled",
+      vec!["disabled_pak01_dir.vpk".to_string()],
+      vec!["pak01_dir.vpk".to_string()],
+      None,
+    );
+
+    assert_eq!(manifest.mods.get("disabled").unwrap().order, Some(3));
+  }
+
+  #[test]
+  fn assign_missing_orders_backfills_null_entries() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mods.insert(
+      "ordered".to_string(),
+      ProfileVpkManifestEntry {
+        order: Some(5),
+        ..Default::default()
+      },
+    );
+    manifest.mods.insert(
+      "missing".to_string(),
+      ProfileVpkManifestEntry {
+        order: None,
+        ..Default::default()
+      },
+    );
+
+    assert!(manifest.assign_missing_orders());
+    assert_eq!(manifest.mods.get("missing").unwrap().order, Some(6));
+  }
+
+  #[test]
+  fn saved_enabled_entries_do_not_serialize_null_order() {
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled(
+      "123",
+      vec!["pak01_dir.vpk".to_string()],
+      vec!["original.vpk".to_string()],
+      None,
+    );
+
+    let json = serde_json::to_string(&manifest).unwrap();
+
+    assert!(!json.contains("\"order\":null"));
+    assert!(json.contains("\"order\":0"));
   }
 
   #[test]

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -2,6 +2,7 @@ import { Button } from "@deadlock-mods/ui/components/button";
 import { Card } from "@deadlock-mods/ui/components/card";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Pause, Play } from "@phosphor-icons/react";
+import type { TFunction } from "i18next";
 import { type MouseEvent, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -21,7 +22,10 @@ type StatusChipVariant = {
   dotClass: string;
 };
 
-const getStatusVariant = (status: ModStatus): StatusChipVariant => {
+const getStatusVariant = (
+  status: ModStatus,
+  t: TFunction,
+): StatusChipVariant => {
   switch (status) {
     case ModStatus.Downloading:
       return {
@@ -37,7 +41,7 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
       };
     case ModStatus.Paused:
       return {
-        label: "Paused",
+        label: t("downloads.paused"),
         pillClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
         dotClass: "bg-amber-500",
       };
@@ -59,6 +63,12 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
         pillClass: "bg-primary/15 text-primary",
         dotClass: "bg-primary",
       };
+    case ModStatus.NeedsRepair:
+      return {
+        label: t("downloads.needsRepair"),
+        pillClass: "bg-amber-500/15 text-amber-800 dark:text-amber-300",
+        dotClass: "bg-amber-500",
+      };
     case ModStatus.FailedToDownload:
       return {
         label: "Failed",
@@ -76,9 +86,7 @@ const getStatusVariant = (status: ModStatus): StatusChipVariant => {
 
 const StatusChip = ({ status }: { status: ModStatus }) => {
   const { t } = useTranslation();
-  const variant = getStatusVariant(status);
-  const label =
-    status === ModStatus.Paused ? t("downloads.paused") : variant.label;
+  const variant = getStatusVariant(status, t);
   return (
     <span
       className={cn(
@@ -89,7 +97,7 @@ const StatusChip = ({ status }: { status: ModStatus }) => {
         aria-hidden
         className={cn("size-1.5 rounded-full", variant.dotClass)}
       />
-      {label}
+      {variant.label}
     </span>
   );
 };

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -2,6 +2,7 @@ import type { ModDto } from "@deadlock-mods/shared";
 import { Button } from "@deadlock-mods/ui/components/button";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Switch } from "@deadlock-mods/ui/components/switch";
+import { invoke } from "@tauri-apps/api/core";
 import {
   Tooltip,
   TooltipContent,
@@ -9,8 +10,11 @@ import {
 } from "@deadlock-mods/ui/components/tooltip";
 import {
   Check,
+  CircleHelp,
   DownloadIcon,
   Loader2,
+  PlusIcon,
+  WrenchIcon,
   X,
   XIcon,
 } from "@deadlock-mods/ui/icons";
@@ -31,12 +35,22 @@ import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { useDownload } from "@/hooks/use-download";
 import useInstallWithCollection from "@/hooks/use-install-with-collection";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
+import {
+  normalizeRepairDownloads,
+  useRepairMods,
+} from "@/hooks/use-repair-mods";
 import useUninstall from "@/hooks/use-uninstall";
 import logger from "@/lib/logger";
 import { resolveModHero } from "@/lib/mods/hero-resolution";
 import { usePersistedStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { type LocalMod, ModStatus } from "@/types/mods";
+import {
+  type LocalMod,
+  type ModDownloadItem,
+  ModStatus,
+  type RepairReason,
+} from "@/types/mods";
+import { isTauriError } from "@/types/tauri";
 
 interface ModButtonProps {
   remoteMod: Pick<ModDto, "remoteId" | "name" | "downloadable"> | undefined;
@@ -47,10 +61,12 @@ export const ModStatusIcon = ({
   status,
   hovering,
   className,
+  repairReason,
 }: {
   status: ModStatus | undefined;
   hovering?: boolean;
   className?: string;
+  repairReason?: RepairReason;
 }) => {
   const loadingStatuses = [
     ModStatus.Downloading,
@@ -75,15 +91,23 @@ export const ModStatusIcon = ({
       case ModStatus.FailedToInstall:
       case ModStatus.FailedToRemove:
         return XIcon;
+      case ModStatus.NeedsRepair:
+        if (
+          repairReason === "needsDownloadChoice" ||
+          repairReason === "needsFileSelection"
+        ) {
+          return CircleHelp;
+        }
+        return WrenchIcon;
       case ModStatus.Removed:
       case ModStatus.Error:
         return RiErrorWarningLine;
       case ModStatus.Extracting:
         return Loader2;
       default:
-        return DownloadIcon;
+        return PlusIcon;
     }
-  }, [status, hovering]);
+  }, [status, hovering, repairReason]);
 
   return (
     <Icon
@@ -103,6 +127,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
   const { analytics } = useAnalyticsContext();
   const confirm = useConfirm();
   const localMods = usePersistedStore((state) => state.localMods);
+  const getActiveProfile = usePersistedStore((state) => state.getActiveProfile);
 
   const { availableFiles } = useModDownloads({
     remoteId: remoteMod?.remoteId,
@@ -124,6 +149,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     cancelInstallation,
     currentMod,
   } = useInstallWithCollection();
+  const { repairMod } = useRepairMods();
   const { uninstall } = useUninstall();
   const getModProgress = usePersistedStore((state) => state.getModProgress);
   const setInstalledVpks = usePersistedStore((state) => state.setInstalledVpks);
@@ -143,6 +169,23 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     ((resolution: HeroConflictResolution) => void) | null
   >(null);
 
+  const persistRepairMetadata = useCallback(
+    async (mod: LocalMod, sourceDownloads: ModDownloadItem[]) => {
+      const activeProfile = getActiveProfile();
+      await invoke("update_profile_vpk_manifest_repair_metadata", {
+        profileFolder: activeProfile?.folderName ?? null,
+        modId: mod.remoteId,
+        sourceDownloads: sourceDownloads.map((download) => ({
+          name: download.name,
+          size: download.size ?? 0,
+          url: download.url,
+          md5Checksum: download.md5Checksum ?? null,
+        })),
+      });
+    },
+    [getActiveProfile],
+  );
+
   const performInstall = useCallback(
     async (mod: typeof localMod) => {
       if (!mod) {
@@ -156,7 +199,24 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           setModStatus(m.remoteId, ModStatus.Installed);
           setInstalledVpks(m.remoteId, result.installed_vpks, result.file_tree);
           setModEnabledInCurrentProfile(m.remoteId, true);
-          toast.success(t("notifications.modInstalledSuccessfully"));
+          persistRepairMetadata(
+            m,
+            m.selectedDownloads?.length
+              ? m.selectedDownloads
+              : m.repairDownloads?.length
+                ? normalizeRepairDownloads(m.repairDownloads)
+                : (m.downloads ?? []),
+          ).catch((error) => {
+            logger
+              .withMetadata({ modId: m.remoteId })
+              .withError(error)
+              .warn("Failed to persist VPK repair metadata");
+          });
+          const successMessage =
+            m.status === ModStatus.NeedsRepair
+              ? t("notifications.modRepairedSuccessfully")
+              : t("notifications.modEnabledSuccessfully");
+          toast.success(successMessage);
           analytics.trackModInstalled(m.remoteId, {
             vpk_count: result.installed_vpks.length,
             file_tree_complexity: result.file_tree?.has_multiple_files
@@ -166,7 +226,13 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         },
         onError: (m, error) => {
           setModStatus(m.remoteId, ModStatus.Downloaded);
-          toast.error(error.message || t("notifications.failedToInstallMod"));
+          if (isTauriError(error) && error.kind === "vpkInUse") {
+            toast.error(t("notifications.failedToEnableMod"), {
+              description: t("notifications.enableErrorVpkInUse"),
+            });
+          } else {
+            toast.error(error.message || t("notifications.failedToInstallMod"));
+          }
           analytics.trackError(
             "mod_installation",
             error.message || "Unknown installation error",
@@ -194,6 +260,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
       setModStatus,
       setInstalledVpks,
       setModEnabledInCurrentProfile,
+      persistRepairMetadata,
       t,
       analytics,
     ],
@@ -279,6 +346,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           await uninstall(localMod, false);
           analytics.trackModUninstalled(localMod.remoteId, "user_choice");
           break;
+        case ModStatus.NeedsRepair:
+          await repairMod(localMod, {
+            interactive: true,
+            availableFiles,
+            installInteractively: performInstall,
+            requestDownloadSelection: async () => {
+              await download();
+              toast.info(t("modButton.needsRepairSelectDownload"));
+            },
+          });
+          break;
         case ModStatus.FailedToDownload:
           break;
         case ModStatus.Error:
@@ -302,6 +380,8 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     removeMod,
     askHeroConflict,
     performInstall,
+    repairMod,
+    availableFiles,
     t,
     analytics,
     remoteMod?.remoteId,
@@ -337,12 +417,20 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           return t("modButton.enableMod");
         }
         return t("modButton.downloaded");
+      case ModStatus.NeedsRepair:
+        if (
+          localMod.repairReason === "needsDownloadChoice" ||
+          localMod.repairReason === "needsFileSelection"
+        ) {
+          return t("modButton.chooseRepairSource");
+        }
+        return t("modButton.needsRepair");
       case undefined:
         return t("modButton.add");
       default:
         return t(`modButton.${localMod?.status}`);
     }
-  }, [localMod?.status, t, hovering]);
+  }, [localMod?.status, localMod?.repairReason, t, hovering]);
 
   const tooltip = useMemo(() => {
     switch (localMod?.status) {
@@ -350,12 +438,17 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         return t("modButton.installedTooltip");
       case ModStatus.Downloaded:
         return t("modButton.downloadedTooltip");
+      case ModStatus.NeedsRepair:
+        if (localMod.repairReason) {
+          return t(`modStatus.repairReason.${localMod.repairReason}`);
+        }
+        return t("modButton.needsRepairTooltip");
       case undefined:
         return t("modButton.add");
       default:
         return t(`modButton.${localMod?.status}`);
     }
-  }, [localMod?.status, t]);
+  }, [localMod?.status, localMod?.repairReason, t]);
 
   const buttonVariant = useMemo(() => {
     switch (localMod?.status) {
@@ -369,10 +462,20 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           return "default";
         }
         return "outline";
+      case ModStatus.NeedsRepair:
+        return "outline";
       default:
         return variant === "iconOnly" ? "outline" : "default";
     }
   }, [variant, localMod?.status, hovering]);
+
+  const buttonClassName = useMemo(
+    () =>
+      localMod?.status === ModStatus.NeedsRepair
+        ? "border-amber-500/50 bg-amber-500/10 text-amber-800 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200"
+        : undefined,
+    [localMod?.status],
+  );
 
   return (
     <ErrorBoundary>
@@ -417,13 +520,18 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
             <Button
               disabled={isActionInProgress || isAnalyzing}
               icon={
-                <ModStatusIcon hovering={hovering} status={localMod?.status} />
+                <ModStatusIcon
+                  hovering={hovering}
+                  repairReason={localMod?.repairReason}
+                  status={localMod?.status}
+                />
               }
               onClick={onClick}
               ref={ref}
               size={variant === "iconOnly" ? "icon" : "default"}
               title={text}
-              variant={buttonVariant}>
+              variant={buttonVariant}
+              className={buttonClassName}>
               {variant === "iconOnly" ? null : text}
             </Button>
           </TooltipTrigger>

--- a/apps/desktop/src/components/mod-browsing/mod-card.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-card.tsx
@@ -11,6 +11,7 @@ import {
   UpdateAvailableBadge,
   UpdatedRecentlyBadge,
 } from "@/components/mod-management/mod-update-badges";
+import { NeedsRepairBadge } from "@/components/mod-management/needs-repair-badge";
 import { ObsoleteModWarning } from "@/components/mod-management/obsolete-mod-warning";
 import { OutdatedModWarning } from "@/components/mod-management/outdated-mod-warning";
 import { useThemeOverride } from "@/components/providers/theme-overrides";
@@ -102,6 +103,7 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
           />
         )}
         {(status === ModStatus.Installed ||
+          status === ModStatus.NeedsRepair ||
           mod.isObsolete ||
           isModOutdated(mod) ||
           isUpdatedRecently(mod) ||
@@ -109,6 +111,9 @@ const ModCard = memo(({ mod, readOnly = false }: ModCardProps) => {
           <div className='pointer-events-none absolute inset-x-0 bottom-0 z-10 flex items-end justify-end gap-1 bg-gradient-to-t from-black/60 to-transparent px-2 pb-2 pt-6'>
             {status === ModStatus.Installed && (
               <Badge>{t("modStatus.installed")}</Badge>
+            )}
+            {status === ModStatus.NeedsRepair && (
+              <NeedsRepairBadge reason={localMod?.repairReason} />
             )}
             {mod.isObsolete && <ObsoleteModWarning variant='indicator' />}
             {isModOutdated(mod) && <OutdatedModWarning variant='indicator' />}

--- a/apps/desktop/src/components/mod-management/needs-repair-badge.tsx
+++ b/apps/desktop/src/components/mod-management/needs-repair-badge.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@deadlock-mods/ui/components/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deadlock-mods/ui/components/tooltip";
+import { AlertTriangle, CircleHelp } from "@deadlock-mods/ui/icons";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import type { RepairReason } from "@/types/mods";
+
+type NeedsRepairBadgeProps = {
+  className?: string;
+  reason?: RepairReason;
+};
+
+const manualChoiceReasons = new Set<RepairReason>([
+  "needsDownloadChoice",
+  "needsFileSelection",
+]);
+
+export const NeedsRepairBadge = ({
+  className,
+  reason,
+}: NeedsRepairBadgeProps) => {
+  const { t } = useTranslation();
+  const needsChoice = reason ? manualChoiceReasons.has(reason) : false;
+  const Icon = needsChoice ? CircleHelp : AlertTriangle;
+  const tooltip = reason
+    ? t(`modStatus.repairReason.${reason}`)
+    : t("modStatus.needsRepairTooltip");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          variant='outline'
+          className={cn(
+            "border-amber-500/50 bg-amber-500/15 text-amber-800 hover:bg-amber-500/20 dark:text-amber-300",
+            className,
+          )}>
+          <Icon className='h-3 w-3' />
+          {t("modStatus.needsRepair")}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+};

--- a/apps/desktop/src/components/mod-management/status.tsx
+++ b/apps/desktop/src/components/mod-management/status.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { ModStatus } from "@/types/mods";
+import { NeedsRepairBadge } from "./needs-repair-badge";
 
 const Status = ({ status }: { status: ModStatus }) => {
   const { t } = useTranslation();
@@ -16,6 +17,7 @@ const Status = ({ status }: { status: ModStatus }) => {
         return Loader2;
       case ModStatus.Installed:
         return Check;
+      case ModStatus.NeedsRepair:
       case ModStatus.Error:
         return X;
       default:
@@ -35,12 +37,18 @@ const Status = ({ status }: { status: ModStatus }) => {
         return t("modStatus.paused");
       case ModStatus.Installed:
         return t("modStatus.installed");
+      case ModStatus.NeedsRepair:
+        return t("modStatus.needsRepair");
       case ModStatus.Error:
         return t("modStatus.error");
       default:
         return t("modStatus.unknown");
     }
   }, [status, t]);
+
+  if (status === ModStatus.NeedsRepair) {
+    return <NeedsRepairBadge />;
+  }
 
   return (
     <Badge className='flex w-fit items-center gap-2' variant='secondary'>

--- a/apps/desktop/src/hooks/use-repair-mods.ts
+++ b/apps/desktop/src/hooks/use-repair-mods.ts
@@ -1,0 +1,502 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { invoke } from "@tauri-apps/api/core";
+import { appLocalDataDir, join } from "@tauri-apps/api/path";
+import { useTranslation } from "react-i18next";
+import { getModDownloads } from "@/lib/api-client";
+import { downloadManager } from "@/lib/download/manager";
+import { getErrorMessage } from "@/lib/errors";
+import logger from "@/lib/logger";
+import { usePersistedStore } from "@/lib/store";
+import {
+  type InstallableMod,
+  type LocalMod,
+  type ModDownloadItem,
+  type ModFileTree,
+  ModStatus,
+  type RepairDownloadItem,
+  type RepairReason,
+} from "@/types/mods";
+
+type RepairSkipReason =
+  | "missing-downloads"
+  | "multiple-downloads"
+  | "needs-file-selection";
+
+export type RepairSkippedMod = {
+  remoteId: string;
+  reason: RepairSkipReason;
+};
+
+export type RepairFailedMod = {
+  remoteId: string;
+  error: string;
+};
+
+export type RepairModsResult = {
+  queued: string[];
+  repaired: string[];
+  skipped: RepairSkippedMod[];
+  failed: RepairFailedMod[];
+};
+
+type RepairModOptions = {
+  interactive?: boolean;
+  availableFiles?: ModDownloadItem[];
+  requestDownloadSelection?: () => Promise<void> | void;
+  installInteractively?: (mod: LocalMod) => Promise<void>;
+};
+
+export const normalizeRepairDownloads = (
+  downloads: RepairDownloadItem[],
+): ModDownloadItem[] =>
+  downloads.map((download) => ({
+    name: download.name,
+    size: download.size,
+    url: download.url,
+    description: download.description ?? null,
+    createdAt: download.createdAt ?? null,
+    updatedAt: download.updatedAt ?? null,
+    md5Checksum: download.md5Checksum ?? null,
+  }));
+
+const downloadFilesForMetadata = (downloads: ModDownloadItem[]) =>
+  downloads.map((download) => ({
+    name: download.name,
+    size: download.size ?? 0,
+    url: download.url,
+    md5Checksum: download.md5Checksum ?? null,
+  }));
+
+const getStoredDownloads = (mod: LocalMod): ModDownloadItem[] | null => {
+  if (mod.repairDownloads?.length) {
+    return normalizeRepairDownloads(mod.repairDownloads);
+  }
+
+  if (mod.selectedDownloads?.length) {
+    return mod.selectedDownloads;
+  }
+
+  return null;
+};
+
+const repairReasonForSkip = (reason: RepairSkipReason): RepairReason => {
+  switch (reason) {
+    case "multiple-downloads":
+      return "needsDownloadChoice";
+    case "needs-file-selection":
+      return "needsFileSelection";
+    case "missing-downloads":
+      return "missingPayload";
+  }
+};
+
+const selectedFileTreeForBatch = (
+  mod: LocalMod,
+  analyzedFileTree: ModFileTree,
+): ModFileTree | RepairSkipReason => {
+  if (!analyzedFileTree.has_multiple_files) {
+    return analyzedFileTree;
+  }
+
+  const previousTree = mod.installedFileTree;
+  if (!previousTree?.has_multiple_files) {
+    return "needs-file-selection";
+  }
+
+  const selectedPaths = new Set(
+    previousTree.files
+      .filter((file) => file.is_selected)
+      .map((file) => file.path),
+  );
+  if (selectedPaths.size === 0) {
+    return "needs-file-selection";
+  }
+
+  const files = analyzedFileTree.files.map((file) => ({
+    ...file,
+    is_selected: selectedPaths.has(file.path),
+  }));
+  if (!files.some((file) => file.is_selected)) {
+    return "needs-file-selection";
+  }
+
+  return {
+    ...analyzedFileTree,
+    files,
+  };
+};
+
+export const useRepairMods = () => {
+  const { t } = useTranslation();
+  const {
+    getActiveProfile,
+    setModStatus,
+    setModProgress,
+    setInstalledVpks,
+    setSelectedDownloads,
+    setModDownloads,
+    setModEnabledInCurrentProfile,
+    isRepairingMods,
+    setIsRepairingMods,
+    setModRepairReason,
+  } = usePersistedStore();
+
+  const persistRepairMetadata = async (
+    profileFolder: string | null,
+    modId: string,
+    sourceDownloads: ModDownloadItem[],
+  ) => {
+    await invoke("update_profile_vpk_manifest_repair_metadata", {
+      profileFolder,
+      modId,
+      sourceDownloads: downloadFilesForMetadata(sourceDownloads),
+    });
+  };
+
+  const resolveDownloads = async (
+    mod: LocalMod,
+    options: RepairModOptions,
+  ): Promise<ModDownloadItem[] | RepairSkipReason> => {
+    const storedDownloads = getStoredDownloads(mod);
+    if (storedDownloads?.length) {
+      return storedDownloads;
+    }
+
+    const availableFiles = options.availableFiles ?? [];
+    if (availableFiles.length === 1) {
+      return availableFiles;
+    }
+    if (availableFiles.length > 1) {
+      return "multiple-downloads";
+    }
+
+    try {
+      const response = await getModDownloads(mod.remoteId);
+      if (response.downloads.length === 1) {
+        return response.downloads;
+      }
+      return response.downloads.length > 1
+        ? "multiple-downloads"
+        : "missing-downloads";
+    } catch (error) {
+      logger
+        .withMetadata({ modId: mod.remoteId })
+        .withError(error)
+        .warn("Failed to fetch repair downloads");
+      return "missing-downloads";
+    }
+  };
+
+  const queueRepairDownload = (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+    profileFolder: string | null,
+  ) =>
+    new Promise<void>((resolve, reject) => {
+      setModStatus(mod.remoteId, ModStatus.Downloading);
+      downloadManager.addToQueue({
+        ...mod,
+        downloads,
+        profileFolder,
+        onStart: () => {
+          setModStatus(mod.remoteId, ModStatus.Downloading);
+        },
+        onProgress: (progress) => {
+          setModProgress(mod.remoteId, progress);
+        },
+        onComplete: () => {
+          setModStatus(mod.remoteId, ModStatus.Downloaded);
+          resolve();
+        },
+        onError: (error) => {
+          setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+          setModRepairReason(mod.remoteId, "repairFailed");
+          reject(error);
+        },
+      });
+    });
+
+  const rememberRepairDownloads = (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+  ) => {
+    setModDownloads(mod.remoteId, downloads);
+    setSelectedDownloads(mod.remoteId, downloads);
+    usePersistedStore.setState((state) => ({
+      localMods: state.localMods.map((localMod) =>
+        localMod.remoteId === mod.remoteId
+          ? { ...localMod, repairDownloads: downloads }
+          : localMod,
+      ),
+    }));
+  };
+
+  const installDownloadedRepair = async (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+    profileFolder: string | null,
+  ): Promise<RepairModsResult> => {
+    try {
+      const base = await appLocalDataDir();
+      const modsRoot = await join(base, "mods");
+      const modDir = await join(modsRoot, mod.remoteId);
+      const analyzedFileTree = await invoke<ModFileTree>("get_mod_file_tree", {
+        modPath: modDir,
+      });
+      const fileTree = selectedFileTreeForBatch(mod, analyzedFileTree);
+      if (typeof fileTree === "string") {
+        setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+        setModRepairReason(mod.remoteId, repairReasonForSkip(fileTree));
+        return {
+          queued: [],
+          repaired: [],
+          skipped: [{ remoteId: mod.remoteId, reason: fileTree }],
+          failed: [],
+        };
+      }
+
+      setModStatus(mod.remoteId, ModStatus.Installing);
+      const result = await invoke<InstallableMod>("install_mod", {
+        deadlockMod: {
+          id: mod.remoteId,
+          name: mod.name,
+          is_map: mod.isMap,
+          file_tree: fileTree,
+        },
+        profileFolder,
+      });
+
+      setInstalledVpks(mod.remoteId, result.installed_vpks, result.file_tree);
+      setModEnabledInCurrentProfile(mod.remoteId, true);
+      setModRepairReason(mod.remoteId, undefined);
+      await persistRepairMetadata(profileFolder, mod.remoteId, downloads);
+
+      return {
+        queued: [],
+        repaired: [mod.remoteId],
+        skipped: [],
+        failed: [],
+      };
+    } catch (error) {
+      const message = getErrorMessage(error);
+      logger
+        .withMetadata({ modId: mod.remoteId })
+        .withError(error)
+        .error("Failed to repair mod");
+      setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+      setModRepairReason(mod.remoteId, "repairFailed");
+      return {
+        queued: [],
+        repaired: [],
+        skipped: [],
+        failed: [{ remoteId: mod.remoteId, error: message }],
+      };
+    }
+  };
+
+  const repairModDirectly = async (
+    mod: LocalMod,
+    downloads: ModDownloadItem[],
+    profileFolder: string | null,
+  ): Promise<RepairModsResult> => {
+    rememberRepairDownloads(mod, downloads);
+    await queueRepairDownload(mod, downloads, profileFolder);
+    const result = await installDownloadedRepair(mod, downloads, profileFolder);
+    return {
+      ...result,
+      queued: [mod.remoteId],
+    };
+  };
+
+  const repairMod = async (
+    mod: LocalMod,
+    options: RepairModOptions = {},
+  ): Promise<RepairModsResult> => {
+    const interactive = options.interactive ?? true;
+    const profileFolder = getActiveProfile()?.folderName ?? null;
+    const downloads = await resolveDownloads(mod, options);
+
+    if (typeof downloads === "string") {
+      setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+      setModRepairReason(mod.remoteId, repairReasonForSkip(downloads));
+      if (interactive && options.requestDownloadSelection) {
+        await options.requestDownloadSelection();
+      }
+      return {
+        queued: [],
+        repaired: [],
+        skipped: [{ remoteId: mod.remoteId, reason: downloads }],
+        failed: [],
+      };
+    }
+
+    if (interactive && options.installInteractively) {
+      rememberRepairDownloads(mod, downloads);
+      const repairCandidate: LocalMod = {
+        ...mod,
+        status: ModStatus.Downloaded,
+        downloads,
+        selectedDownloads: downloads,
+        repairDownloads: downloads,
+      };
+
+      downloadManager.addToQueue({
+        ...repairCandidate,
+        downloads,
+        profileFolder,
+        onStart: () => {
+          setModStatus(mod.remoteId, ModStatus.Downloading);
+        },
+        onProgress: (progress) => {
+          setModProgress(mod.remoteId, progress);
+        },
+        onComplete: async () => {
+          setModStatus(mod.remoteId, ModStatus.Downloaded);
+          const latestMod =
+            usePersistedStore
+              .getState()
+              .localMods.find((m) => m.remoteId === mod.remoteId) ??
+            repairCandidate;
+
+          await options.installInteractively?.({
+            ...latestMod,
+            status: ModStatus.Downloaded,
+            downloads,
+            selectedDownloads: downloads,
+            repairDownloads: downloads,
+          });
+        },
+        onError: (error) => {
+          toast.error(`Failed to repair ${mod.name}: ${error.message}`);
+          setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+          setModRepairReason(mod.remoteId, "repairFailed");
+        },
+      });
+
+      return {
+        queued: [mod.remoteId],
+        repaired: [],
+        skipped: [],
+        failed: [],
+      };
+    }
+
+    return repairModDirectly(mod, downloads, profileFolder);
+  };
+
+  const repairMods = async (mods: LocalMod[]): Promise<RepairModsResult> => {
+    if (mods.length === 0 || usePersistedStore.getState().isRepairingMods) {
+      return { queued: [], repaired: [], skipped: [], failed: [] };
+    }
+
+    setIsRepairingMods(true);
+    const aggregate: RepairModsResult = {
+      queued: [],
+      repaired: [],
+      skipped: [],
+      failed: [],
+    };
+
+    try {
+      const profileFolder = getActiveProfile()?.folderName ?? null;
+      const resolvedRepairs = await Promise.all(
+        mods.map(async (mod) => ({
+          mod,
+          downloads: await resolveDownloads(mod, { interactive: false }),
+        })),
+      );
+
+      const queuedRepairs: Array<{
+        mod: LocalMod;
+        downloads: ModDownloadItem[];
+        downloadComplete: Promise<
+          | { ok: true }
+          | {
+              ok: false;
+              error: string;
+            }
+        >;
+      }> = [];
+
+      for (const { mod, downloads } of resolvedRepairs) {
+        if (typeof downloads === "string") {
+          setModStatus(mod.remoteId, ModStatus.NeedsRepair);
+          setModRepairReason(mod.remoteId, repairReasonForSkip(downloads));
+          aggregate.skipped.push({ remoteId: mod.remoteId, reason: downloads });
+          continue;
+        }
+
+        rememberRepairDownloads(mod, downloads);
+        queuedRepairs.push({
+          mod,
+          downloads,
+          downloadComplete: queueRepairDownload(mod, downloads, profileFolder)
+            .then(() => ({ ok: true as const }))
+            .catch((error) => ({
+              ok: false as const,
+              error: getErrorMessage(error),
+            })),
+        });
+        aggregate.queued.push(mod.remoteId);
+      }
+
+      for (const repair of queuedRepairs) {
+        const downloadResult = await repair.downloadComplete;
+        if (!downloadResult.ok) {
+          aggregate.failed.push({
+            remoteId: repair.mod.remoteId,
+            error: downloadResult.error,
+          });
+          continue;
+        }
+
+        const result = await installDownloadedRepair(
+          repair.mod,
+          repair.downloads,
+          profileFolder,
+        );
+        aggregate.repaired.push(...result.repaired);
+        aggregate.skipped.push(...result.skipped);
+        aggregate.failed.push(...result.failed);
+      }
+
+      if (aggregate.skipped.length === 0 && aggregate.failed.length === 0) {
+        toast.success(
+          t("modButton.repairAllSuccess", {
+            count: aggregate.repaired.length,
+          }),
+        );
+      } else if (
+        aggregate.queued.length === 0 &&
+        aggregate.repaired.length === 0 &&
+        aggregate.failed.length === 0 &&
+        aggregate.skipped.length > 0
+      ) {
+        toast.warning(
+          t("modButton.repairAllManualOnly", {
+            count: aggregate.skipped.length,
+          }),
+        );
+      } else {
+        toast.warning(
+          t("modButton.repairAllPartial", {
+            queued: aggregate.queued.length,
+            repaired: aggregate.repaired.length,
+            manual: aggregate.skipped.length,
+            failed: aggregate.failed.length,
+          }),
+        );
+      }
+
+      return aggregate;
+    } finally {
+      setIsRepairingMods(false);
+    }
+  };
+
+  return {
+    isRepairing: isRepairingMods,
+    repairMod,
+    repairMods,
+  };
+};

--- a/apps/desktop/src/lib/mods/installed-helpers.ts
+++ b/apps/desktop/src/lib/mods/installed-helpers.ts
@@ -1,4 +1,9 @@
-import { type LocalMod, ModStatus } from "@/types/mods";
+import { type LocalMod, ModStatus, type RepairReason } from "@/types/mods";
+
+const manualRepairReasons = new Set<RepairReason>([
+  "needsDownloadChoice",
+  "needsFileSelection",
+]);
 
 export function isInstalledModWithVpks(mod: LocalMod): boolean {
   return (
@@ -6,4 +11,32 @@ export function isInstalledModWithVpks(mod: LocalMod): boolean {
     !!mod.installedVpks &&
     mod.installedVpks.length > 0
   );
+}
+
+export function isRepairableMod(mod: LocalMod): boolean {
+  return mod.status === ModStatus.NeedsRepair;
+}
+
+export function isManualRepairMod(mod: LocalMod): boolean {
+  return (
+    isRepairableMod(mod) &&
+    !!mod.repairReason &&
+    manualRepairReasons.has(mod.repairReason)
+  );
+}
+
+export function isAutomaticRepairMod(mod: LocalMod): boolean {
+  return isRepairableMod(mod) && !isManualRepairMod(mod);
+}
+
+export function getModStatusSortRank(mod: LocalMod): number {
+  if (isInstalledModWithVpks(mod)) {
+    return 0;
+  }
+
+  if (isRepairableMod(mod)) {
+    return 1;
+  }
+
+  return 2;
 }

--- a/apps/desktop/src/lib/mods/library-display.test.ts
+++ b/apps/desktop/src/lib/mods/library-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { filterStableLibraryModsByStatus } from "./library-display";
+import { filterLibraryModsByStatus, ModFilter } from "./library-display";
 import { type LocalMod, ModStatus } from "@/types/mods";
 
 type LocalModOverrides = Partial<
@@ -46,7 +46,7 @@ const mod = (
 
 const ids = (mods: LocalMod[]) => mods.map((item) => item.remoteId);
 
-describe("filterStableLibraryModsByStatus", () => {
+describe("filterLibraryModsByStatus", () => {
   it("preserves library order in the all view", () => {
     const mods = [
       mod("disabled-newer", ModStatus.Downloaded, {
@@ -62,7 +62,7 @@ describe("filterStableLibraryModsByStatus", () => {
       }),
     ];
 
-    expect(ids(filterStableLibraryModsByStatus(mods, "all"))).toEqual([
+    expect(ids(filterLibraryModsByStatus(mods, ModFilter.All))).toEqual([
       "disabled-newer",
       "enabled-late-load-order",
       "enabled-early-load-order",
@@ -82,7 +82,7 @@ describe("filterStableLibraryModsByStatus", () => {
       }),
     ];
 
-    expect(ids(filterStableLibraryModsByStatus(mods, "enabled"))).toEqual([
+    expect(ids(filterLibraryModsByStatus(mods, ModFilter.Enabled))).toEqual([
       "enabled-load-order-10",
       "enabled-load-order-1",
     ]);
@@ -98,7 +98,7 @@ describe("filterStableLibraryModsByStatus", () => {
       mod("failed-install", ModStatus.FailedToInstall),
     ];
 
-    expect(ids(filterStableLibraryModsByStatus(mods, "disabled"))).toEqual([
+    expect(ids(filterLibraryModsByStatus(mods, ModFilter.Disabled))).toEqual([
       "downloaded",
       "failed-install",
     ]);
@@ -114,10 +114,9 @@ describe("filterStableLibraryModsByStatus", () => {
       mod("repair-earlier", ModStatus.NeedsRepair),
     ];
 
-    expect(ids(filterStableLibraryModsByStatus(mods, "needsRepair"))).toEqual([
-      "repair-later",
-      "repair-earlier",
-    ]);
+    expect(ids(filterLibraryModsByStatus(mods, ModFilter.NeedsRepair))).toEqual(
+      ["repair-later", "repair-earlier"],
+    );
   });
 
   it("preserves caller-provided search result order instead of regrouping by status", () => {
@@ -129,9 +128,8 @@ describe("filterStableLibraryModsByStatus", () => {
       }),
     ];
 
-    expect(ids(filterStableLibraryModsByStatus(searchResults, "all"))).toEqual([
-      "search-hit-disabled",
-      "search-hit-enabled",
-    ]);
+    expect(
+      ids(filterLibraryModsByStatus(searchResults, ModFilter.All)),
+    ).toEqual(["search-hit-disabled", "search-hit-enabled"]);
   });
 });

--- a/apps/desktop/src/lib/mods/library-display.test.ts
+++ b/apps/desktop/src/lib/mods/library-display.test.ts
@@ -94,12 +94,29 @@ describe("filterStableLibraryModsByStatus", () => {
         installedVpks: ["installed.vpk"],
       }),
       mod("downloaded", ModStatus.Downloaded),
+      mod("needs-repair", ModStatus.NeedsRepair),
       mod("failed-install", ModStatus.FailedToInstall),
     ];
 
     expect(ids(filterStableLibraryModsByStatus(mods, "disabled"))).toEqual([
       "downloaded",
       "failed-install",
+    ]);
+  });
+
+  it("preserves library-relative order in the needs repair view", () => {
+    const mods = [
+      mod("downloaded", ModStatus.Downloaded),
+      mod("repair-later", ModStatus.NeedsRepair),
+      mod("installed", ModStatus.Installed, {
+        installedVpks: ["installed.vpk"],
+      }),
+      mod("repair-earlier", ModStatus.NeedsRepair),
+    ];
+
+    expect(ids(filterStableLibraryModsByStatus(mods, "needsRepair"))).toEqual([
+      "repair-later",
+      "repair-earlier",
     ]);
   });
 

--- a/apps/desktop/src/lib/mods/library-display.ts
+++ b/apps/desktop/src/lib/mods/library-display.ts
@@ -1,9 +1,10 @@
 import type { LocalMod } from "@/types/mods";
-import { isInstalledModWithVpks } from "./installed-helpers";
+import { isInstalledModWithVpks, isRepairableMod } from "./installed-helpers";
 
 export enum ModFilter {
   All = "all",
   Enabled = "enabled",
+  NeedsRepair = "needsRepair",
   Disabled = "disabled",
 }
 
@@ -14,8 +15,12 @@ export function filterLibraryModsByStatus(
   switch (filter) {
     case ModFilter.Enabled:
       return mods.filter(isInstalledModWithVpks);
+    case ModFilter.NeedsRepair:
+      return mods.filter(isRepairableMod);
     case ModFilter.Disabled:
-      return mods.filter((mod) => !isInstalledModWithVpks(mod));
+      return mods.filter(
+        (mod) => !isInstalledModWithVpks(mod) && !isRepairableMod(mod),
+      );
     case ModFilter.All:
       return mods;
   }

--- a/apps/desktop/src/lib/profiles/manifest-state.test.ts
+++ b/apps/desktop/src/lib/profiles/manifest-state.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { ModStatus } from "@/types/mods";
+import type { VpkManifestEntry } from "@/types/profiles";
+import { projectManifestEntryToModState } from "./manifest-state";
+
+const entry = (overrides: Partial<VpkManifestEntry>): VpkManifestEntry => ({
+  enabled: true,
+  desiredState: "enabled",
+  diskState: "active",
+  order: 0,
+  currentVpks: ["pak01_dir.vpk"],
+  disabledVpks: [],
+  originalVpkNames: ["original.vpk"],
+  ...overrides,
+});
+
+const project = (
+  manifestEntry: VpkManifestEntry,
+  enabledVpks: string[] = manifestEntry.currentVpks,
+  allVpks: string[] = [...enabledVpks, ...manifestEntry.disabledVpks],
+) =>
+  projectManifestEntryToModState(manifestEntry, {
+    enabledVpkSet: new Set(enabledVpks),
+    allVpkSet: new Set(allVpks),
+    fallbackInstallOrder: 77,
+  });
+
+describe("projectManifestEntryToModState", () => {
+  it("projects active enabled entries as installed", () => {
+    const projected = project(
+      entry({
+        currentVpks: ["pak09_dir.vpk"],
+        order: 9,
+      }),
+    );
+
+    expect(projected.status).toBe(ModStatus.Installed);
+    expect(projected.installedVpks).toEqual(["pak09_dir.vpk"]);
+    expect(projected.installOrder).toBe(9);
+    expect(projected.repairReason).toBeUndefined();
+  });
+
+  it("trusts manifest mismatch over filename scan", () => {
+    const projected = project(
+      entry({
+        diskState: "mismatch",
+        repairReason: "fingerprintMismatch",
+        currentVpks: ["pak11_dir.vpk"],
+      }),
+      ["pak11_dir.vpk"],
+    );
+
+    expect(projected.status).toBe(ModStatus.NeedsRepair);
+    expect(projected.installedVpks).toEqual([]);
+    expect(projected.repairReason).toBe("fingerprintMismatch");
+  });
+
+  it("trusts manifest unverified state over filename scan", () => {
+    const projected = project(
+      entry({
+        diskState: "unverified",
+        repairReason: "unverifiedManifest",
+        currentVpks: ["pak12_dir.vpk"],
+      }),
+      ["pak12_dir.vpk"],
+    );
+
+    expect(projected.status).toBe(ModStatus.NeedsRepair);
+    expect(projected.repairReason).toBe("unverifiedManifest");
+  });
+
+  it("marks enabled entries with missing payload as repairable", () => {
+    const projected = project(
+      entry({
+        diskState: "missing",
+        repairReason: "missingEnabledVpks",
+      }),
+      [],
+    );
+
+    expect(projected.status).toBe(ModStatus.NeedsRepair);
+    expect(projected.repairReason).toBe("missingEnabledVpks");
+  });
+
+  it("projects disabled entries with prefixed payload as downloaded", () => {
+    const projected = project(
+      entry({
+        enabled: false,
+        desiredState: "disabled",
+        diskState: "disabled",
+        currentVpks: [],
+        disabledVpks: ["123_pak01_dir.vpk"],
+      }),
+      [],
+      ["123_pak01_dir.vpk"],
+    );
+
+    expect(projected.status).toBe(ModStatus.Downloaded);
+    expect(projected.repairReason).toBeUndefined();
+  });
+
+  it("trusts manifest missing state for disabled entries even when scan sees a prefixed file", () => {
+    const projected = project(
+      entry({
+        enabled: false,
+        desiredState: "disabled",
+        diskState: "missing",
+        repairReason: "missingPayload",
+        currentVpks: [],
+        disabledVpks: ["123_pak01_dir.vpk"],
+      }),
+      [],
+      ["123_pak01_dir.vpk"],
+    );
+
+    expect(projected.status).toBe(ModStatus.NeedsRepair);
+    expect(projected.repairReason).toBe("missingPayload");
+  });
+
+  it("falls back to filename scan for legacy entries without disk state", () => {
+    const projected = project(
+      entry({
+        diskState: undefined,
+        desiredState: undefined,
+        enabled: true,
+        currentVpks: ["C:\\Deadlock\\addons\\pak14_dir.vpk"],
+        order: null,
+      }),
+      ["pak14_dir.vpk"],
+    );
+
+    expect(projected.status).toBe(ModStatus.Installed);
+    expect(projected.installedVpks).toEqual([
+      "C:\\Deadlock\\addons\\pak14_dir.vpk",
+    ]);
+    expect(projected.installOrder).toBe(77);
+  });
+});

--- a/apps/desktop/src/lib/profiles/manifest-state.ts
+++ b/apps/desktop/src/lib/profiles/manifest-state.ts
@@ -1,0 +1,115 @@
+import { ModStatus, type RepairReason } from "@/types/mods";
+import type { VpkManifestEntry } from "@/types/profiles";
+
+export const vpkFilename = (vpk: string) => vpk.split(/[\\/]/).pop() || vpk;
+
+export const hasEveryEnabledVpk = (
+  vpks: string[] | undefined,
+  enabledVpkSet: Set<string>,
+) => {
+  const currentVpks = vpks ?? [];
+  return (
+    currentVpks.length > 0 &&
+    currentVpks.every((vpk) => enabledVpkSet.has(vpkFilename(vpk)))
+  );
+};
+
+export const manifestWantsEnabled = (entry: VpkManifestEntry) =>
+  entry.desiredState ? entry.desiredState === "enabled" : entry.enabled;
+
+export const manifestRepairReason = (
+  entry: VpkManifestEntry,
+  fallback: RepairReason,
+) => (entry.repairReason ?? fallback) as RepairReason;
+
+type ProjectManifestEntryOptions = {
+  enabledVpkSet: Set<string>;
+  allVpkSet: Set<string>;
+  fallbackRepairReason?: RepairReason;
+  fallbackInstallOrder?: number;
+};
+
+export type ManifestEntryProjection = {
+  wantsEnabled: boolean;
+  hasEnabledVpks: boolean;
+  hasDisabledVpks: boolean;
+  status: ModStatus.Installed | ModStatus.Downloaded | ModStatus.NeedsRepair;
+  repairReason?: RepairReason;
+  installedVpks: string[];
+  installOrder?: number;
+};
+
+export const projectManifestEntryToModState = (
+  entry: VpkManifestEntry,
+  {
+    enabledVpkSet,
+    allVpkSet,
+    fallbackRepairReason,
+    fallbackInstallOrder,
+  }: ProjectManifestEntryOptions,
+): ManifestEntryProjection => {
+  const currentVpks = entry.currentVpks ?? [];
+  const disabledVpks = entry.disabledVpks ?? [];
+  const wantsEnabled = manifestWantsEnabled(entry);
+  const hasEnabledVpks = entry.diskState
+    ? wantsEnabled && entry.diskState === "active"
+    : wantsEnabled && hasEveryEnabledVpk(currentVpks, enabledVpkSet);
+  const hasDisabledVpks =
+    !wantsEnabled &&
+    (entry.diskState
+      ? entry.diskState === "disabled"
+      : disabledVpks.some((vpk) => allVpkSet.has(vpk)));
+  const installOrder = entry.order ?? fallbackInstallOrder;
+
+  if (hasEnabledVpks) {
+    return {
+      wantsEnabled,
+      hasEnabledVpks,
+      hasDisabledVpks,
+      status: ModStatus.Installed,
+      repairReason: undefined,
+      installedVpks: currentVpks,
+      installOrder,
+    };
+  }
+
+  if (wantsEnabled) {
+    return {
+      wantsEnabled,
+      hasEnabledVpks,
+      hasDisabledVpks,
+      status: ModStatus.NeedsRepair,
+      repairReason: manifestRepairReason(
+        entry,
+        fallbackRepairReason ?? "missingEnabledVpks",
+      ),
+      installedVpks: [],
+      installOrder,
+    };
+  }
+
+  if (hasDisabledVpks) {
+    return {
+      wantsEnabled,
+      hasEnabledVpks,
+      hasDisabledVpks,
+      status: ModStatus.Downloaded,
+      repairReason: undefined,
+      installedVpks: [],
+      installOrder,
+    };
+  }
+
+  return {
+    wantsEnabled,
+    hasEnabledVpks,
+    hasDisabledVpks,
+    status: ModStatus.NeedsRepair,
+    repairReason: manifestRepairReason(
+      entry,
+      fallbackRepairReason ?? "missingPayload",
+    ),
+    installedVpks: [],
+    installOrder,
+  };
+};

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -7,11 +7,10 @@ import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { isInstalledModWithVpks } from "@/lib/mods/installed-helpers";
 import {
-  type LocalMod,
-  ModStatus,
-  type InstalledModInfo,
-  type RepairReason,
-} from "@/types/mods";
+  projectManifestEntryToModState,
+  vpkFilename,
+} from "@/lib/profiles/manifest-state";
+import { type LocalMod, ModStatus, type InstalledModInfo } from "@/types/mods";
 import {
   createProfileId,
   DEFAULT_PROFILE_ID,
@@ -89,27 +88,6 @@ export const profilesDeepMergeKeys =
 
 const RECOVERED_PROFILE_DESCRIPTION = "Profile detected from filesystem";
 const PROFILE_FOLDER_NAME_PATTERN = /^(profile_\d+_[^_]+)(?:_(.+))?$/;
-
-const vpkFilename = (vpk: string) => vpk.split(/[\\/]/).pop() || vpk;
-
-const hasEveryEnabledVpk = (
-  vpks: string[] | undefined,
-  enabledVpkSet: Set<string>,
-) => {
-  const currentVpks = vpks ?? [];
-  return (
-    currentVpks.length > 0 &&
-    currentVpks.every((vpk) => enabledVpkSet.has(vpkFilename(vpk)))
-  );
-};
-
-const manifestWantsEnabled = (entry: VpkManifest["mods"][string]) =>
-  entry.desiredState ? entry.desiredState === "enabled" : entry.enabled;
-
-const manifestRepairReason = (
-  entry: VpkManifest["mods"][string],
-  fallback: RepairReason,
-) => (entry.repairReason ?? fallback) as RepairReason;
 
 const toRecoveredProfileName = (value: string) => {
   const displayName = value
@@ -819,20 +797,16 @@ export const createProfilesSlice: StateCreator<
 
         if (manifestEntry) {
           const currentVpks = manifestEntry.currentVpks ?? [];
-          const disabledVpks = manifestEntry.disabledVpks ?? [];
-          const wantsEnabled = manifestWantsEnabled(manifestEntry);
-          const hasEnabledVpks = manifestEntry.diskState
-            ? wantsEnabled && manifestEntry.diskState === "active"
-            : wantsEnabled && hasEveryEnabledVpk(currentVpks, enabledVpkSet);
-          const hasDisabledVpks =
-            !wantsEnabled &&
-            (manifestEntry.diskState
-              ? manifestEntry.diskState === "disabled"
-              : disabledVpks.some((vpk) => allVpkSet.has(vpk)));
           const existingRepairReason =
             mod.status === ModStatus.NeedsRepair ? mod.repairReason : undefined;
+          const projected = projectManifestEntryToModState(manifestEntry, {
+            enabledVpkSet,
+            allVpkSet,
+            fallbackRepairReason: existingRepairReason,
+            fallbackInstallOrder: mod.installOrder,
+          });
 
-          if (hasEnabledVpks) {
+          if (projected.status === ModStatus.Installed) {
             updatedEnabledMods[mod.remoteId] = {
               remoteId: mod.remoteId,
               enabled: true,
@@ -841,15 +815,15 @@ export const createProfilesSlice: StateCreator<
 
             updatedLocalMods.push({
               ...mod,
-              status: ModStatus.Installed,
-              repairReason: undefined,
-              installedVpks: currentVpks,
-              installOrder: manifestEntry.order ?? mod.installOrder,
+              status: projected.status,
+              repairReason: projected.repairReason,
+              installedVpks: projected.installedVpks,
+              installOrder: projected.installOrder,
               repairDownloads:
                 manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
           } else {
-            if (wantsEnabled) {
+            if (projected.wantsEnabled) {
               logger
                 .withMetadata({
                   profileId,
@@ -865,24 +839,10 @@ export const createProfilesSlice: StateCreator<
 
             updatedLocalMods.push({
               ...mod,
-              status: wantsEnabled
-                ? ModStatus.NeedsRepair
-                : hasDisabledVpks
-                  ? ModStatus.Downloaded
-                  : ModStatus.NeedsRepair,
-              repairReason: wantsEnabled
-                ? manifestRepairReason(
-                    manifestEntry,
-                    existingRepairReason ?? "missingEnabledVpks",
-                  )
-                : hasDisabledVpks
-                  ? undefined
-                  : manifestRepairReason(
-                      manifestEntry,
-                      existingRepairReason ?? "missingPayload",
-                    ),
-              installedVpks: [],
-              installOrder: manifestEntry.order ?? mod.installOrder,
+              status: projected.status,
+              repairReason: projected.repairReason,
+              installedVpks: projected.installedVpks,
+              installOrder: projected.installOrder,
               repairDownloads:
                 manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
@@ -1118,41 +1078,30 @@ export const createProfilesSlice: StateCreator<
     const enabledVpkSet = new Set(
       allVpks.filter((vpk) => /^pak\d+_dir\.vpk$/i.test(vpk)),
     );
+    const allVpkSet = new Set(allVpks);
 
     for (const [modId, entry] of manifestEntries) {
       try {
         const modDetails = await getMod(modId);
-        const currentVpks = entry.currentVpks ?? [];
-        const wantsEnabled = manifestWantsEnabled(entry);
-        const hasEnabledVpks = entry.diskState
-          ? wantsEnabled && entry.diskState === "active"
-          : wantsEnabled && hasEveryEnabledVpk(currentVpks, enabledVpkSet);
-        const needsRepair =
-          (wantsEnabled && !hasEnabledVpks) ||
-          (!wantsEnabled && entry.diskState === "missing");
+        const projected = projectManifestEntryToModState(entry, {
+          enabledVpkSet,
+          allVpkSet,
+          fallbackInstallOrder: restoredMods.length,
+        });
 
         const restoredMod: LocalMod = {
           ...modDetails,
-          status: hasEnabledVpks
-            ? ModStatus.Installed
-            : needsRepair
-              ? ModStatus.NeedsRepair
-              : ModStatus.Downloaded,
-          repairReason: needsRepair
-            ? manifestRepairReason(
-                entry,
-                wantsEnabled ? "missingEnabledVpks" : "missingPayload",
-              )
-            : undefined,
-          installedVpks: hasEnabledVpks ? currentVpks : [],
-          installOrder: entry.order ?? restoredMods.length,
+          status: projected.status,
+          repairReason: projected.repairReason,
+          installedVpks: projected.installedVpks,
+          installOrder: projected.installOrder,
           downloadedAt: new Date(),
           repairDownloads: entry.sourceDownloads,
         };
 
         restoredMods.push(restoredMod);
 
-        if (hasEnabledVpks) {
+        if (projected.status === ModStatus.Installed) {
           enabledMods[modId] = {
             remoteId: modId,
             enabled: true,
@@ -1164,8 +1113,8 @@ export const createProfilesSlice: StateCreator<
           .withMetadata({
             modId,
             name: modDetails.name,
-            hasEnabledVpks,
-            needsRepair,
+            hasEnabledVpks: projected.hasEnabledVpks,
+            needsRepair: projected.status === ModStatus.NeedsRepair,
           })
           .info("Restored mod from manifest");
       } catch (error) {

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -6,7 +6,12 @@ import { getMod } from "@/lib/api-client";
 import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { isInstalledModWithVpks } from "@/lib/mods/installed-helpers";
-import { type LocalMod, ModStatus, type InstalledModInfo } from "@/types/mods";
+import {
+  type LocalMod,
+  ModStatus,
+  type InstalledModInfo,
+  type RepairReason,
+} from "@/types/mods";
 import {
   createProfileId,
   DEFAULT_PROFILE_ID,
@@ -84,6 +89,27 @@ export const profilesDeepMergeKeys =
 
 const RECOVERED_PROFILE_DESCRIPTION = "Profile detected from filesystem";
 const PROFILE_FOLDER_NAME_PATTERN = /^(profile_\d+_[^_]+)(?:_(.+))?$/;
+
+const vpkFilename = (vpk: string) => vpk.split(/[\\/]/).pop() || vpk;
+
+const hasEveryEnabledVpk = (
+  vpks: string[] | undefined,
+  enabledVpkSet: Set<string>,
+) => {
+  const currentVpks = vpks ?? [];
+  return (
+    currentVpks.length > 0 &&
+    currentVpks.every((vpk) => enabledVpkSet.has(vpkFilename(vpk)))
+  );
+};
+
+const manifestWantsEnabled = (entry: VpkManifest["mods"][string]) =>
+  entry.desiredState ? entry.desiredState === "enabled" : entry.enabled;
+
+const manifestRepairReason = (
+  entry: VpkManifest["mods"][string],
+  fallback: RepairReason,
+) => (entry.repairReason ?? fallback) as RepairReason;
 
 const toRecoveredProfileName = (value: string) => {
   const displayName = value
@@ -794,12 +820,15 @@ export const createProfilesSlice: StateCreator<
         if (manifestEntry) {
           const currentVpks = manifestEntry.currentVpks ?? [];
           const disabledVpks = manifestEntry.disabledVpks ?? [];
-          const hasEnabledVpks =
-            manifestEntry.enabled &&
-            currentVpks.some((vpk) => enabledVpkSet.has(vpk));
+          const wantsEnabled = manifestWantsEnabled(manifestEntry);
+          const hasEnabledVpks = manifestEntry.diskState
+            ? wantsEnabled && manifestEntry.diskState === "active"
+            : wantsEnabled && hasEveryEnabledVpk(currentVpks, enabledVpkSet);
           const hasDisabledVpks =
-            !manifestEntry.enabled &&
-            disabledVpks.some((vpk) => allVpkSet.has(vpk));
+            !wantsEnabled &&
+            (manifestEntry.diskState
+              ? manifestEntry.diskState === "disabled"
+              : disabledVpks.some((vpk) => allVpkSet.has(vpk)));
           const existingRepairReason =
             mod.status === ModStatus.NeedsRepair ? mod.repairReason : undefined;
 
@@ -820,7 +849,7 @@ export const createProfilesSlice: StateCreator<
                 manifestEntry.sourceDownloads ?? mod.repairDownloads,
             });
           } else {
-            if (manifestEntry.enabled) {
+            if (wantsEnabled) {
               logger
                 .withMetadata({
                   profileId,
@@ -836,16 +865,22 @@ export const createProfilesSlice: StateCreator<
 
             updatedLocalMods.push({
               ...mod,
-              status: manifestEntry.enabled
+              status: wantsEnabled
                 ? ModStatus.NeedsRepair
                 : hasDisabledVpks
                   ? ModStatus.Downloaded
                   : ModStatus.NeedsRepair,
-              repairReason: manifestEntry.enabled
-                ? (existingRepairReason ?? "missingEnabledVpks")
+              repairReason: wantsEnabled
+                ? manifestRepairReason(
+                    manifestEntry,
+                    existingRepairReason ?? "missingEnabledVpks",
+                  )
                 : hasDisabledVpks
                   ? undefined
-                  : (existingRepairReason ?? "missingPayload"),
+                  : manifestRepairReason(
+                      manifestEntry,
+                      existingRepairReason ?? "missingPayload",
+                    ),
               installedVpks: [],
               installOrder: manifestEntry.order ?? mod.installOrder,
               repairDownloads:
@@ -859,11 +894,10 @@ export const createProfilesSlice: StateCreator<
         const disabledVpksForMod = allVpks.filter((vpk) =>
           vpk.startsWith(`${mod.remoteId}_`),
         );
-        const enabledVpksForMod =
-          mod.installedVpks?.filter((installedVpk) => {
-            const filename = installedVpk.split(/[\\/]/).pop() || "";
-            return enabledVpkSet.has(filename);
-          }) ?? [];
+        const installedVpks = mod.installedVpks ?? [];
+        const enabledVpksForMod = installedVpks.filter((installedVpk) =>
+          enabledVpkSet.has(vpkFilename(installedVpk)),
+        );
 
         const hasVpksInProfile =
           disabledVpksForMod.length > 0 || enabledVpksForMod.length > 0;
@@ -921,7 +955,10 @@ export const createProfilesSlice: StateCreator<
         }
 
         // Check if the mod has enabled VPKs
-        const hasEnabledVpks = enabledVpksForMod.length > 0;
+        const hasEnabledVpks =
+          installedVpks.length > 0 &&
+          enabledVpksForMod.length === installedVpks.length;
+        const hasPartialEnabledVpks = enabledVpksForMod.length > 0;
 
         if (hasEnabledVpks) {
           // Mod is enabled in this profile
@@ -950,6 +987,22 @@ export const createProfilesSlice: StateCreator<
             modId: mod.remoteId,
             enabled: true,
             currentVpks: enabledVpksForMod,
+            disabledVpks: [],
+            originalVpkNames: [],
+            order: mod.installOrder ?? null,
+          });
+        } else if (hasPartialEnabledVpks) {
+          updatedLocalMods.push({
+            ...mod,
+            status: ModStatus.NeedsRepair,
+            repairReason: "missingEnabledVpks",
+            installedVpks: [],
+          });
+
+          seedEntries.push({
+            modId: mod.remoteId,
+            enabled: true,
+            currentVpks: installedVpks,
             disabledVpks: [],
             originalVpkNames: [],
             order: mod.installOrder ?? null,
@@ -1070,9 +1123,13 @@ export const createProfilesSlice: StateCreator<
       try {
         const modDetails = await getMod(modId);
         const currentVpks = entry.currentVpks ?? [];
-        const hasEnabledVpks =
-          entry.enabled && currentVpks.some((vpk) => enabledVpkSet.has(vpk));
-        const needsRepair = entry.enabled && !hasEnabledVpks;
+        const wantsEnabled = manifestWantsEnabled(entry);
+        const hasEnabledVpks = entry.diskState
+          ? wantsEnabled && entry.diskState === "active"
+          : wantsEnabled && hasEveryEnabledVpk(currentVpks, enabledVpkSet);
+        const needsRepair =
+          (wantsEnabled && !hasEnabledVpks) ||
+          (!wantsEnabled && entry.diskState === "missing");
 
         const restoredMod: LocalMod = {
           ...modDetails,
@@ -1081,7 +1138,12 @@ export const createProfilesSlice: StateCreator<
             : needsRepair
               ? ModStatus.NeedsRepair
               : ModStatus.Downloaded,
-          repairReason: needsRepair ? "missingEnabledVpks" : undefined,
+          repairReason: needsRepair
+            ? manifestRepairReason(
+                entry,
+                wantsEnabled ? "missingEnabledVpks" : "missingPayload",
+              )
+            : undefined,
           installedVpks: hasEnabledVpks ? currentVpks : [],
           installOrder: entry.order ?? restoredMods.length,
           downloadedAt: new Date(),

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -240,9 +240,14 @@
     "disableAllConfirmAction": "Disable all",
     "disableAllConfirmCancel": "Cancel",
     "disableAllSuccess": "All mods disabled",
+    "repairBroken": "Repair broken ({{count}})",
+    "manualRepair": "Manual repair ({{count}})",
+    "manualRepairTooltip_one": "{{count}} mod needs a download or VPK choice before repair. Use the question-mark repair button on the mod.",
+    "manualRepairTooltip_other": "{{count}} mods need a download or VPK choice before repair. Use the question-mark repair button on each mod.",
     "tabs": {
       "all": "All",
       "installed": "Installed",
+      "needsRepair": "Needs repair",
       "downloaded": "Downloaded"
     }
   },
@@ -289,6 +294,7 @@
     "deleteError": "Failed to delete mod",
     "deleteErrorVpkInUse": "Some mod files are currently in use by the game. Please close Deadlock and try again.",
     "disableError": "Failed to disable mod",
+    "disableErrorVpkInUse": "Some mod files are temporarily locked by Deadlock, Steam, or another process. Wait a few seconds, close the game if it is running, then try again.",
     "vpkScanAlert": {
       "title": "Unrecognized mod files found",
       "titleTooltipLabel": "What are unrecognized mod files?",
@@ -350,12 +356,17 @@
     "pause": "Pause",
     "resume": "Resume",
     "paused": "Paused",
+    "needsRepair": "Needs repair",
     "pauseError": "Could not pause download: {{message}}",
     "resumeError": "Could not resume download: {{message}}"
   },
   "notifications": {
     "modInstalledSuccessfully": "Mod installed successfully",
+    "modEnabledSuccessfully": "Mod enabled successfully",
+    "modRepairedSuccessfully": "Mod repaired successfully",
     "failedToInstallMod": "Failed to install mod",
+    "failedToEnableMod": "Failed to enable mod",
+    "enableErrorVpkInUse": "Some VPK files are temporarily locked by Deadlock, Steam, or another process. Wait a few seconds, close the game if it is running, then try again.",
     "installationCanceled": "Installation canceled",
     "modContainsFiles": "{{modName}} contains {{fileCount}} files. Select which ones to install.",
     "failedToPerformAction": "Failed to perform action",
@@ -905,6 +916,15 @@
     "removed": "Removed",
     "failedToRemove": "Failed to remove",
     "error": "Error occurred",
+    "needsRepair": "Needs repair",
+    "needsRepairTooltip": "Manifest says this mod is enabled, but its VPK files are missing.",
+    "repairReason": {
+      "missingEnabledVpks": "Manifest says this mod is enabled, but its VPK files are missing.",
+      "missingPayload": "This mod is in your library, but its downloaded VPK files are missing. Redownload it to repair.",
+      "needsDownloadChoice": "Repair needs you to choose which download file to use.",
+      "needsFileSelection": "Repair needs you to choose which VPK file to install.",
+      "repairFailed": "Repair failed. Try again, or redownload this mod manually."
+    },
     "unknown": "Unknown"
   },
   "modButton": {
@@ -921,6 +941,14 @@
     "removed": "Removed",
     "failedToRemove": "Failed to remove",
     "error": "Error occurred",
+    "needsRepair": "Repair Mod",
+    "chooseRepairSource": "Choose repair source",
+    "needsRepairTooltip": "The manifest says this mod should be enabled, but its VPK files are missing. Redownload and reinstall it.",
+    "needsRepairSelectDownload": "Select the download file to repair this mod.",
+    "repairAllSuccess": "Repaired {{count}} broken mods.",
+    "repairAllManualOnly_one": "{{count}} mod needs manual repair.",
+    "repairAllManualOnly_other": "{{count}} mods need manual repair.",
+    "repairAllPartial": "Queued {{queued}}, repaired {{repaired}}, manual {{manual}}, failed {{failed}}.",
     "disableMod": "Disable Mod?",
     "enableMod": "Enable Mod?",
     "installedTooltip": "Toggle to disable mod (will not delete, just disable it ingame)",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -923,7 +923,9 @@
       "missingPayload": "This mod is in your library, but its downloaded VPK files are missing. Redownload it to repair.",
       "needsDownloadChoice": "Repair needs you to choose which download file to use.",
       "needsFileSelection": "Repair needs you to choose which VPK file to install.",
-      "repairFailed": "Repair failed. Try again, or redownload this mod manually."
+      "repairFailed": "Repair failed. Try again, or redownload this mod manually.",
+      "fingerprintMismatch": "The active VPK does not match this mod's saved fingerprint. It was disabled until repaired.",
+      "unverifiedManifest": "This manifest entry has no saved VPK fingerprint, so the active file cannot be verified."
     },
     "unknown": "Unknown"
   },

--- a/apps/desktop/src/pages/my-mods.tsx
+++ b/apps/desktop/src/pages/my-mods.tsx
@@ -44,16 +44,18 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  CircleHelp,
   Download,
   EllipsisVertical,
   FolderOpen,
   LayoutGrid,
-  Settings,
   LayoutList,
   Loader2,
   PowerOff,
   RefreshCw,
   ScanSearch,
+  Settings,
+  WrenchIcon,
 } from "@deadlock-mods/ui/icons";
 import { Trash, UploadSimple } from "@phosphor-icons/react";
 import { MagnifyingGlass } from "@phosphor-icons/react";
@@ -66,6 +68,7 @@ import ModButton from "@/components/mod-browsing/mod-button";
 import NSFWBlur from "@/components/mod-browsing/nsfw-blur";
 import AudioPlayerPreview from "@/components/mod-management/audio-player-preview";
 import { ModContextMenu } from "@/components/mod-management/mod-context-menu";
+import { NeedsRepairBadge } from "@/components/mod-management/needs-repair-badge";
 import { ModOptionsDialog } from "@/components/mod-management/mod-options-dialog";
 import { OutdatedModWarning } from "@/components/mod-management/outdated-mod-warning";
 import SearchBar from "@/components/mod-browsing/search-bar";
@@ -83,6 +86,7 @@ import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { useSearch } from "@/hooks/use-search";
 import { useModOptions } from "@/hooks/use-mod-options";
+import { useRepairMods } from "@/hooks/use-repair-mods";
 import useUninstall from "@/hooks/use-uninstall";
 import { useVpkScan } from "@/hooks/use-vpk-scan";
 import { useThemeOverride } from "@/components/providers/theme-overrides";
@@ -100,7 +104,12 @@ import type {
   FilterMode,
   MapQuickFilter,
 } from "@/lib/store/slices/ui";
-import { isInstalledModWithVpks } from "@/lib/mods/installed-helpers";
+import {
+  isAutomaticRepairMod,
+  isInstalledModWithVpks,
+  isManualRepairMod,
+  isRepairableMod,
+} from "@/lib/mods/installed-helpers";
 import { cn, isModOutdated } from "@/lib/utils";
 import { type LocalMod, ModStatus } from "@/types/mods";
 
@@ -277,6 +286,9 @@ const GridModCard = ({ mod }: { mod: LocalMod }) => {
             )}
           </div>
           <div className='absolute top-2 right-2 flex flex-col gap-1'>
+            {mod.status === ModStatus.NeedsRepair && (
+              <NeedsRepairBadge reason={mod.repairReason} />
+            )}
             {mod.isAudio && (
               <Badge variant='secondary'>{t("mods.audio")}</Badge>
             )}
@@ -425,6 +437,12 @@ const ListModCard = ({ mod }: { mod: LocalMod }) => {
                 </div>
               )}
               <div className='absolute top-1 right-1 flex flex-col gap-1'>
+                {mod.status === ModStatus.NeedsRepair && (
+                  <NeedsRepairBadge
+                    className='text-xs'
+                    reason={mod.repairReason}
+                  />
+                )}
                 {mod.isAudio && (
                   <Badge className='text-xs' variant='secondary'>
                     {t("mods.audio")}
@@ -598,6 +616,7 @@ const MyMods = () => {
     dismissProgressToast,
   } = useAddonAnalysis();
   const { disableAll, isPending: isDisablingAll } = useDisableAllMods();
+  const { repairMods, isRepairing } = useRepairMods();
 
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.GRID);
   const [activeTab, setActiveTab] = useState<ModFilter>(ModFilter.All);
@@ -742,12 +761,24 @@ const MyMods = () => {
   const installedMods = getOrderedMods();
 
   const enabledModsCount = mods.filter(isInstalledModWithVpks).length;
+  const needsRepairMods = mods.filter(isRepairableMod);
+  const needsRepairCount = needsRepairMods.length;
+  const autoRepairMods = needsRepairMods.filter(isAutomaticRepairMod);
+  const autoRepairCount = autoRepairMods.length;
+  const manualRepairMods = needsRepairMods.filter(isManualRepairMod);
+  const manualRepairCount = manualRepairMods.length;
   const disabledModsCount = mods.filter(
-    (mod) => !isInstalledModWithVpks(mod),
+    (mod) => !isInstalledModWithVpks(mod) && !isRepairableMod(mod),
   ).length;
   const enabledVpkFileCount = mods
     .filter(isInstalledModWithVpks)
     .reduce((sum, mod) => sum + (mod.installedVpks?.length ?? 0), 0);
+
+  useEffect(() => {
+    if (activeTab === ModFilter.NeedsRepair && needsRepairCount === 0) {
+      setActiveTab(ModFilter.All);
+    }
+  }, [activeTab, needsRepairCount]);
 
   const vpkStatSubordinateClass =
     enabledVpkFileCount >= ENGINE_VPK_LIMIT
@@ -974,6 +1005,7 @@ const MyMods = () => {
               switch (value) {
                 case ModFilter.All:
                 case ModFilter.Enabled:
+                case ModFilter.NeedsRepair:
                 case ModFilter.Disabled:
                   setActiveTab(value);
                   break;
@@ -1023,6 +1055,43 @@ const MyMods = () => {
                     />
                   </div>
                   <div className='flex min-w-0 flex-wrap items-center justify-start gap-2 xl:justify-end'>
+                    {autoRepairCount > 0 && (
+                      <Button
+                        onClick={() => repairMods(autoRepairMods)}
+                        size='sm'
+                        variant='outline'
+                        disabled={isRepairing}
+                        isLoading={isRepairing}
+                        icon={<WrenchIcon className='h-4 w-4' />}
+                        className='border-amber-500/50 bg-amber-500/10 text-amber-800 hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200'>
+                        {t("myMods.repairBroken", {
+                          count: autoRepairCount,
+                        })}
+                      </Button>
+                    )}
+                    {manualRepairCount > 0 && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge
+                            variant='outline'
+                            tabIndex={0}
+                            aria-label={t("myMods.manualRepairTooltip", {
+                              count: manualRepairCount,
+                            })}
+                            className='cursor-help border-amber-500/50 bg-amber-500/15 px-2.5 py-1.5 text-sm text-amber-800 hover:bg-amber-500/20 focus-visible:outline-none dark:text-amber-300'>
+                            <CircleHelp className='h-4 w-4' />
+                            {t("myMods.manualRepair", {
+                              count: manualRepairCount,
+                            })}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent className='max-w-xs text-pretty'>
+                          {t("myMods.manualRepairTooltip", {
+                            count: manualRepairCount,
+                          })}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
                     <TabsList className='h-auto min-h-9 max-w-full flex-wrap justify-start'>
                       <TabsTrigger value={ModFilter.All}>
                         {t("myMods.tabs.all")}
@@ -1037,6 +1106,15 @@ const MyMods = () => {
                           ({enabledModsCount})
                         </span>
                       </TabsTrigger>
+                      {needsRepairCount > 0 && (
+                        <TabsTrigger value={ModFilter.NeedsRepair}>
+                          <WrenchIcon className='mr-2 h-4 w-4' />
+                          {t("myMods.tabs.needsRepair")}
+                          <span className='ml-2 text-muted-foreground text-xs'>
+                            ({needsRepairCount})
+                          </span>
+                        </TabsTrigger>
+                      )}
                       <TabsTrigger value={ModFilter.Disabled}>
                         <Download className='mr-2 h-4 w-4' />
                         {t("myMods.tabs.downloaded")}
@@ -1118,6 +1196,12 @@ const MyMods = () => {
 
                 {displayMods.length > 0 && (
                   <TabsContent className='mt-0' value={ModFilter.Enabled}>
+                    <ModsList mods={visibleMods} viewMode={viewMode} />
+                  </TabsContent>
+                )}
+
+                {displayMods.length > 0 && (
+                  <TabsContent className='mt-0' value={ModFilter.NeedsRepair}>
                     <ModsList mods={visibleMods} viewMode={viewMode} />
                   </TabsContent>
                 )}

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -44,7 +44,9 @@ export type RepairReason =
   | "missingPayload"
   | "needsDownloadChoice"
   | "needsFileSelection"
-  | "repairFailed";
+  | "repairFailed"
+  | "fingerprintMismatch"
+  | "unverifiedManifest";
 
 export interface LocalMod extends ModDto {
   status: ModStatus;

--- a/apps/desktop/src/types/profiles.ts
+++ b/apps/desktop/src/types/profiles.ts
@@ -23,9 +23,20 @@ export interface ModProfile {
 
 export interface VpkManifestEntry {
   enabled: boolean;
+  desiredState?: "enabled" | "disabled";
+  diskState?: "active" | "disabled" | "missing" | "mismatch" | "unverified";
+  repairReason?:
+    | "missingEnabledVpks"
+    | "missingPayload"
+    | "needsDownloadChoice"
+    | "needsFileSelection"
+    | "repairFailed"
+    | "fingerprintMismatch"
+    | "unverifiedManifest";
   order?: number | null;
   currentVpks: string[];
   disabledVpks: string[];
+  quarantinedVpks?: string[];
   originalVpkNames: string[];
   sourceDownloads?: RepairDownloadItem[];
   vpkFingerprints?: Array<{


### PR DESCRIPTION
## Summary
- add `useRepairMods`, repair badges, repair actions, and My Mods repair controls/tab
- show repair status on download cards and mod cards/buttons
- preserve My Mods stable ordering for the repair tab and keep disabled mods separate from repairable mods
- include CodeRabbit follow-ups for path-only file matching and localized repair status labels

## Stack
Base: `codex/vpk-file-operation-consistency`

Depends on:
- merged #470
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/483
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/484
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/485
- https://github.com/deadlock-mod-manager/deadlock-mod-manager/pull/486

## Tests
- `pnpm --filter @deadlock-mods/desktop test -- src/lib/mods/library-display.test.ts src/lib/profiles/manifest-state.test.ts`
- `pnpm --filter @deadlock-mods/desktop check-types`

Recreated from https://github.com/oldreceipt/deadlock-mod-manager/pull/5
Original author: @oldreceipt
