### PR TITLE
feat(desktop): add autoexec command library 

### DIFF
--- a/.changeset/clever-autoexec-build.md
+++ b/.changeset/clever-autoexec-build.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Add autoexec command library with search, presets, clear, and launch toggle

--- a/.changeset/clever-autoexec-build.md
+++ b/.changeset/clever-autoexec-build.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-Add autoexec command library with search, presets, clear, and launch toggle
+Add autoexec command library with search, clear, and launch toggle

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -468,7 +468,13 @@ jobs:
 
   trigger-windows-signing:
     needs:
-      [check-commits, prepare-matrix, create-nightly-release, build-nightly, build-cef]
+      [
+        check-commits,
+        prepare-matrix,
+        create-nightly-release,
+        build-nightly,
+        build-cef,
+      ]
     if: >-
       always() &&
       needs.check-commits.outputs.should_build == 'true' &&

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -468,13 +468,7 @@ jobs:
 
   trigger-windows-signing:
     needs:
-      [
-        check-commits,
-        prepare-matrix,
-        create-nightly-release,
-        build-nightly,
-        build-cef,
-      ]
+      [check-commits, prepare-matrix, create-nightly-release, build-nightly, build-cef]
     if: >-
       always() &&
       needs.check-commits.outputs.should_build == 'true' &&

--- a/apps/desktop/src-tauri/src/commands/autoexec.rs
+++ b/apps/desktop/src-tauri/src/commands/autoexec.rs
@@ -67,7 +67,7 @@ pub async fn get_autoexec_config() -> Result<AutoexecConfig, Error> {
 pub async fn update_autoexec_config(
   full_content: String,
   readonly_sections: Vec<crate::mod_manager::ReadonlySection>,
-) -> Result<(), Error> {
+) -> Result<AutoexecConfig, Error> {
   log::info!("Updating autoexec config");
   let mod_manager = MANAGER.lock().unwrap();
   let game_path = mod_manager

--- a/apps/desktop/src-tauri/src/mod_manager/autoexec_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/autoexec_manager.rs
@@ -15,6 +15,27 @@ const MAP_COMMAND_SECTION_START: &str =
   "// === Deadlock Mod Manager - Map Command (DO NOT EDIT) ===";
 const MAP_COMMAND_SECTION_END: &str = "// === End Map Command ===";
 
+#[derive(Debug, Clone, Copy)]
+struct ManagedSection {
+  label: &'static str,
+  start_marker: &'static str,
+  end_marker: &'static str,
+}
+
+const CROSSHAIR_SECTION: ManagedSection = ManagedSection {
+  label: "crosshair",
+  start_marker: CROSSHAIR_SECTION_START,
+  end_marker: CROSSHAIR_SECTION_END,
+};
+
+const MAP_COMMAND_SECTION: ManagedSection = ManagedSection {
+  label: "map command",
+  start_marker: MAP_COMMAND_SECTION_START,
+  end_marker: MAP_COMMAND_SECTION_END,
+};
+
+const MANAGED_SECTIONS: &[ManagedSection] = &[CROSSHAIR_SECTION, MAP_COMMAND_SECTION];
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadonlySection {
   pub start_line: usize,
@@ -29,50 +50,103 @@ pub struct AutoexecConfig {
   pub readonly_sections: Vec<ReadonlySection>,
 }
 
-/// Merges managed readonly sections back into user-edited full content. Used by
-/// [`AutoexecManager::update_editable_content`] and unit tests.
+fn managed_section_for_content(content: &str) -> Option<ManagedSection> {
+  MANAGED_SECTIONS
+    .iter()
+    .find(|section| content.starts_with(section.start_marker))
+    .copied()
+}
+
+fn managed_section_for_line(line: &str) -> Option<ManagedSection> {
+  MANAGED_SECTIONS
+    .iter()
+    .find(|section| line.contains(section.start_marker))
+    .copied()
+}
+
+fn section_range(content: &str, section: ManagedSection) -> Option<(usize, usize)> {
+  let start_pos = content.find(section.start_marker)?;
+  let rel_end = content[start_pos..].find(section.end_marker)?;
+  let end_pos = start_pos + rel_end + section.end_marker.len();
+  Some((start_pos, end_pos))
+}
+
+fn append_section(content: &mut String, section_content: &str) {
+  if !content.is_empty() && !content.ends_with('\n') {
+    content.push('\n');
+  }
+  content.push_str(section_content);
+}
+
+fn upsert_managed_section(
+  content: &mut String,
+  section: ManagedSection,
+  section_content: &str,
+) {
+  if let Some((start_pos, end_pos)) = section_range(content, section) {
+    content.replace_range(start_pos..end_pos, section_content);
+    return;
+  }
+
+  if let Some(start_pos) = content.find(section.start_marker) {
+    log::warn!(
+      "Found {} start marker but not end marker, replacing from start marker",
+      section.label
+    );
+    content.replace_range(start_pos.., section_content);
+    return;
+  }
+
+  append_section(content, section_content);
+}
+
+fn remove_managed_section(content: &mut String, section: ManagedSection) {
+  if let Some((start_pos, end_pos)) = section_range(content, section) {
+    let before_section = content[..start_pos].trim_end();
+    let after_section = content[end_pos..].trim_start();
+
+    let mut new_content = String::new();
+    if !before_section.is_empty() {
+      new_content.push_str(before_section);
+    }
+    if !after_section.is_empty() {
+      append_section(&mut new_content, after_section);
+    }
+
+    *content = new_content;
+    return;
+  }
+
+  if let Some(start_pos) = content.find(section.start_marker) {
+    log::warn!(
+      "Found {} start marker but not end marker, removing from start marker to end",
+      section.label
+    );
+    content.truncate(start_pos);
+    *content = content.trim_end().to_string();
+    return;
+  }
+
+  log::info!("{} section not found, nothing to remove", section.label);
+}
+
 fn merge_readonly_sections_into_full_content(
   full_content: &str,
   readonly_sections: &[ReadonlySection],
 ) -> String {
   let mut result_content = full_content.to_string();
 
-  for readonly_section in readonly_sections.iter().rev() {
-    let (start_marker, end_marker) = if readonly_section
-      .content
-      .starts_with(MAP_COMMAND_SECTION_START)
-    {
-      (MAP_COMMAND_SECTION_START, MAP_COMMAND_SECTION_END)
-    } else if readonly_section
-      .content
-      .starts_with(CROSSHAIR_SECTION_START)
-    {
-      (CROSSHAIR_SECTION_START, CROSSHAIR_SECTION_END)
-    } else {
-      log::warn!(
-        "Readonly section does not start with a known managed marker; skipping merge for that section"
-      );
+  for readonly_section in readonly_sections {
+    let Some(section) = managed_section_for_content(&readonly_section.content) else {
+      log::warn!("Readonly section does not start with a known managed marker; skipping merge");
       continue;
     };
 
-    if let Some(start_pos) = result_content.find(start_marker) {
-      if let Some(rel_end) = result_content[start_pos..].find(end_marker) {
-        let end_pos = start_pos + rel_end + end_marker.len();
-        let current_section = &result_content[start_pos..end_pos];
-        if current_section != readonly_section.content {
-          result_content.replace_range(start_pos..end_pos, &readonly_section.content);
-        }
-      } else {
-        log::warn!("Found start marker but not end marker, restoring readonly section");
-        result_content.replace_range(start_pos.., &readonly_section.content);
-      }
-    } else {
+    if !result_content.contains(section.start_marker) {
       log::info!("Readonly section not found in content, restoring it");
-      if !result_content.is_empty() && !result_content.ends_with('\n') {
-        result_content.push('\n');
-      }
-      result_content.push_str(&readonly_section.content);
     }
+
+    upsert_managed_section(&mut result_content, section, &readonly_section.content);
   }
 
   result_content
@@ -132,29 +206,27 @@ impl AutoexecManager {
     let lines: Vec<&str> = full_content.lines().collect();
     let mut readonly_sections = Vec::new();
     let mut editable_lines = Vec::new();
-    let mut in_readonly_section = false;
+    let mut active_readonly_section: Option<ManagedSection> = None;
     let mut readonly_start = 0;
     let mut readonly_lines = Vec::new();
 
     for (line_num, line) in lines.iter().enumerate() {
-      if line.contains(CROSSHAIR_SECTION_START) || line.contains(MAP_COMMAND_SECTION_START) {
-        in_readonly_section = true;
+      if let Some(section) = managed_section_for_line(line) {
+        active_readonly_section = Some(section);
         readonly_start = line_num;
         readonly_lines.clear();
         readonly_lines.push(*line);
-      } else if line.contains(CROSSHAIR_SECTION_END) || line.contains(MAP_COMMAND_SECTION_END) {
-        if in_readonly_section {
-          readonly_lines.push(*line);
+      } else if let Some(section) = active_readonly_section {
+        readonly_lines.push(*line);
+        if line.contains(section.end_marker) {
           readonly_sections.push(ReadonlySection {
             start_line: readonly_start,
             end_line: line_num,
             content: readonly_lines.join("\n"),
           });
           readonly_lines.clear();
-          in_readonly_section = false;
+          active_readonly_section = None;
         }
-      } else if in_readonly_section {
-        readonly_lines.push(*line);
       } else {
         editable_lines.push(*line);
       }
@@ -173,9 +245,10 @@ impl AutoexecManager {
     game_path: &Path,
     full_content: &str,
     readonly_sections: &[ReadonlySection],
-  ) -> Result<(), Error> {
+  ) -> Result<AutoexecConfig, Error> {
     let result_content = merge_readonly_sections_into_full_content(full_content, readonly_sections);
-    self.write_autoexec_config(game_path, &result_content)
+    self.write_autoexec_config(game_path, &result_content)?;
+    self.get_editable_content(game_path)
   }
 
   pub fn update_crosshair_section(
@@ -189,21 +262,7 @@ impl AutoexecManager {
       CROSSHAIR_SECTION_START, crosshair_config, CROSSHAIR_SECTION_END
     );
 
-    if let Some(start_pos) = content.find(CROSSHAIR_SECTION_START) {
-      if let Some(end_pos) = content.find(CROSSHAIR_SECTION_END) {
-        let end_pos = end_pos + CROSSHAIR_SECTION_END.len();
-        content.replace_range(start_pos..end_pos, &crosshair_section);
-      } else {
-        log::warn!("Found start marker but not end marker, appending section");
-        content.push('\n');
-        content.push_str(&crosshair_section);
-      }
-    } else {
-      if !content.is_empty() && !content.ends_with('\n') {
-        content.push('\n');
-      }
-      content.push_str(&crosshair_section);
-    }
+    upsert_managed_section(&mut content, CROSSHAIR_SECTION, &crosshair_section);
 
     self.write_autoexec_config(game_path, &content)
   }
@@ -211,32 +270,7 @@ impl AutoexecManager {
   pub fn remove_crosshair_section(&self, game_path: &Path) -> Result<(), Error> {
     let mut content = self.read_autoexec_config(game_path)?;
 
-    if let Some(start_pos) = content.find(CROSSHAIR_SECTION_START) {
-      if let Some(end_pos) = content.find(CROSSHAIR_SECTION_END) {
-        let end_pos = end_pos + CROSSHAIR_SECTION_END.len();
-        let before_section = content[..start_pos].trim_end();
-        let after_section = content[end_pos..].trim_start();
-
-        let mut new_content = String::new();
-        if !before_section.is_empty() {
-          new_content.push_str(before_section);
-        }
-        if !after_section.is_empty() {
-          if !new_content.is_empty() && !new_content.ends_with('\n') {
-            new_content.push('\n');
-          }
-          new_content.push_str(after_section);
-        }
-
-        content = new_content;
-      } else {
-        log::warn!("Found start marker but not end marker, removing from start marker to end");
-        content.truncate(start_pos);
-        content = content.trim_end().to_string();
-      }
-    } else {
-      log::info!("Crosshair section not found, nothing to remove");
-    }
+    remove_managed_section(&mut content, CROSSHAIR_SECTION);
 
     self.write_autoexec_config(game_path, &content)
   }
@@ -248,21 +282,7 @@ impl AutoexecManager {
       MAP_COMMAND_SECTION_START, map_name, MAP_COMMAND_SECTION_END
     );
 
-    if let Some(start_pos) = content.find(MAP_COMMAND_SECTION_START) {
-      if let Some(end_pos) = content.find(MAP_COMMAND_SECTION_END) {
-        let end_pos = end_pos + MAP_COMMAND_SECTION_END.len();
-        content.replace_range(start_pos..end_pos, &map_section);
-      } else {
-        log::warn!("Found map command start marker but not end marker, appending section");
-        content.push('\n');
-        content.push_str(&map_section);
-      }
-    } else {
-      if !content.is_empty() && !content.ends_with('\n') {
-        content.push('\n');
-      }
-      content.push_str(&map_section);
-    }
+    upsert_managed_section(&mut content, MAP_COMMAND_SECTION, &map_section);
 
     self.write_autoexec_config(game_path, &content)
   }
@@ -270,34 +290,7 @@ impl AutoexecManager {
   pub fn remove_map_command(&self, game_path: &Path) -> Result<(), Error> {
     let mut content = self.read_autoexec_config(game_path)?;
 
-    if let Some(start_pos) = content.find(MAP_COMMAND_SECTION_START) {
-      if let Some(end_pos) = content.find(MAP_COMMAND_SECTION_END) {
-        let end_pos = end_pos + MAP_COMMAND_SECTION_END.len();
-        let before_section = content[..start_pos].trim_end();
-        let after_section = content[end_pos..].trim_start();
-
-        let mut new_content = String::new();
-        if !before_section.is_empty() {
-          new_content.push_str(before_section);
-        }
-        if !after_section.is_empty() {
-          if !new_content.is_empty() && !new_content.ends_with('\n') {
-            new_content.push('\n');
-          }
-          new_content.push_str(after_section);
-        }
-
-        content = new_content;
-      } else {
-        log::warn!(
-          "Found map command start marker but not end marker, removing from start marker to end"
-        );
-        content.truncate(start_pos);
-        content = content.trim_end().to_string();
-      }
-    } else {
-      log::info!("Map command section not found, nothing to remove");
-    }
+    remove_managed_section(&mut content, MAP_COMMAND_SECTION);
 
     self.write_autoexec_config(game_path, &content)
   }
@@ -305,9 +298,7 @@ impl AutoexecManager {
   pub fn get_map_command(&self, game_path: &Path) -> Result<Option<String>, Error> {
     let content = self.read_autoexec_config(game_path)?;
 
-    if let Some(start_pos) = content.find(MAP_COMMAND_SECTION_START)
-      && let Some(end_pos) = content.find(MAP_COMMAND_SECTION_END)
-    {
+    if let Some((start_pos, end_pos)) = section_range(&content, MAP_COMMAND_SECTION) {
       let section = &content[start_pos..end_pos];
       for line in section.lines() {
         let trimmed = line.trim();
@@ -394,6 +385,15 @@ mod tests {
     }
   }
 
+  fn unique_test_game_path(test_name: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .expect("system clock should be after unix epoch")
+      .as_nanos();
+
+    std::env::temp_dir().join(format!("dmm_autoexec_{test_name}_{nanos}"))
+  }
+
   #[test]
   fn merge_map_only_idempotent_no_duplicate_on_second_pass() {
     let map = map_section("streetball");
@@ -451,5 +451,25 @@ mod tests {
     assert!(out.contains(MAP_COMMAND_SECTION_START));
     assert!(out.contains("map streetball"));
     assert_eq!(out.matches(MAP_COMMAND_SECTION_START).count(), 1);
+  }
+
+  #[test]
+  fn update_editable_content_returns_restored_readonly_content() {
+    let manager = AutoexecManager::new();
+    let game_path = unique_test_game_path("returns_restored_readonly_content");
+    let map = map_section("streetball");
+    let sections = vec![section_readonly(&map)];
+
+    let returned = manager
+      .update_editable_content(&game_path, "", &sections)
+      .expect("autoexec update should succeed");
+    let written = std::fs::read_to_string(manager.get_autoexec_path(&game_path))
+      .expect("autoexec should be written");
+
+    assert!(returned.full_content.contains(MAP_COMMAND_SECTION_START));
+    assert!(returned.full_content.contains("map streetball"));
+    assert_eq!(written, returned.full_content);
+
+    std::fs::remove_dir_all(&game_path).expect("temp game path should be removed");
   }
 }

--- a/apps/desktop/src/components/crosshairs/active-crosshairs.tsx
+++ b/apps/desktop/src/components/crosshairs/active-crosshairs.tsx
@@ -107,7 +107,7 @@ export const ActiveCrosshairs = () => {
       <h2 className='text-lg font-semibold mb-4'>
         {t("crosshairs.activeCrosshairs")}
       </h2>
-      <div className='flex gap-4 overflow-x-auto pb-2'>
+      <div className='flex gap-4 overflow-x-auto pb-2 pt-1'>
         {activeCrosshairHistory.map(
           (config: CrosshairConfig, index: number) => (
             <div

--- a/apps/desktop/src/components/crosshairs/crosshair-card.tsx
+++ b/apps/desktop/src/components/crosshairs/crosshair-card.tsx
@@ -10,12 +10,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@deadlock-mods/ui/components/tooltip";
-import {
-  CheckIcon,
-  EyeIcon,
-  PencilIcon,
-  TrashIcon,
-} from "@phosphor-icons/react";
+import { CheckCircleIcon, EyeIcon, TrashIcon } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
@@ -110,20 +105,20 @@ export const CrosshairCard = ({
           "hover:-translate-y-0.5 hover:border-primary/40 hover:bg-card/80",
           "hover:shadow-lg hover:shadow-primary/5",
           isActive &&
-            "border-primary/60 shadow-md shadow-primary/10 ring-1 ring-primary/30",
+            "border-primary/50 shadow-md shadow-primary/10 ring-1 ring-primary/20",
         )}
         onClick={handlePreviewOpen}>
         <CardContent className='relative flex flex-col p-0'>
-          {isActive && (
+          {isActive && !crosshair && (
             <>
-              <CornerBracket className='top-1.5 left-1.5 border-t-2 border-l-2' />
-              <CornerBracket className='top-1.5 right-1.5 border-t-2 border-r-2' />
-              <CornerBracket className='bottom-1.5 left-1.5 border-b-2 border-l-2' />
-              <CornerBracket className='bottom-1.5 right-1.5 border-b-2 border-r-2' />
+              <CornerBracket position='top-left' />
+              <CornerBracket position='top-right' />
+              <CornerBracket position='bottom-left' />
+              <CornerBracket position='bottom-right' />
             </>
           )}
 
-          <div className='relative h-[200px] w-full overflow-hidden'>
+          <div className='relative h-[200px] w-full'>
             <div
               aria-hidden
               className={cn(
@@ -145,8 +140,8 @@ export const CrosshairCard = ({
               className={cn(
                 "absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 p-2",
                 "bg-gradient-to-t from-background/95 via-background/70 to-transparent",
-                "translate-y-2 opacity-0 transition-all duration-200 ease-out",
-                "group-hover:translate-y-0 group-hover:opacity-100",
+                "opacity-0 transition-opacity duration-200 ease-out",
+                "group-hover:opacity-100",
               )}>
               <ActionIconButton
                 icon={<EyeIcon className='h-4 w-4' weight='duotone' />}
@@ -158,11 +153,10 @@ export const CrosshairCard = ({
               />
               <ActionIconButton
                 icon={
-                  isActive ? (
-                    <CheckIcon className='h-4 w-4' weight='bold' />
-                  ) : (
-                    <PencilIcon className='h-4 w-4' weight='duotone' />
-                  )
+                  <CheckCircleIcon
+                    className='h-4 w-4'
+                    weight={isActive ? "fill" : "duotone"}
+                  />
                 }
                 label={
                   isActive
@@ -189,20 +183,6 @@ export const CrosshairCard = ({
                 />
               )}
             </div>
-
-            {isActive && (
-              <div className='absolute top-2 right-2 z-10 flex items-center gap-1.5 rounded-full border border-primary/40 bg-background/80 px-2 py-0.5 backdrop-blur-sm'>
-                <span className='relative flex h-1.5 w-1.5'>
-                  <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75' />
-                  <span className='relative inline-flex h-1.5 w-1.5 rounded-full bg-primary' />
-                </span>
-                <span
-                  className='font-bold text-[9px] text-primary uppercase tracking-[0.2em]'
-                  style={SERIF_FONT}>
-                  {t("crosshairs.currentlyActive")}
-                </span>
-              </div>
-            )}
           </div>
 
           {crosshair && (
@@ -266,12 +246,21 @@ export const CrosshairCard = ({
   );
 };
 
-const CornerBracket = ({ className }: { className?: string }) => (
+type CornerPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+const cornerPositionClasses: Record<CornerPosition, string> = {
+  "top-left": "top-1.5 left-1.5 border-t-2 border-l-2",
+  "top-right": "top-1.5 right-1.5 border-t-2 border-r-2",
+  "bottom-left": "bottom-1.5 left-1.5 border-b-2 border-l-2",
+  "bottom-right": "bottom-1.5 right-1.5 border-b-2 border-r-2",
+};
+
+const CornerBracket = ({ position }: { position: CornerPosition }) => (
   <span
     aria-hidden
     className={cn(
-      "pointer-events-none absolute z-10 h-2.5 w-2.5 border-primary/70",
-      className,
+      "pointer-events-none absolute z-10 h-3 w-3 border-primary/60",
+      cornerPositionClasses[position],
     )}
   />
 );

--- a/apps/desktop/src/components/settings/autoexec-settings.tsx
+++ b/apps/desktop/src/components/settings/autoexec-settings.tsx
@@ -30,7 +30,10 @@ import {
   getAutoexecCommandFileComment,
   normalizeAutoexecContent,
 } from "@/lib/autoexec/autoexec-content";
-import { enableAutoexecLaunchOptionIfDisabled } from "@/lib/autoexec/launch-option";
+import {
+  disableAutoexecLaunchOptionIfEnabled,
+  enableAutoexecLaunchOptionIfDisabled,
+} from "@/lib/autoexec/launch-option";
 import type { FlatAutoexecCommand } from "@/lib/autoexec/predefined-commands";
 import logger from "@/lib/logger";
 import { STALE_TIME_LOCAL } from "@/lib/query-constants";
@@ -94,6 +97,8 @@ export const AutoexecSettings = () => {
 
         if (variables.fullContent.trim().length > 0) {
           enableAutoexecLaunchOptionIfDisabled();
+        } else {
+          disableAutoexecLaunchOptionIfEnabled();
         }
       }
 
@@ -154,6 +159,7 @@ export const AutoexecSettings = () => {
       });
     },
     onSuccess: async () => {
+      disableAutoexecLaunchOptionIfEnabled();
       toast.success(t("settings.autoexecCleared"));
       await queryClient.invalidateQueries({ queryKey: ["autoexec-config"] });
     },

--- a/apps/desktop/src/components/settings/autoexec-settings.tsx
+++ b/apps/desktop/src/components/settings/autoexec-settings.tsx
@@ -16,15 +16,25 @@ import {
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Textarea } from "@deadlock-mods/ui/components/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { FolderOpenIcon, PencilIcon } from "@phosphor-icons/react";
+import { FolderOpenIcon, PencilIcon, TrashIcon } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
+import { useConfirm } from "@/components/providers/alert-dialog";
+import {
+  appendPredefinedCommand,
+  commandExistsInContent,
+  getAutoexecCommandFileComment,
+  normalizeAutoexecContent,
+} from "@/lib/autoexec/autoexec-content";
+import { enableAutoexecLaunchOptionIfDisabled } from "@/lib/autoexec/launch-option";
+import type { FlatAutoexecCommand } from "@/lib/autoexec/predefined-commands";
 import logger from "@/lib/logger";
 import { STALE_TIME_LOCAL } from "@/lib/query-constants";
+import { AutoexecCommandLibrary } from "./autoexec/autoexec-command-library";
 import Section from "./section";
 
 interface ReadonlySection {
@@ -51,7 +61,9 @@ type AutoexecFormValues = z.infer<typeof autoexecSchema>;
 
 export const AutoexecSettings = () => {
   const { t } = useTranslation();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
+  const isSilentSaveRef = useRef(false);
   const { data: config, isLoading } = useQuery({
     queryKey: ["autoexec-config"],
     queryFn: getAutoexecConfig,
@@ -67,14 +79,6 @@ export const AutoexecSettings = () => {
     },
   });
 
-  useEffect(() => {
-    if (config) {
-      form.reset({
-        content: config.full_content,
-      });
-    }
-  }, [config, form]);
-
   const saveMutation = useMutation({
     mutationFn: async (params: {
       fullContent: string;
@@ -82,8 +86,18 @@ export const AutoexecSettings = () => {
     }) => {
       return invoke("update_autoexec_config", params);
     },
-    onSuccess: async () => {
-      toast.success(t("settings.autoexecSaved"));
+    onSuccess: async (_data, variables) => {
+      const wasSilentSave = isSilentSaveRef.current;
+
+      if (!wasSilentSave) {
+        toast.success(t("settings.autoexecSaved"));
+
+        if (variables.fullContent.trim().length > 0) {
+          enableAutoexecLaunchOptionIfDisabled();
+        }
+      }
+
+      isSilentSaveRef.current = false;
       await queryClient.invalidateQueries({ queryKey: ["autoexec-config"] });
     },
     onError: (error) => {
@@ -91,6 +105,26 @@ export const AutoexecSettings = () => {
       toast.error(t("settings.autoexecSaveError"));
     },
   });
+
+  useEffect(() => {
+    if (!config) {
+      return;
+    }
+
+    const normalizedContent = normalizeAutoexecContent(config.full_content);
+
+    if (normalizedContent !== config.full_content) {
+      form.reset({ content: normalizedContent });
+      isSilentSaveRef.current = true;
+      saveMutation.mutate({
+        fullContent: normalizedContent,
+        readonlySections: config.readonly_sections,
+      });
+      return;
+    }
+
+    form.reset({ content: config.full_content });
+  }, [config, form]);
 
   const openFolderMutation = useMutation({
     mutationFn: () => invoke("open_autoexec_folder"),
@@ -108,8 +142,32 @@ export const AutoexecSettings = () => {
     },
   });
 
+  const clearMutation = useMutation({
+    mutationFn: async () => {
+      if (!config) {
+        return;
+      }
+
+      return invoke("update_autoexec_config", {
+        fullContent: "",
+        readonlySections: config.readonly_sections,
+      });
+    },
+    onSuccess: async () => {
+      toast.success(t("settings.autoexecCleared"));
+      await queryClient.invalidateQueries({ queryKey: ["autoexec-config"] });
+    },
+    onError: (error) => {
+      logger.errorOnly(error);
+      toast.error(t("settings.autoexecSaveError"));
+    },
+  });
+
   const onSubmit = (values: AutoexecFormValues) => {
-    if (!config) return;
+    if (!config) {
+      return;
+    }
+
     saveMutation.mutate({
       fullContent: values.content,
       readonlySections: config.readonly_sections,
@@ -124,7 +182,47 @@ export const AutoexecSettings = () => {
     openEditorMutation.mutate();
   };
 
+  const handleClear = async () => {
+    if (!config) {
+      return;
+    }
+
+    const confirmed = await confirm({
+      title: t("settings.autoexecClearConfirmTitle"),
+      body: t("settings.autoexecClearConfirmBody"),
+      actionButton: t("settings.autoexecClearConfirmAction"),
+      cancelButton: t("common.cancel"),
+      tone: "destructive",
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    clearMutation.mutate();
+  };
+
   const watchedContent = form.watch("content");
+
+  const handleAddCommand = useCallback(
+    (command: FlatAutoexecCommand) => {
+      if (commandExistsInContent(watchedContent, command.command)) {
+        return;
+      }
+
+      const description = getAutoexecCommandFileComment(command.id);
+      const nextContent = appendPredefinedCommand(
+        watchedContent,
+        command.command,
+        command.value,
+        description,
+      );
+
+      form.setValue("content", nextContent, { shouldDirty: true });
+      toast.success(t("settings.autoexecCommandAdded"));
+    },
+    [form, t, watchedContent],
+  );
 
   const isDirty = watchedContent !== config?.full_content;
 
@@ -144,29 +242,22 @@ export const AutoexecSettings = () => {
     <Section
       description={t("settings.autoexecDescription")}
       title={t("settings.autoexec")}>
-      <div className='space-y-4'>
+      <div className='space-y-6'>
         <Card className='p-0'>
           <CardHeader>
-            <CardTitle>What's an Autoexec Config?</CardTitle>
-            <CardDescription>
-              <p>
-                Autoexec is a CFG file for launching a game with set convars
-                (think console command) that will get automatically executed on
-                launch of the game.
-              </p>
-              <p>
-                The mod manager uses this file to set the crosshair settings
-                automatically without needing to run commands in the console.
-                You can still edit the file manually if you want to to add more
-                commands.
-              </p>
-              <p>
-                P.S: the autoexec config can never be empty if added as launch
-                option or else it'll crash the game.
-              </p>
+            <CardTitle>{t("settings.autoexecInfoTitle")}</CardTitle>
+            <CardDescription className='space-y-3'>
+              <p>{t("settings.autoexecInfoBody1")}</p>
+              <p>{t("settings.autoexecInfoBody2")}</p>
+              <p>{t("settings.autoexecInfoBody3")}</p>
             </CardDescription>
           </CardHeader>
         </Card>
+
+        <AutoexecCommandLibrary
+          content={watchedContent}
+          onAddCommand={handleAddCommand}
+        />
 
         <Form {...form}>
           <form className='space-y-4' onSubmit={form.handleSubmit(onSubmit)}>
@@ -176,7 +267,7 @@ export const AutoexecSettings = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className='text-lg font-semibold'>
-                    Current Autoexec Config
+                    {t("settings.autoexecEditorHeading")}
                   </FormLabel>
                   <FormControl>
                     <Textarea
@@ -198,28 +289,39 @@ export const AutoexecSettings = () => {
 
             <div className='flex gap-2'>
               <Button
+                isLoading={openFolderMutation.isPending}
                 onClick={handleOpenFolder}
                 type='button'
-                variant='outline'
-                isLoading={openFolderMutation.isPending}>
+                variant='outline'>
                 <FolderOpenIcon className='h-4 w-4' />
                 {t("settings.openInFolder")}
               </Button>
               <Button
+                isLoading={openEditorMutation.isPending}
                 onClick={handleOpenEditor}
                 type='button'
-                variant='outline'
-                isLoading={openEditorMutation.isPending}>
+                variant='outline'>
                 <PencilIcon className='h-4 w-4' />
                 {t("settings.openInEditor")}
               </Button>
               <Button
+                disabled={
+                  clearMutation.isPending || watchedContent.trim().length === 0
+                }
+                isLoading={clearMutation.isPending}
+                onClick={handleClear}
+                type='button'
+                variant='outline'>
+                <TrashIcon className='h-4 w-4' />
+                {t("settings.autoexecClear")}
+              </Button>
+              <Button
                 className='ml-auto'
-                isLoading={saveMutation.isPending}
                 disabled={saveMutation.isPending || !isDirty}
+                isLoading={saveMutation.isPending}
                 type='submit'>
                 {saveMutation.isPending
-                  ? "Saving..."
+                  ? t("settings.autoexecSaving")
                   : t("settings.saveChanges")}
               </Button>
             </div>

--- a/apps/desktop/src/components/settings/autoexec-settings.tsx
+++ b/apps/desktop/src/components/settings/autoexec-settings.tsx
@@ -103,12 +103,14 @@ export const AutoexecSettings = () => {
         }
       }
 
-      isSilentSaveRef.current = false;
       await queryClient.invalidateQueries({ queryKey: ["autoexec-config"] });
     },
     onError: (error) => {
       logger.errorOnly(error);
       toast.error(t("settings.autoexecSaveError"));
+    },
+    onSettled: () => {
+      isSilentSaveRef.current = false;
     },
   });
 
@@ -159,6 +161,11 @@ export const AutoexecSettings = () => {
       if (!hasAutoexecLaunchableContent(savedConfig.full_content)) {
         disableAutoexecLaunchOptionIfEnabled();
       }
+      queryClient.setQueryData<AutoexecConfig>(
+        ["autoexec-config"],
+        savedConfig,
+      );
+      form.reset({ content: savedConfig.full_content });
       toast.success(t("settings.autoexecCleared"));
       await queryClient.invalidateQueries({ queryKey: ["autoexec-config"] });
     },

--- a/apps/desktop/src/components/settings/autoexec-settings.tsx
+++ b/apps/desktop/src/components/settings/autoexec-settings.tsx
@@ -28,6 +28,7 @@ import {
   appendPredefinedCommand,
   commandExistsInContent,
   getAutoexecCommandFileComment,
+  hasAutoexecLaunchableContent,
   normalizeAutoexecContent,
 } from "@/lib/autoexec/autoexec-content";
 import {
@@ -87,15 +88,15 @@ export const AutoexecSettings = () => {
       fullContent: string;
       readonlySections: ReadonlySection[];
     }) => {
-      return invoke("update_autoexec_config", params);
+      return invoke<AutoexecConfig>("update_autoexec_config", params);
     },
-    onSuccess: async (_data, variables) => {
+    onSuccess: async (savedConfig) => {
       const wasSilentSave = isSilentSaveRef.current;
 
       if (!wasSilentSave) {
         toast.success(t("settings.autoexecSaved"));
 
-        if (variables.fullContent.trim().length > 0) {
+        if (hasAutoexecLaunchableContent(savedConfig.full_content)) {
           enableAutoexecLaunchOptionIfDisabled();
         } else {
           disableAutoexecLaunchOptionIfEnabled();
@@ -148,18 +149,16 @@ export const AutoexecSettings = () => {
   });
 
   const clearMutation = useMutation({
-    mutationFn: async () => {
-      if (!config) {
-        return;
-      }
-
-      return invoke("update_autoexec_config", {
+    mutationFn: async (currentConfig: AutoexecConfig) => {
+      return invoke<AutoexecConfig>("update_autoexec_config", {
         fullContent: "",
-        readonlySections: config.readonly_sections,
+        readonlySections: currentConfig.readonly_sections,
       });
     },
-    onSuccess: async () => {
-      disableAutoexecLaunchOptionIfEnabled();
+    onSuccess: async (savedConfig) => {
+      if (!hasAutoexecLaunchableContent(savedConfig.full_content)) {
+        disableAutoexecLaunchOptionIfEnabled();
+      }
       toast.success(t("settings.autoexecCleared"));
       await queryClient.invalidateQueries({ queryKey: ["autoexec-config"] });
     },
@@ -205,7 +204,7 @@ export const AutoexecSettings = () => {
       return;
     }
 
-    clearMutation.mutate();
+    clearMutation.mutate(config);
   };
 
   const watchedContent = form.watch("content");

--- a/apps/desktop/src/components/settings/autoexec/autoexec-category-chips.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-category-chips.tsx
@@ -1,0 +1,56 @@
+import type { LucideIcon } from "@deadlock-mods/ui/icons";
+import { Button } from "@deadlock-mods/ui/components/button";
+import { LayoutGrid } from "@deadlock-mods/ui/icons";
+import { useTranslation } from "react-i18next";
+import type { AutoexecLibraryCategoryFilter } from "@/hooks/use-autoexec-library-filter";
+import { AUTOEXEC_CATEGORIES } from "@/lib/autoexec/predefined-commands";
+import { cn } from "@/lib/utils";
+
+type AutoexecCategoryChipsProps = {
+  selectedCategory: AutoexecLibraryCategoryFilter;
+  onCategoryChange: (categoryId: AutoexecLibraryCategoryFilter) => void;
+};
+
+export const AutoexecCategoryChips = ({
+  selectedCategory,
+  onCategoryChange,
+}: AutoexecCategoryChipsProps) => {
+  const { t } = useTranslation();
+
+  const renderChip = (
+    categoryId: AutoexecLibraryCategoryFilter,
+    label: string,
+    Icon?: LucideIcon,
+  ) => {
+    const isSelected = selectedCategory === categoryId;
+
+    return (
+      <Button
+        className={cn(
+          "shrink-0 gap-1.5",
+          isSelected && "border-primary/60 bg-primary/5 text-primary",
+        )}
+        key={categoryId}
+        onClick={() => onCategoryChange(categoryId)}
+        size='sm'
+        type='button'
+        variant='outline'>
+        {Icon ? <Icon className='h-3.5 w-3.5' /> : null}
+        {label}
+      </Button>
+    );
+  };
+
+  return (
+    <div className='-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+      {renderChip("all", t("settings.autoexecCategories.all"), LayoutGrid)}
+      {AUTOEXEC_CATEGORIES.map((category) =>
+        renderChip(
+          category.id,
+          t(`settings.autoexecCategories.${category.id}`),
+          category.icon,
+        ),
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/settings/autoexec/autoexec-category-chips.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-category-chips.tsx
@@ -43,7 +43,7 @@ export const AutoexecCategoryChips = ({
   };
 
   return (
-    <div className='-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+    <div className='-mx-1 flex gap-2 overflow-x-auto overscroll-x-contain px-1 pb-2'>
       {renderChip("all", t("settings.autoexecCategories.all"), LayoutGrid)}
       {AUTOEXEC_CATEGORIES.map((category) =>
         renderChip(

--- a/apps/desktop/src/components/settings/autoexec/autoexec-category-chips.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-category-chips.tsx
@@ -26,6 +26,7 @@ export const AutoexecCategoryChips = ({
 
     return (
       <Button
+        aria-pressed={isSelected}
         className={cn(
           "shrink-0 gap-1.5",
           isSelected && "border-primary/60 bg-primary/5 text-primary",

--- a/apps/desktop/src/components/settings/autoexec/autoexec-command-library.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-command-library.tsx
@@ -1,4 +1,6 @@
+import { Alert, AlertDescription } from "@deadlock-mods/ui/components/alert";
 import { SearchInput } from "@deadlock-mods/ui/components/search-input";
+import { AlertTriangle } from "@deadlock-mods/ui/icons";
 import { useTranslation } from "react-i18next";
 import { useAutoexecLibraryFilter } from "@/hooks/use-autoexec-library-filter";
 import type { FlatAutoexecCommand } from "@/lib/autoexec/predefined-commands";
@@ -27,6 +29,13 @@ export const AutoexecCommandLibrary = ({
 
   return (
     <div className='flex flex-col gap-4'>
+      <Alert variant='warning'>
+        <AlertTriangle className='h-4 w-4' />
+        <AlertDescription>
+          {t("settings.autoexecCommandWarning")}
+        </AlertDescription>
+      </Alert>
+
       <div className='flex flex-col gap-1'>
         <h4 className='font-semibold text-foreground text-sm'>
           {t("settings.autoexecLibraryHeading")}

--- a/apps/desktop/src/components/settings/autoexec/autoexec-command-library.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-command-library.tsx
@@ -1,0 +1,101 @@
+import { SearchInput } from "@deadlock-mods/ui/components/search-input";
+import { useTranslation } from "react-i18next";
+import { useAutoexecLibraryFilter } from "@/hooks/use-autoexec-library-filter";
+import type { FlatAutoexecCommand } from "@/lib/autoexec/predefined-commands";
+import { AutoexecCategoryChips } from "./autoexec-category-chips";
+import { AutoexecCommandRow } from "./autoexec-command-row";
+
+type AutoexecCommandLibraryProps = {
+  content: string;
+  onAddCommand: (command: FlatAutoexecCommand) => void;
+};
+
+export const AutoexecCommandLibrary = ({
+  content,
+  onAddCommand,
+}: AutoexecCommandLibraryProps) => {
+  const { t } = useTranslation();
+  const {
+    query,
+    setQuery,
+    selectedCategory,
+    setSelectedCategory,
+    filteredCommands,
+    groupedCategories,
+    hasResults,
+  } = useAutoexecLibraryFilter(t);
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-1'>
+        <h4 className='font-semibold text-foreground text-sm'>
+          {t("settings.autoexecLibraryHeading")}
+        </h4>
+        <p className='text-muted-foreground text-sm'>
+          {t("settings.autoexecLibraryDescription")}
+        </p>
+      </div>
+
+      <SearchInput
+        id='autoexec-command-search'
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder={t("settings.autoexecLibrarySearchPlaceholder")}
+        value={query}
+      />
+
+      <AutoexecCategoryChips
+        onCategoryChange={setSelectedCategory}
+        selectedCategory={selectedCategory}
+      />
+
+      <div className='max-h-[420px] overflow-y-auto rounded-md border border-border/30 bg-background/20 p-3'>
+        {!hasResults ? (
+          <p className='py-8 text-center text-muted-foreground text-sm'>
+            {t("settings.autoexecLibraryEmpty")}
+          </p>
+        ) : selectedCategory === "all" ? (
+          <div className='flex flex-col gap-6'>
+            {groupedCategories.map(({ category, commands }) => {
+              const CategoryIcon = category.icon;
+
+              return (
+                <div className='flex flex-col gap-2' key={category.id}>
+                  <div className='sticky top-0 z-10 flex items-center gap-2 border-border/30 border-b bg-background/95 py-2 backdrop-blur-sm'>
+                    <CategoryIcon className='h-4 w-4 text-primary' />
+                    <h5 className='font-semibold text-foreground text-sm'>
+                      {t(`settings.autoexecCategories.${category.id}`)}
+                    </h5>
+                    <span className='text-muted-foreground text-xs'>
+                      ({commands.length})
+                    </span>
+                  </div>
+                  <div className='flex flex-col gap-2'>
+                    {commands.map((command) => (
+                      <AutoexecCommandRow
+                        command={command}
+                        content={content}
+                        key={command.id}
+                        onAddCommand={onAddCommand}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className='flex flex-col gap-2'>
+            {filteredCommands.map((command) => (
+              <AutoexecCommandRow
+                command={command}
+                content={content}
+                key={command.id}
+                onAddCommand={onAddCommand}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/components/settings/autoexec/autoexec-command-library.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-command-library.tsx
@@ -57,7 +57,7 @@ export const AutoexecCommandLibrary = ({
         selectedCategory={selectedCategory}
       />
 
-      <div className='max-h-[420px] overflow-y-auto rounded-md border border-border/30 bg-background/20 p-3'>
+      <div className='max-h-[420px] overflow-y-auto rounded-md border border-border/30 bg-background/20 px-3 pb-3'>
         {!hasResults ? (
           <p className='py-8 text-center text-muted-foreground text-sm'>
             {t("settings.autoexecLibraryEmpty")}

--- a/apps/desktop/src/components/settings/autoexec/autoexec-command-row.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-command-row.tsx
@@ -22,13 +22,21 @@ export const AutoexecCommandRow = ({
   const { t } = useTranslation();
   const isAdded = commandExistsInContent(content, command.command);
   const description = t(`settings.autoexecCommands.${command.id}.description`);
+  const isDefaultCommand = command.intent === "default";
 
   return (
     <div className='flex flex-row items-center justify-between gap-4 rounded-md border border-border/30 bg-background/40 px-4 py-3 transition-colors hover:bg-muted/30'>
       <div className='flex min-w-0 flex-col gap-1'>
-        <code className='font-mono text-sm text-foreground'>
-          {formatCommandPreview(command.command, command.value)}
-        </code>
+        <div className='flex flex-wrap items-center gap-2'>
+          <code className='font-mono text-sm text-foreground'>
+            {formatCommandPreview(command.command, command.value)}
+          </code>
+          {isDefaultCommand && (
+            <Badge variant='outline'>
+              {t("settings.autoexecCommandDefaultBadge")}
+            </Badge>
+          )}
+        </div>
         <p className='text-muted-foreground text-sm'>{description}</p>
       </div>
 

--- a/apps/desktop/src/components/settings/autoexec/autoexec-command-row.tsx
+++ b/apps/desktop/src/components/settings/autoexec/autoexec-command-row.tsx
@@ -1,0 +1,53 @@
+import { Badge } from "@deadlock-mods/ui/components/badge";
+import { Button } from "@deadlock-mods/ui/components/button";
+import { PlusIcon } from "@deadlock-mods/ui/icons";
+import { useTranslation } from "react-i18next";
+import {
+  commandExistsInContent,
+  formatCommandPreview,
+} from "@/lib/autoexec/autoexec-content";
+import type { FlatAutoexecCommand } from "@/lib/autoexec/predefined-commands";
+
+type AutoexecCommandRowProps = {
+  command: FlatAutoexecCommand;
+  content: string;
+  onAddCommand: (command: FlatAutoexecCommand) => void;
+};
+
+export const AutoexecCommandRow = ({
+  command,
+  content,
+  onAddCommand,
+}: AutoexecCommandRowProps) => {
+  const { t } = useTranslation();
+  const isAdded = commandExistsInContent(content, command.command);
+  const description = t(`settings.autoexecCommands.${command.id}.description`);
+
+  return (
+    <div className='flex flex-row items-center justify-between gap-4 rounded-md border border-border/30 bg-background/40 px-4 py-3 transition-colors hover:bg-muted/30'>
+      <div className='flex min-w-0 flex-col gap-1'>
+        <code className='font-mono text-sm text-foreground'>
+          {formatCommandPreview(command.command, command.value)}
+        </code>
+        <p className='text-muted-foreground text-sm'>{description}</p>
+      </div>
+
+      <div className='flex shrink-0 items-center gap-2'>
+        {isAdded ? (
+          <Badge variant='secondary'>
+            {t("settings.autoexecCommandAddedBadge")}
+          </Badge>
+        ) : (
+          <Button
+            onClick={() => onAddCommand(command)}
+            size='sm'
+            type='button'
+            variant='outline'>
+            <PlusIcon className='h-4 w-4' />
+            {t("settings.autoexecCommandAdd")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/hooks/use-autoexec-library-filter.ts
+++ b/apps/desktop/src/hooks/use-autoexec-library-filter.ts
@@ -66,14 +66,11 @@ export const useAutoexecLibraryFilter = (t: TFunction) => {
 
     return AUTOEXEC_CATEGORIES.map((category) => ({
       category,
-      commands: category.commands
-        .map((command) => ({
-          ...command,
-          categoryId: category.id,
-        }))
-        .filter((command) => matchesQuery(command, normalizedQuery, t)),
+      commands: filteredCommands.filter(
+        (command) => command.categoryId === category.id,
+      ),
     })).filter((group) => group.commands.length > 0);
-  }, [normalizedQuery, selectedCategory, t]);
+  }, [filteredCommands, selectedCategory]);
 
   const hasResults =
     selectedCategory === "all"

--- a/apps/desktop/src/hooks/use-autoexec-library-filter.ts
+++ b/apps/desktop/src/hooks/use-autoexec-library-filter.ts
@@ -1,0 +1,92 @@
+import { useMemo, useState } from "react";
+import type { TFunction } from "i18next";
+import {
+  AUTOEXEC_CATEGORIES,
+  type AutoexecCategoryDefinition,
+  type AutoexecCategoryId,
+  type FlatAutoexecCommand,
+  FLAT_AUTOEXEC_COMMANDS,
+} from "@/lib/autoexec/predefined-commands";
+
+export type AutoexecLibraryCategoryFilter = AutoexecCategoryId | "all";
+
+export interface AutoexecLibraryGroupedCategory {
+  category: AutoexecCategoryDefinition;
+  commands: FlatAutoexecCommand[];
+}
+
+const getSearchableText = (
+  command: FlatAutoexecCommand,
+  t: TFunction,
+): string => {
+  const description = t(`settings.autoexecCommands.${command.id}.description`);
+  const categoryLabel = t(`settings.autoexecCategories.${command.categoryId}`);
+
+  return [command.command, command.value, description, categoryLabel]
+    .join(" ")
+    .toLowerCase();
+};
+
+const matchesQuery = (
+  command: FlatAutoexecCommand,
+  normalizedQuery: string,
+  t: TFunction,
+): boolean => {
+  if (normalizedQuery.length === 0) {
+    return true;
+  }
+
+  return getSearchableText(command, t).includes(normalizedQuery);
+};
+
+export const useAutoexecLibraryFilter = (t: TFunction) => {
+  const [query, setQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] =
+    useState<AutoexecLibraryCategoryFilter>("all");
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredCommands = useMemo(() => {
+    return FLAT_AUTOEXEC_COMMANDS.filter((command) => {
+      if (
+        selectedCategory !== "all" &&
+        command.categoryId !== selectedCategory
+      ) {
+        return false;
+      }
+
+      return matchesQuery(command, normalizedQuery, t);
+    });
+  }, [normalizedQuery, selectedCategory, t]);
+
+  const groupedCategories = useMemo((): AutoexecLibraryGroupedCategory[] => {
+    if (selectedCategory !== "all") {
+      return [];
+    }
+
+    return AUTOEXEC_CATEGORIES.map((category) => ({
+      category,
+      commands: category.commands
+        .map((command) => ({
+          ...command,
+          categoryId: category.id,
+        }))
+        .filter((command) => matchesQuery(command, normalizedQuery, t)),
+    })).filter((group) => group.commands.length > 0);
+  }, [normalizedQuery, selectedCategory, t]);
+
+  const hasResults =
+    selectedCategory === "all"
+      ? groupedCategories.length > 0
+      : filteredCommands.length > 0;
+
+  return {
+    query,
+    setQuery,
+    selectedCategory,
+    setSelectedCategory,
+    filteredCommands,
+    groupedCategories,
+    hasResults,
+  };
+};

--- a/apps/desktop/src/hooks/use-launch-map.ts
+++ b/apps/desktop/src/hooks/use-launch-map.ts
@@ -1,37 +1,20 @@
-import { CustomSettingType } from "@deadlock-mods/shared";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
+import { enableAutoexecLaunchOptionIfDisabled } from "@/lib/autoexec/launch-option";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
 import { getAdditionalArgs } from "@/lib/utils";
 
-const AUTOEXEC_LAUNCH_OPTION_ID = "autoexec-launch-option";
-
 export const useLaunchMap = (onSuccess?: () => void) => {
-  const { settings, toggleSetting, getActiveProfile } = usePersistedStore();
+  const { getActiveProfile } = usePersistedStore();
   const queryClient = useQueryClient();
 
   const launchMapMutation = useMutation({
     mutationFn: async (mapName: string) => {
       await invoke("add_map_command_to_autoexec", { mapName });
 
-      const autoexecSetting = settings[AUTOEXEC_LAUNCH_OPTION_ID];
-      if (!autoexecSetting?.enabled) {
-        toggleSetting(
-          AUTOEXEC_LAUNCH_OPTION_ID,
-          {
-            id: AUTOEXEC_LAUNCH_OPTION_ID,
-            key: "-exec",
-            value: "autoexec",
-            type: CustomSettingType.LAUNCH_OPTION,
-            description: null,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          },
-          true,
-        );
-      }
+      enableAutoexecLaunchOptionIfDisabled();
 
       const activeProfile = getActiveProfile();
       const profileFolder = activeProfile?.folderName ?? null;

--- a/apps/desktop/src/hooks/use-launch-map.ts
+++ b/apps/desktop/src/hooks/use-launch-map.ts
@@ -7,7 +7,7 @@ import { usePersistedStore } from "@/lib/store";
 import { getAdditionalArgs } from "@/lib/utils";
 
 export const useLaunchMap = (onSuccess?: () => void) => {
-  const { getActiveProfile } = usePersistedStore();
+  const getActiveProfile = usePersistedStore((state) => state.getActiveProfile);
   const queryClient = useQueryClient();
 
   const launchMapMutation = useMutation({

--- a/apps/desktop/src/lib/autoexec/autoexec-content.test.ts
+++ b/apps/desktop/src/lib/autoexec/autoexec-content.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import {
+  hasAutoexecLaunchableContent,
+  removeCondebugFromContent,
+  repairI18nKeyCommentsInContent,
+} from "./autoexec-content";
+
+describe("hasAutoexecLaunchableContent", () => {
+  it("returns false for empty content", () => {
+    expect(hasAutoexecLaunchableContent("")).toBe(false);
+  });
+
+  it("returns false for whitespace-only content", () => {
+    expect(hasAutoexecLaunchableContent(" \n\t ")).toBe(false);
+  });
+
+  it("returns true for restored managed sections", () => {
+    expect(
+      hasAutoexecLaunchableContent(
+        "// === Deadlock Mod Manager - Crosshair Settings (DO NOT EDIT) ===\ncl_crosshaircolor 5\n// === End Crosshair Settings ===",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("repairI18nKeyCommentsInContent", () => {
+  it("replaces generated i18n key comments with english descriptions", () => {
+    expect(
+      repairI18nKeyCommentsInContent(
+        "// settings.autoexecCommands.fpsMax.description\nfps_max 240",
+      ),
+    ).toBe("// Main FPS limit. 0 means unlimited.\nfps_max 240");
+  });
+});
+
+describe("removeCondebugFromContent", () => {
+  it("removes stale generated condebug comments", () => {
+    expect(
+      removeCondebugFromContent(
+        "// settings.autoexecCommands.condebug.description\ncondebug",
+      ),
+    ).toBe("");
+  });
+
+  it("keeps user comments before stale condebug commands", () => {
+    expect(
+      removeCondebugFromContent("// keep this\ncondebug\nfps_max 240"),
+    ).toBe("// keep this\nfps_max 240");
+  });
+});

--- a/apps/desktop/src/lib/autoexec/autoexec-content.ts
+++ b/apps/desktop/src/lib/autoexec/autoexec-content.ts
@@ -104,7 +104,7 @@ export const removeCondebugFromContent = (content: string): string => {
   return result.join("\n").trimEnd();
 };
 
-export const parseAutoexecCommandKeys = (content: string): Set<string> => {
+const parseAutoexecCommandKeys = (content: string): Set<string> => {
   const keys = new Set<string>();
 
   for (const line of content.split("\n")) {

--- a/apps/desktop/src/lib/autoexec/autoexec-content.ts
+++ b/apps/desktop/src/lib/autoexec/autoexec-content.ts
@@ -1,0 +1,131 @@
+import i18n from "@/lib/i18n";
+
+const WHITESPACE_REGEX = /\s+/;
+
+const I18N_KEY_COMMENT_PREFIX = "// settings.autoexecCommands.";
+
+const parseCommandLine = (line: string): string | null => {
+  const trimmed = line.trim();
+  if (trimmed.length === 0 || trimmed.startsWith("//")) {
+    return null;
+  }
+
+  const [commandKey] = trimmed.split(WHITESPACE_REGEX);
+  if (!commandKey) {
+    return null;
+  }
+
+  return commandKey;
+};
+
+export const getAutoexecCommandFileComment = (commandId: string): string => {
+  return i18n.t(`settings.autoexecCommands.${commandId}.description`, {
+    lng: "en",
+  });
+};
+
+export const repairI18nKeyCommentsInContent = (content: string): string => {
+  let repairedContent = content;
+
+  for (const line of content.split("\n")) {
+    const trimmedLine = line.trim();
+    if (
+      !trimmedLine.startsWith(I18N_KEY_COMMENT_PREFIX) ||
+      !trimmedLine.endsWith(".description")
+    ) {
+      continue;
+    }
+
+    const commandId = trimmedLine
+      .slice(I18N_KEY_COMMENT_PREFIX.length)
+      .replace(/\.description$/, "");
+
+    if (commandId.length === 0) {
+      continue;
+    }
+
+    const englishComment = getAutoexecCommandFileComment(commandId);
+    if (englishComment.startsWith("settings.autoexecCommands.")) {
+      continue;
+    }
+
+    repairedContent = repairedContent.replace(
+      trimmedLine,
+      `// ${englishComment}`,
+    );
+  }
+
+  return repairedContent;
+};
+
+export const removeCondebugFromContent = (content: string): string => {
+  const lines = content.split("\n");
+  const result: string[] = [];
+
+  for (const line of lines) {
+    const commandKey = parseCommandLine(line);
+    if (commandKey === "condebug") {
+      const previousLine = result.at(-1)?.trim() ?? "";
+      if (previousLine.startsWith("//")) {
+        result.pop();
+      }
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n").trimEnd();
+};
+
+export const parseAutoexecCommandKeys = (content: string): Set<string> => {
+  const keys = new Set<string>();
+
+  for (const line of content.split("\n")) {
+    const commandKey = parseCommandLine(line);
+    if (commandKey) {
+      keys.add(commandKey);
+    }
+  }
+
+  return keys;
+};
+
+export const commandExistsInContent = (
+  content: string,
+  commandKey: string,
+): boolean => {
+  return parseAutoexecCommandKeys(content).has(commandKey);
+};
+
+export const appendPredefinedCommand = (
+  content: string,
+  command: string,
+  value: string,
+  description: string,
+): string => {
+  const commandLine = value.length > 0 ? `${command} ${value}` : command;
+  const block = `\n// ${description}\n${commandLine}\n`;
+  const trimmedContent = content.trimEnd();
+
+  if (trimmedContent.length === 0) {
+    return `${block.trimStart()}\n`;
+  }
+
+  return `${trimmedContent}${block}`;
+};
+
+export const formatCommandPreview = (
+  command: string,
+  value: string,
+): string => {
+  if (value.length === 0) {
+    return command;
+  }
+
+  return `${command} ${value}`;
+};
+
+export const normalizeAutoexecContent = (content: string): string => {
+  return removeCondebugFromContent(repairI18nKeyCommentsInContent(content));
+};

--- a/apps/desktop/src/lib/autoexec/autoexec-content.ts
+++ b/apps/desktop/src/lib/autoexec/autoexec-content.ts
@@ -3,6 +3,8 @@ import i18n from "@/lib/i18n";
 const WHITESPACE_REGEX = /\s+/;
 
 const I18N_KEY_COMMENT_PREFIX = "// settings.autoexecCommands.";
+const I18N_DESCRIPTION_SUFFIX = ".description";
+const CONDEBUG_COMMAND = "condebug";
 
 const parseCommandLine = (line: string): string | null => {
   const trimmed = line.trim();
@@ -24,38 +26,65 @@ export const getAutoexecCommandFileComment = (commandId: string): string => {
   });
 };
 
-export const repairI18nKeyCommentsInContent = (content: string): string => {
-  let repairedContent = content;
+const parseGeneratedCommentCommandId = (line: string): string | null => {
+  const trimmedLine = line.trim();
 
-  for (const line of content.split("\n")) {
-    const trimmedLine = line.trim();
-    if (
-      !trimmedLine.startsWith(I18N_KEY_COMMENT_PREFIX) ||
-      !trimmedLine.endsWith(".description")
-    ) {
-      continue;
-    }
-
-    const commandId = trimmedLine
-      .slice(I18N_KEY_COMMENT_PREFIX.length)
-      .replace(/\.description$/, "");
-
-    if (commandId.length === 0) {
-      continue;
-    }
-
-    const englishComment = getAutoexecCommandFileComment(commandId);
-    if (englishComment.startsWith("settings.autoexecCommands.")) {
-      continue;
-    }
-
-    repairedContent = repairedContent.replace(
-      trimmedLine,
-      `// ${englishComment}`,
-    );
+  if (
+    !trimmedLine.startsWith(I18N_KEY_COMMENT_PREFIX) ||
+    !trimmedLine.endsWith(I18N_DESCRIPTION_SUFFIX)
+  ) {
+    return null;
   }
 
-  return repairedContent;
+  const commandId = trimmedLine
+    .slice(I18N_KEY_COMMENT_PREFIX.length)
+    .slice(0, -I18N_DESCRIPTION_SUFFIX.length);
+
+  return commandId.length > 0 ? commandId : null;
+};
+
+const isGeneratedCommandComment = (
+  line: string,
+  commandId: string,
+): boolean => {
+  const trimmedLine = line.trim();
+
+  return (
+    trimmedLine ===
+      `${I18N_KEY_COMMENT_PREFIX}${commandId}${I18N_DESCRIPTION_SUFFIX}` ||
+    trimmedLine === `// ${getAutoexecCommandFileComment(commandId)}`
+  );
+};
+
+export const repairI18nKeyCommentsInContent = (content: string): string => {
+  return content
+    .split("\n")
+    .map((line) => {
+      const commandId = parseGeneratedCommentCommandId(line);
+
+      if (!commandId) {
+        return line;
+      }
+
+      const englishComment = getAutoexecCommandFileComment(commandId);
+      if (englishComment.startsWith("settings.autoexecCommands.")) {
+        return line;
+      }
+
+      const indentation = line.slice(0, line.length - line.trimStart().length);
+      return `${indentation}// ${englishComment}`;
+    })
+    .join("\n");
+};
+
+const removePreviousGeneratedComment = (
+  lines: string[],
+  commandId: string,
+): void => {
+  const previousLine = lines.at(-1);
+  if (previousLine && isGeneratedCommandComment(previousLine, commandId)) {
+    lines.pop();
+  }
 };
 
 export const removeCondebugFromContent = (content: string): string => {
@@ -64,11 +93,8 @@ export const removeCondebugFromContent = (content: string): string => {
 
   for (const line of lines) {
     const commandKey = parseCommandLine(line);
-    if (commandKey === "condebug") {
-      const previousLine = result.at(-1)?.trim() ?? "";
-      if (previousLine.startsWith("//")) {
-        result.pop();
-      }
+    if (commandKey === CONDEBUG_COMMAND) {
+      removePreviousGeneratedComment(result, CONDEBUG_COMMAND);
       continue;
     }
 
@@ -96,6 +122,10 @@ export const commandExistsInContent = (
   commandKey: string,
 ): boolean => {
   return parseAutoexecCommandKeys(content).has(commandKey);
+};
+
+export const hasAutoexecLaunchableContent = (content: string): boolean => {
+  return content.trim().length > 0;
 };
 
 export const appendPredefinedCommand = (

--- a/apps/desktop/src/lib/autoexec/constants.ts
+++ b/apps/desktop/src/lib/autoexec/constants.ts
@@ -1,0 +1,1 @@
+export const AUTOEXEC_LAUNCH_OPTION_ID = "autoexec-launch-option";

--- a/apps/desktop/src/lib/autoexec/launch-option.ts
+++ b/apps/desktop/src/lib/autoexec/launch-option.ts
@@ -2,8 +2,6 @@ import { CustomSettingType } from "@deadlock-mods/shared";
 import { usePersistedStore } from "@/lib/store";
 import { AUTOEXEC_LAUNCH_OPTION_ID } from "./constants";
 
-export { AUTOEXEC_LAUNCH_OPTION_ID };
-
 export const enableAutoexecLaunchOptionIfDisabled = (): void => {
   const { settings, toggleSetting } = usePersistedStore.getState();
   const autoexecSetting = settings[AUTOEXEC_LAUNCH_OPTION_ID];

--- a/apps/desktop/src/lib/autoexec/launch-option.ts
+++ b/apps/desktop/src/lib/autoexec/launch-option.ts
@@ -1,7 +1,8 @@
 import { CustomSettingType } from "@deadlock-mods/shared";
 import { usePersistedStore } from "@/lib/store";
+import { AUTOEXEC_LAUNCH_OPTION_ID } from "./constants";
 
-export const AUTOEXEC_LAUNCH_OPTION_ID = "autoexec-launch-option";
+export { AUTOEXEC_LAUNCH_OPTION_ID };
 
 export const enableAutoexecLaunchOptionIfDisabled = (): void => {
   const { settings, toggleSetting } = usePersistedStore.getState();

--- a/apps/desktop/src/lib/autoexec/launch-option.ts
+++ b/apps/desktop/src/lib/autoexec/launch-option.ts
@@ -1,0 +1,27 @@
+import { CustomSettingType } from "@deadlock-mods/shared";
+import { usePersistedStore } from "@/lib/store";
+
+export const AUTOEXEC_LAUNCH_OPTION_ID = "autoexec-launch-option";
+
+export const enableAutoexecLaunchOptionIfDisabled = (): void => {
+  const { settings, toggleSetting } = usePersistedStore.getState();
+  const autoexecSetting = settings[AUTOEXEC_LAUNCH_OPTION_ID];
+
+  if (autoexecSetting?.enabled) {
+    return;
+  }
+
+  toggleSetting(
+    AUTOEXEC_LAUNCH_OPTION_ID,
+    {
+      id: AUTOEXEC_LAUNCH_OPTION_ID,
+      key: "-exec",
+      value: "autoexec",
+      type: CustomSettingType.LAUNCH_OPTION,
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    true,
+  );
+};

--- a/apps/desktop/src/lib/autoexec/launch-option.ts
+++ b/apps/desktop/src/lib/autoexec/launch-option.ts
@@ -25,3 +25,14 @@ export const enableAutoexecLaunchOptionIfDisabled = (): void => {
     true,
   );
 };
+
+export const disableAutoexecLaunchOptionIfEnabled = (): void => {
+  const { settings, toggleSetting } = usePersistedStore.getState();
+  const autoexecSetting = settings[AUTOEXEC_LAUNCH_OPTION_ID];
+
+  if (!autoexecSetting?.enabled) {
+    return;
+  }
+
+  toggleSetting(AUTOEXEC_LAUNCH_OPTION_ID, autoexecSetting, false);
+};

--- a/apps/desktop/src/lib/autoexec/predefined-commands.test.ts
+++ b/apps/desktop/src/lib/autoexec/predefined-commands.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { FLAT_AUTOEXEC_COMMANDS } from "./predefined-commands";
+import {
+  AUTOEXEC_CATEGORIES,
+  FLAT_AUTOEXEC_COMMANDS,
+} from "./predefined-commands";
 
 describe("predefined autoexec commands", () => {
   it("does not ship duplicate command keys", () => {
@@ -11,10 +14,31 @@ describe("predefined autoexec commands", () => {
     expect(uniqueCommandKeys.size).toBe(commandKeys.length);
   });
 
-  it("does not include stale region override presets", () => {
+  it("does not include stale region override entries", () => {
     expect(
       FLAT_AUTOEXEC_COMMANDS.some(
         (command) => command.command === "citadel_region_override",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not keep the removed region override category id", () => {
+    const categoryIds: string[] = AUTOEXEC_CATEGORIES.map(
+      (category) => category.id,
+    );
+
+    expect(categoryIds.includes("matchmakingRegion")).toBe(false);
+  });
+
+  it("does not include obsolete or command-only entries as convars", () => {
+    const removedCommands = new Set([
+      "battery_saver",
+      "citadel_render_minimap",
+    ]);
+
+    expect(
+      FLAT_AUTOEXEC_COMMANDS.some((command) =>
+        removedCommands.has(command.command),
       ),
     ).toBe(false);
   });

--- a/apps/desktop/src/lib/autoexec/predefined-commands.test.ts
+++ b/apps/desktop/src/lib/autoexec/predefined-commands.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { FLAT_AUTOEXEC_COMMANDS } from "./predefined-commands";
+
+describe("predefined autoexec commands", () => {
+  it("does not ship duplicate command keys", () => {
+    const commandKeys = FLAT_AUTOEXEC_COMMANDS.map(
+      (command) => command.command,
+    );
+    const uniqueCommandKeys = new Set(commandKeys);
+
+    expect(uniqueCommandKeys.size).toBe(commandKeys.length);
+  });
+
+  it("does not include stale region override presets", () => {
+    expect(
+      FLAT_AUTOEXEC_COMMANDS.some(
+        (command) => command.command === "citadel_region_override",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/autoexec/predefined-commands.ts
+++ b/apps/desktop/src/lib/autoexec/predefined-commands.ts
@@ -1,0 +1,415 @@
+import type { LucideIcon } from "@deadlock-mods/ui/icons";
+import {
+  Film,
+  Gauge,
+  Globe,
+  Keyboard,
+  Lock,
+  Map,
+  Mic,
+  Monitor,
+  MousePointer2,
+  ShoppingCart,
+  Sparkles,
+  Volume2,
+  Wifi,
+} from "@deadlock-mods/ui/icons";
+
+export type AutoexecCategoryId =
+  | "performance"
+  | "network"
+  | "hudUi"
+  | "minimap"
+  | "matchmakingRegion"
+  | "privateLobbyDefaults"
+  | "mouseSensitivity"
+  | "abilityQuickcast"
+  | "buildItems"
+  | "audio"
+  | "voiceChat"
+  | "visualEffects"
+  | "replaySpectator";
+
+export interface PredefinedAutoexecCommand {
+  id: string;
+  command: string;
+  value: string;
+}
+
+export interface AutoexecCategoryDefinition {
+  id: AutoexecCategoryId;
+  icon: LucideIcon;
+  commands: PredefinedAutoexecCommand[];
+}
+
+export interface FlatAutoexecCommand extends PredefinedAutoexecCommand {
+  categoryId: AutoexecCategoryId;
+}
+
+export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
+  {
+    id: "performance",
+    icon: Gauge,
+    commands: [
+      { id: "fpsMax", command: "fps_max", value: "240" },
+      { id: "fpsMaxUi", command: "fps_max_ui", value: "144" },
+      {
+        id: "engineNoFocusSleep",
+        command: "engine_no_focus_sleep",
+        value: "0",
+      },
+      {
+        id: "engineLowLatencySleepAfterClientTick",
+        command: "engine_low_latency_sleep_after_client_tick",
+        value: "true",
+      },
+      { id: "batterySaver", command: "battery_saver", value: "false" },
+    ],
+  },
+  {
+    id: "network",
+    icon: Wifi,
+    commands: [
+      { id: "rate", command: "rate", value: "1000000" },
+      { id: "clUpdaterate", command: "cl_updaterate", value: "20" },
+      { id: "clInterpRatio", command: "cl_interp_ratio", value: "0" },
+      {
+        id: "clLagcompensation",
+        command: "cl_lagcompensation",
+        value: "true",
+      },
+      {
+        id: "clHudTelemetryNetMisdeliveryShow",
+        command: "cl_hud_telemetry_net_misdelivery_show",
+        value: "1",
+      },
+      {
+        id: "clHudTelemetryNetQualityGraphShow",
+        command: "cl_hud_telemetry_net_quality_graph_show",
+        value: "0",
+      },
+    ],
+  },
+  {
+    id: "hudUi",
+    icon: Monitor,
+    commands: [
+      {
+        id: "citadelUnitStatusUseNew",
+        command: "citadel_unit_status_use_new",
+        value: "true",
+      },
+      {
+        id: "citadelHudVisible",
+        command: "citadel_hud_visible",
+        value: "true",
+      },
+      {
+        id: "citadelHideReplayHud",
+        command: "citadel_hide_replay_hud",
+        value: "false",
+      },
+      {
+        id: "citadelHintSystemDisable",
+        command: "citadel_hint_system_disable",
+        value: "true",
+      },
+      {
+        id: "citadelAlwaysShowActiveHudStats",
+        command: "citadel_always_show_active_hud_stats",
+        value: "true",
+      },
+      {
+        id: "citadelShowActiveSlotPopup",
+        command: "citadel_show_active_slot_popup",
+        value: "true",
+      },
+      {
+        id: "citadelShowAllPurchaseToasts",
+        command: "citadel_show_all_purchase_toasts",
+        value: "true",
+      },
+      {
+        id: "citadelShopDefaultTab",
+        command: "citadel_shop_default_tab",
+        value: "-1",
+      },
+      {
+        id: "clAutoCursorScale",
+        command: "cl_auto_cursor_scale",
+        value: "true",
+      },
+      { id: "clShowfps", command: "cl_showfps", value: "0" },
+      {
+        id: "clShowframenumber",
+        command: "cl_showframenumber",
+        value: "false",
+      },
+      {
+        id: "clTrueviewShowStatus",
+        command: "cl_trueview_show_status",
+        value: "2",
+      },
+    ],
+  },
+  {
+    id: "minimap",
+    icon: Map,
+    commands: [
+      {
+        id: "minimapUpdateRateHz",
+        command: "minimap_update_rate_hz",
+        value: "60",
+      },
+      {
+        id: "citadelRenderMinimap",
+        command: "citadel_render_minimap",
+        value: "true",
+      },
+      {
+        id: "citadelMinimapUnitClickRadius",
+        command: "citadel_minimap_unit_click_radius",
+        value: "200",
+      },
+      {
+        id: "citadelMinimapPlayerWidth",
+        command: "citadel_minimap_player_width",
+        value: "7",
+      },
+      {
+        id: "citadelMinimapLocalPlayerWidth",
+        command: "citadel_minimap_local_player_width",
+        value: "12",
+      },
+      {
+        id: "citadelMinimapMaxIconShrink",
+        command: "citadel_minimap_max_icon_shrink",
+        value: "0.8",
+      },
+      {
+        id: "citadelMinimapOverlapScanDistance",
+        command: "citadel_minimap_overlap_scan_distance",
+        value: "12.5",
+      },
+      {
+        id: "citadelMinimapZipLineThickness",
+        command: "citadel_minimap_zip_line_thickness",
+        value: "2",
+      },
+      {
+        id: "citadelMinimapSpectatorFowTeamView",
+        command: "citadel_minimap_spectator_fow_team_view",
+        value: "1",
+      },
+    ],
+  },
+  {
+    id: "matchmakingRegion",
+    icon: Globe,
+    commands: [
+      { id: "mmPreferSoloOnly", command: "mm_prefer_solo_only", value: "1" },
+      {
+        id: "citadelRegionOverrideAuto",
+        command: "citadel_region_override",
+        value: "-1",
+      },
+      {
+        id: "citadelRegionOverrideNa",
+        command: "citadel_region_override",
+        value: "0",
+      },
+      {
+        id: "citadelRegionOverrideEu",
+        command: "citadel_region_override",
+        value: "1",
+      },
+      {
+        id: "citadelRegionOverrideAsia",
+        command: "citadel_region_override",
+        value: "2",
+      },
+    ],
+  },
+  {
+    id: "privateLobbyDefaults",
+    icon: Lock,
+    commands: [
+      {
+        id: "citadelPrivateLobbyBotDifficulty",
+        command: "citadel_private_lobby_bot_difficulty",
+        value: "0",
+      },
+      {
+        id: "citadelPrivateLobbyCheatsEnabled",
+        command: "citadel_private_lobby_cheats_enabled",
+        value: "false",
+      },
+      {
+        id: "citadelPrivateLobbyDuplicateHeroesEnabled",
+        command: "citadel_private_lobby_duplicate_heroes_enabled",
+        value: "false",
+      },
+      {
+        id: "citadelPrivateLobbyIsPubliclyVisible",
+        command: "citadel_private_lobby_is_publicly_visible",
+        value: "false",
+      },
+      {
+        id: "citadelPrivateLobbyRandomizeLanes",
+        command: "citadel_private_lobby_randomize_lanes",
+        value: "false",
+      },
+      {
+        id: "citadelPrivateLobbyServerRegion",
+        command: "citadel_private_lobby_server_region",
+        value: "1",
+      },
+    ],
+  },
+  {
+    id: "mouseSensitivity",
+    icon: MousePointer2,
+    commands: [
+      { id: "fovDesired", command: "fov_desired", value: "75" },
+      { id: "mYaw", command: "m_yaw", value: "0.022" },
+      { id: "mPitch", command: "m_pitch", value: "0.022" },
+      {
+        id: "zoomSensitivityRatio",
+        command: "zoom_sensitivity_ratio",
+        value: "0.818933027098955175",
+      },
+      {
+        id: "clCitadelZoomIsToggle",
+        command: "cl_citadel_zoom_is_toggle",
+        value: "false",
+      },
+    ],
+  },
+  {
+    id: "abilityQuickcast",
+    icon: Keyboard,
+    commands: [
+      {
+        id: "clCitadelQuickcastAbility1",
+        command: "cl_citadel_quickcast_ability1",
+        value: "0",
+      },
+      {
+        id: "clCitadelQuickcastAbility2",
+        command: "cl_citadel_quickcast_ability2",
+        value: "0",
+      },
+      {
+        id: "clCitadelQuickcastAbility3",
+        command: "cl_citadel_quickcast_ability3",
+        value: "0",
+      },
+      {
+        id: "clCitadelQuickcastAbility4",
+        command: "cl_citadel_quickcast_ability4",
+        value: "0",
+      },
+    ],
+  },
+  {
+    id: "buildItems",
+    icon: ShoppingCart,
+    commands: [
+      {
+        id: "citadelAutoQueueBuild",
+        command: "citadel_auto_queue_build",
+        value: "false",
+      },
+    ],
+  },
+  {
+    id: "audio",
+    icon: Volume2,
+    commands: [
+      { id: "volume", command: "volume", value: "1" },
+      { id: "sndGamevolume", command: "snd_gamevolume", value: "1" },
+      {
+        id: "sndGamevoicevolume",
+        command: "snd_gamevoicevolume",
+        value: "1",
+      },
+      { id: "sndVoipvolume", command: "snd_voipvolume", value: "1" },
+      {
+        id: "soundDeviceOverride",
+        command: "sound_device_override",
+        value: '""',
+      },
+    ],
+  },
+  {
+    id: "voiceChat",
+    icon: Mic,
+    commands: [
+      { id: "voiceModenable", command: "voice_modenable", value: "true" },
+      { id: "voiceVox", command: "voice_vox", value: "0" },
+      { id: "voiceThreshold", command: "voice_threshold", value: "-120" },
+      { id: "voiceLoopback", command: "voice_loopback", value: "false" },
+      {
+        id: "voiceAlwaysSampleMic",
+        command: "voice_always_sample_mic",
+        value: "false",
+      },
+      {
+        id: "voiceDeviceOverride",
+        command: "voice_device_override",
+        value: '""',
+      },
+    ],
+  },
+  {
+    id: "visualEffects",
+    icon: Sparkles,
+    commands: [
+      { id: "clRagdollLimit", command: "cl_ragdoll_limit", value: "20" },
+      { id: "violenceAblood", command: "violence_ablood", value: "true" },
+      { id: "violenceAgibs", command: "violence_agibs", value: "true" },
+      { id: "violenceHblood", command: "violence_hblood", value: "true" },
+      { id: "violenceHgibs", command: "violence_hgibs", value: "true" },
+    ],
+  },
+  {
+    id: "replaySpectator",
+    icon: Film,
+    commands: [
+      {
+        id: "citadelAutoHighlightSecondsBefore",
+        command: "citadel_auto_highlight_seconds_before",
+        value: "20",
+      },
+      {
+        id: "citadelAutoHighlightSecondsAfter",
+        command: "citadel_auto_highlight_seconds_after",
+        value: "8",
+      },
+      {
+        id: "citadelReplayManagerDownloadChunkSize",
+        command: "citadel_replay_manager_download_chunk_size",
+        value: "1048576",
+      },
+      {
+        id: "citadelReplayManagerDownloadSimultaneousRequests",
+        command: "citadel_replay_manager_download_simultaneous_requests",
+        value: "3",
+      },
+    ],
+  },
+];
+
+export const FLAT_AUTOEXEC_COMMANDS: FlatAutoexecCommand[] =
+  AUTOEXEC_CATEGORIES.flatMap((category) =>
+    category.commands.map((command) => ({
+      ...command,
+      categoryId: category.id,
+    })),
+  );
+
+export const getAutoexecCategoryById = (
+  categoryId: AutoexecCategoryId,
+): AutoexecCategoryDefinition | undefined => {
+  return AUTOEXEC_CATEGORIES.find((category) => category.id === categoryId);
+};

--- a/apps/desktop/src/lib/autoexec/predefined-commands.ts
+++ b/apps/desktop/src/lib/autoexec/predefined-commands.ts
@@ -208,26 +208,6 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
     icon: Globe,
     commands: [
       { id: "mmPreferSoloOnly", command: "mm_prefer_solo_only", value: "1" },
-      {
-        id: "citadelRegionOverrideAuto",
-        command: "citadel_region_override",
-        value: "-1",
-      },
-      {
-        id: "citadelRegionOverrideNa",
-        command: "citadel_region_override",
-        value: "0",
-      },
-      {
-        id: "citadelRegionOverrideEu",
-        command: "citadel_region_override",
-        value: "1",
-      },
-      {
-        id: "citadelRegionOverrideAsia",
-        command: "citadel_region_override",
-        value: "2",
-      },
     ],
   },
   {

--- a/apps/desktop/src/lib/autoexec/predefined-commands.ts
+++ b/apps/desktop/src/lib/autoexec/predefined-commands.ts
@@ -20,7 +20,7 @@ export type AutoexecCategoryId =
   | "network"
   | "hudUi"
   | "minimap"
-  | "matchmakingRegion"
+  | "matchmaking"
   | "privateLobbyDefaults"
   | "mouseSensitivity"
   | "abilityQuickcast"
@@ -30,10 +30,13 @@ export type AutoexecCategoryId =
   | "visualEffects"
   | "replaySpectator";
 
+export type AutoexecCommandIntent = "default";
+
 export interface PredefinedAutoexecCommand {
   id: string;
   command: string;
   value: string;
+  intent?: AutoexecCommandIntent;
 }
 
 export interface AutoexecCategoryDefinition {
@@ -63,7 +66,6 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         command: "engine_low_latency_sleep_after_client_tick",
         value: "true",
       },
-      { id: "batterySaver", command: "battery_saver", value: "false" },
     ],
   },
   {
@@ -103,11 +105,13 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         id: "citadelHudVisible",
         command: "citadel_hud_visible",
         value: "true",
+        intent: "default",
       },
       {
         id: "citadelHideReplayHud",
         command: "citadel_hide_replay_hud",
         value: "false",
+        intent: "default",
       },
       {
         id: "citadelHintSystemDisable",
@@ -133,17 +137,24 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         id: "citadelShopDefaultTab",
         command: "citadel_shop_default_tab",
         value: "-1",
+        intent: "default",
       },
       {
         id: "clAutoCursorScale",
         command: "cl_auto_cursor_scale",
         value: "true",
       },
-      { id: "clShowfps", command: "cl_showfps", value: "0" },
+      {
+        id: "clShowfps",
+        command: "cl_showfps",
+        value: "0",
+        intent: "default",
+      },
       {
         id: "clShowframenumber",
         command: "cl_showframenumber",
         value: "false",
+        intent: "default",
       },
       {
         id: "clTrueviewShowStatus",
@@ -160,51 +171,54 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         id: "minimapUpdateRateHz",
         command: "minimap_update_rate_hz",
         value: "60",
-      },
-      {
-        id: "citadelRenderMinimap",
-        command: "citadel_render_minimap",
-        value: "true",
+        intent: "default",
       },
       {
         id: "citadelMinimapUnitClickRadius",
         command: "citadel_minimap_unit_click_radius",
         value: "200",
+        intent: "default",
       },
       {
         id: "citadelMinimapPlayerWidth",
         command: "citadel_minimap_player_width",
         value: "7",
+        intent: "default",
       },
       {
         id: "citadelMinimapLocalPlayerWidth",
         command: "citadel_minimap_local_player_width",
         value: "12",
+        intent: "default",
       },
       {
         id: "citadelMinimapMaxIconShrink",
         command: "citadel_minimap_max_icon_shrink",
         value: "0.8",
+        intent: "default",
       },
       {
         id: "citadelMinimapOverlapScanDistance",
         command: "citadel_minimap_overlap_scan_distance",
         value: "12.5",
+        intent: "default",
       },
       {
         id: "citadelMinimapZipLineThickness",
         command: "citadel_minimap_zip_line_thickness",
         value: "2",
+        intent: "default",
       },
       {
         id: "citadelMinimapSpectatorFowTeamView",
         command: "citadel_minimap_spectator_fow_team_view",
         value: "1",
+        intent: "default",
       },
     ],
   },
   {
-    id: "matchmakingRegion",
+    id: "matchmaking",
     icon: Globe,
     commands: [
       { id: "mmPreferSoloOnly", command: "mm_prefer_solo_only", value: "1" },
@@ -218,31 +232,37 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         id: "citadelPrivateLobbyBotDifficulty",
         command: "citadel_private_lobby_bot_difficulty",
         value: "0",
+        intent: "default",
       },
       {
         id: "citadelPrivateLobbyCheatsEnabled",
         command: "citadel_private_lobby_cheats_enabled",
         value: "false",
+        intent: "default",
       },
       {
         id: "citadelPrivateLobbyDuplicateHeroesEnabled",
         command: "citadel_private_lobby_duplicate_heroes_enabled",
         value: "false",
+        intent: "default",
       },
       {
         id: "citadelPrivateLobbyIsPubliclyVisible",
         command: "citadel_private_lobby_is_publicly_visible",
         value: "false",
+        intent: "default",
       },
       {
         id: "citadelPrivateLobbyRandomizeLanes",
         command: "citadel_private_lobby_randomize_lanes",
         value: "false",
+        intent: "default",
       },
       {
         id: "citadelPrivateLobbyServerRegion",
         command: "citadel_private_lobby_server_region",
         value: "1",
+        intent: "default",
       },
     ],
   },
@@ -250,18 +270,30 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
     id: "mouseSensitivity",
     icon: MousePointer2,
     commands: [
-      { id: "fovDesired", command: "fov_desired", value: "75" },
-      { id: "mYaw", command: "m_yaw", value: "0.022" },
-      { id: "mPitch", command: "m_pitch", value: "0.022" },
+      {
+        id: "fovDesired",
+        command: "fov_desired",
+        value: "75",
+        intent: "default",
+      },
+      { id: "mYaw", command: "m_yaw", value: "0.022", intent: "default" },
+      {
+        id: "mPitch",
+        command: "m_pitch",
+        value: "0.022",
+        intent: "default",
+      },
       {
         id: "zoomSensitivityRatio",
         command: "zoom_sensitivity_ratio",
         value: "0.818933027098955175",
+        intent: "default",
       },
       {
         id: "clCitadelZoomIsToggle",
         command: "cl_citadel_zoom_is_toggle",
         value: "false",
+        intent: "default",
       },
     ],
   },
@@ -273,21 +305,25 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         id: "clCitadelQuickcastAbility1",
         command: "cl_citadel_quickcast_ability1",
         value: "0",
+        intent: "default",
       },
       {
         id: "clCitadelQuickcastAbility2",
         command: "cl_citadel_quickcast_ability2",
         value: "0",
+        intent: "default",
       },
       {
         id: "clCitadelQuickcastAbility3",
         command: "cl_citadel_quickcast_ability3",
         value: "0",
+        intent: "default",
       },
       {
         id: "clCitadelQuickcastAbility4",
         command: "cl_citadel_quickcast_ability4",
         value: "0",
+        intent: "default",
       },
     ],
   },
@@ -306,18 +342,30 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
     id: "audio",
     icon: Volume2,
     commands: [
-      { id: "volume", command: "volume", value: "1" },
-      { id: "sndGamevolume", command: "snd_gamevolume", value: "1" },
+      { id: "volume", command: "volume", value: "1", intent: "default" },
+      {
+        id: "sndGamevolume",
+        command: "snd_gamevolume",
+        value: "1",
+        intent: "default",
+      },
       {
         id: "sndGamevoicevolume",
         command: "snd_gamevoicevolume",
         value: "1",
+        intent: "default",
       },
-      { id: "sndVoipvolume", command: "snd_voipvolume", value: "1" },
+      {
+        id: "sndVoipvolume",
+        command: "snd_voipvolume",
+        value: "1",
+        intent: "default",
+      },
       {
         id: "soundDeviceOverride",
         command: "sound_device_override",
         value: '""',
+        intent: "default",
       },
     ],
   },
@@ -325,19 +373,36 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
     id: "voiceChat",
     icon: Mic,
     commands: [
-      { id: "voiceModenable", command: "voice_modenable", value: "true" },
-      { id: "voiceVox", command: "voice_vox", value: "0" },
+      {
+        id: "voiceModenable",
+        command: "voice_modenable",
+        value: "true",
+        intent: "default",
+      },
+      {
+        id: "voiceVox",
+        command: "voice_vox",
+        value: "0",
+        intent: "default",
+      },
       { id: "voiceThreshold", command: "voice_threshold", value: "-120" },
-      { id: "voiceLoopback", command: "voice_loopback", value: "false" },
+      {
+        id: "voiceLoopback",
+        command: "voice_loopback",
+        value: "false",
+        intent: "default",
+      },
       {
         id: "voiceAlwaysSampleMic",
         command: "voice_always_sample_mic",
         value: "false",
+        intent: "default",
       },
       {
         id: "voiceDeviceOverride",
         command: "voice_device_override",
         value: '""',
+        intent: "default",
       },
     ],
   },
@@ -360,21 +425,25 @@ export const AUTOEXEC_CATEGORIES: AutoexecCategoryDefinition[] = [
         id: "citadelAutoHighlightSecondsBefore",
         command: "citadel_auto_highlight_seconds_before",
         value: "20",
+        intent: "default",
       },
       {
         id: "citadelAutoHighlightSecondsAfter",
         command: "citadel_auto_highlight_seconds_after",
         value: "8",
+        intent: "default",
       },
       {
         id: "citadelReplayManagerDownloadChunkSize",
         command: "citadel_replay_manager_download_chunk_size",
         value: "1048576",
+        intent: "default",
       },
       {
         id: "citadelReplayManagerDownloadSimultaneousRequests",
         command: "citadel_replay_manager_download_simultaneous_requests",
         value: "3",
+        intent: "default",
       },
     ],
   },
@@ -387,9 +456,3 @@ export const FLAT_AUTOEXEC_COMMANDS: FlatAutoexecCommand[] =
       categoryId: category.id,
     })),
   );
-
-export const getAutoexecCategoryById = (
-  categoryId: AutoexecCategoryId,
-): AutoexecCategoryDefinition | undefined => {
-  return AUTOEXEC_CATEGORIES.find((category) => category.id === categoryId);
-};

--- a/apps/desktop/src/lib/utils.ts
+++ b/apps/desktop/src/lib/utils.ts
@@ -10,7 +10,7 @@ import { platform } from "@tauri-apps/plugin-os";
 
 import { type LocalMod, ModStatus } from "@/types/mods";
 import type { LocalSetting } from "@/types/settings";
-import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/launch-option";
+import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/constants";
 import {
   STALE_MOD_DAYS,
   STALE_MOD_REPORT_THRESHOLD,
@@ -73,7 +73,7 @@ export const getAdditionalArgs = async (
         additionalArgs.push("-exec autoexec");
       }
     } catch {
-      // Autoexec config doesn't exist or failed to load, skip
+      return additionalArgs.join(" ");
     }
   }
 
@@ -124,8 +124,8 @@ export const getTimePeriodCutoff = (period: TimePeriod): Date | null => {
   }
 };
 
-export const isModOutdated = (mod: ModDto) => {
-  const cutoffDate = new Date("2026-01-22"); // OldGods update
+export const isModOutdated = (mod: ModDto): boolean => {
+  const cutoffDate = new Date("2026-01-22");
   const modUpdatedDate = new Date(mod.remoteUpdatedAt);
   return modUpdatedDate < cutoffDate;
 };

--- a/apps/desktop/src/lib/utils.ts
+++ b/apps/desktop/src/lib/utils.ts
@@ -10,6 +10,7 @@ import { platform } from "@tauri-apps/plugin-os";
 
 import { type LocalMod, ModStatus } from "@/types/mods";
 import type { LocalSetting } from "@/types/settings";
+import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/launch-option";
 import {
   STALE_MOD_DAYS,
   STALE_MOD_REPORT_THRESHOLD,
@@ -51,13 +52,13 @@ export const getAdditionalArgs = async (
     (s) =>
       s.type === CustomSettingType.LAUNCH_OPTION &&
       s.enabled &&
-      s.id !== "autoexec-launch-option",
+      s.id !== AUTOEXEC_LAUNCH_OPTION_ID,
   )) {
     additionalArgs.push(`${setting.key} ${setting.value || ""}`.trim());
   }
 
   const autoexecLaunchOption = settings.find(
-    (s) => s.id === "autoexec-launch-option" && s.enabled,
+    (s) => s.id === AUTOEXEC_LAUNCH_OPTION_ID && s.enabled,
   );
 
   if (autoexecLaunchOption) {

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -656,13 +656,14 @@
     "autoexecInfoBody2": "The mod manager uses this file to set the crosshair settings automatically without needing to run commands in the console. You can still edit the file manually if you want to add more commands.",
     "autoexecInfoBody3": "P.S: the autoexec config can never be empty if added as launch option or else it'll crash the game.",
     "autoexecLibraryHeading": "Command Library",
-    "autoexecLibraryDescription": "Browse common client-side commands and add them to your config with one click.",
-    "autoexecCommandWarning": "Commands in this library are not verified for every Deadlock update. They may stop working or, in rare cases, cause unexpected game behavior. Test added commands carefully and remove anything that causes problems.",
+    "autoexecLibraryDescription": "Browse community-sourced client-side commands. Entries marked Default restore documented defaults rather than tune behavior.",
+    "autoexecCommandWarning": "Commands in this library are community-sourced and may be removed, hidden, or changed between Deadlock updates. Test added commands carefully and remove anything that causes problems.",
     "autoexecLibrarySearchPlaceholder": "Search commands...",
     "autoexecLibraryEmpty": "No commands match your search.",
     "autoexecCommandAdd": "Add",
     "autoexecCommandAdded": "Command added to config. Save to apply.",
     "autoexecCommandAddedBadge": "Added",
+    "autoexecCommandDefaultBadge": "Default",
     "autoexecEditorHeading": "Current Autoexec Config",
     "autoexecSaving": "Saving...",
     "autoexecClear": "Clear",
@@ -676,7 +677,7 @@
       "network": "Network",
       "hudUi": "HUD & UI",
       "minimap": "Minimap",
-      "matchmakingRegion": "Matchmaking",
+      "matchmaking": "Matchmaking",
       "privateLobbyDefaults": "Private Lobby Defaults",
       "mouseSensitivity": "Mouse & Sensitivity",
       "abilityQuickcast": "Ability Quickcast",
@@ -698,9 +699,6 @@
       },
       "engineLowLatencySleepAfterClientTick": {
         "description": "Moves low-latency sleep after client simulation when low latency is active."
-      },
-      "batterySaver": {
-        "description": "Disable battery saver mode."
       },
       "rate": {
         "description": "Maximum client bandwidth rate."
@@ -724,10 +722,10 @@
         "description": "Enable new unit status bars."
       },
       "citadelHudVisible": {
-        "description": "Show the HUD."
+        "description": "Default/reset: show the HUD."
       },
       "citadelHideReplayHud": {
-        "description": "Hide replay HUD."
+        "description": "Default/reset: keep the replay HUD visible."
       },
       "citadelHintSystemDisable": {
         "description": "Disable gameplay hints."
@@ -742,130 +740,127 @@
         "description": "Show all purchase toasts."
       },
       "citadelShopDefaultTab": {
-        "description": "Set default shop tab. -1 means default behavior."
+        "description": "Default/reset: use the game's default shop tab."
       },
       "clAutoCursorScale": {
         "description": "Enable automatic cursor scaling."
       },
       "clShowfps": {
-        "description": "Show FPS counter. 0 off, 1 FPS, 2 smooth FPS, 3 server MS, 4 FPS and log."
+        "description": "Default/reset: hide the FPS counter."
       },
       "clShowframenumber": {
-        "description": "Show frame number."
+        "description": "Default/reset: hide the frame number."
       },
       "clTrueviewShowStatus": {
         "description": "Show TrueView status. 0 never, 1 only if problem, 2 always."
       },
       "minimapUpdateRateHz": {
-        "description": "Update minimap at 60 Hz."
-      },
-      "citadelRenderMinimap": {
-        "description": "Render the minimap."
+        "description": "Default/reset: update the minimap at 60 Hz."
       },
       "citadelMinimapUnitClickRadius": {
-        "description": "Easier minimap unit clicking."
+        "description": "Default/reset: restore minimap unit click radius."
       },
       "citadelMinimapPlayerWidth": {
-        "description": "Larger player icons on minimap."
+        "description": "Default/reset: restore minimap player icon width."
       },
       "citadelMinimapLocalPlayerWidth": {
-        "description": "Larger local player icon on minimap."
+        "description": "Default/reset: restore local player minimap icon width."
       },
       "citadelMinimapMaxIconShrink": {
-        "description": "Controls how much minimap icons can shrink."
+        "description": "Default/reset: restore minimap icon shrink behavior."
       },
       "citadelMinimapOverlapScanDistance": {
-        "description": "Distance used to scan overlapping minimap icons."
+        "description": "Default/reset: restore minimap overlap scan distance."
       },
       "citadelMinimapZipLineThickness": {
-        "description": "Thicker zipline lines on minimap."
+        "description": "Default/reset: restore minimap zipline thickness."
       },
       "citadelMinimapSpectatorFowTeamView": {
-        "description": "Spectator minimap team view."
+        "description": "Default/reset: restore spectator minimap team view."
       },
       "mmPreferSoloOnly": {
         "description": "Prefer matches with solo players."
       },
       "citadelPrivateLobbyBotDifficulty": {
-        "description": "Private lobby bot difficulty."
+        "description": "Default/reset: restore private lobby bot difficulty."
       },
       "citadelPrivateLobbyCheatsEnabled": {
-        "description": "Disable cheats in private lobby by default."
+        "description": "Default/reset: keep private lobby cheats disabled."
       },
       "citadelPrivateLobbyDuplicateHeroesEnabled": {
-        "description": "Disable duplicate heroes in private lobby by default."
+        "description": "Default/reset: keep duplicate heroes disabled."
       },
       "citadelPrivateLobbyIsPubliclyVisible": {
-        "description": "Hide private lobby from public list."
+        "description": "Default/reset: keep private lobbies hidden from public lists."
       },
       "citadelPrivateLobbyRandomizeLanes": {
-        "description": "Disable random lanes in private lobby."
+        "description": "Default/reset: keep random lanes disabled."
       },
       "citadelPrivateLobbyServerRegion": {
-        "description": "Private lobby server region."
+        "description": "Default/reset: restore the private lobby server region."
       },
       "fovDesired": {
-        "description": "Base field of view."
+        "description": "Default/reset: restore base field of view."
       },
       "mYaw": {
-        "description": "Mouse yaw factor."
+        "description": "Default/reset: restore mouse yaw factor."
       },
       "mPitch": {
-        "description": "Mouse pitch factor."
+        "description": "Default/reset: restore mouse pitch factor."
       },
       "zoomSensitivityRatio": {
-        "description": "ADS / zoom sensitivity scale."
+        "description": "Default/reset: restore ADS / zoom sensitivity scale."
       },
       "clCitadelZoomIsToggle": {
-        "description": "Zoom hold behavior. false means hold, true means toggle."
+        "description": "Default/reset: use hold-to-zoom behavior."
       },
       "clCitadelQuickcastAbility1": {
-        "description": "Quickcast mode for ability 1."
+        "description": "Default/reset: restore ability 1 quickcast mode."
       },
       "clCitadelQuickcastAbility2": {
-        "description": "Quickcast mode for ability 2."
+        "description": "Default/reset: restore ability 2 quickcast mode."
       },
       "clCitadelQuickcastAbility3": {
-        "description": "Quickcast mode for ability 3."
+        "description": "Default/reset: restore ability 3 quickcast mode."
       },
       "clCitadelQuickcastAbility4": {
-        "description": "Quickcast mode for ability 4."
+        "description": "Default/reset: restore ability 4 quickcast mode."
       },
       "citadelAutoQueueBuild": {
         "description": "Automatically queue selected build at game start."
       },
       "volume": {
-        "description": "Master volume."
+        "description": "Default/reset: restore master volume."
       },
       "sndGamevolume": {
-        "description": "Game volume."
+        "description": "Default/reset: restore game volume."
       },
       "sndGamevoicevolume": {
-        "description": "Game voice-over volume."
+        "description": "Default/reset: restore game voice-over volume."
       },
       "sndVoipvolume": {
-        "description": "Voice chat volume."
+        "description": "Default/reset: restore voice chat volume."
       },
       "soundDeviceOverride": {
-        "description": "Sound device override. Empty means default device."
+        "description": "Default/reset: use the default sound device."
       },
       "voiceModenable": {
-        "description": "Enable voice chat."
+        "description": "Default/reset: keep voice chat enabled."
       },
       "voiceVox": {
-        "description": "Use push-to-talk instead of always-on VOX."
+        "description": "Default/reset: use push-to-talk instead of always-on VOX."
       },
       "voiceThreshold": {
         "description": "Voice activation threshold."
       },
       "voiceLoopback": {
-        "description": "Keep voice loopback disabled."
+        "description": "Default/reset: keep voice loopback disabled."
       },
       "voiceAlwaysSampleMic": {
-        "description": "Keep voice input stream closed until needed."
+        "description": "Default/reset: keep voice input stream closed until needed."
       },
       "voiceDeviceOverride": {
-        "description": "Voice capture device override. Empty means default device."
+        "description": "Default/reset: use the default voice capture device."
       },
       "clRagdollLimit": {
         "description": "Limit visible ragdolls."
@@ -883,16 +878,16 @@
         "description": "Show human gibs."
       },
       "citadelAutoHighlightSecondsBefore": {
-        "description": "Auto-highlight seconds before event."
+        "description": "Default/reset: restore replay auto-highlight lead-in seconds."
       },
       "citadelAutoHighlightSecondsAfter": {
-        "description": "Auto-highlight seconds after event."
+        "description": "Default/reset: restore replay auto-highlight follow-up seconds."
       },
       "citadelReplayManagerDownloadChunkSize": {
-        "description": "Replay download chunk size."
+        "description": "Default/reset: restore replay download chunk size."
       },
       "citadelReplayManagerDownloadSimultaneousRequests": {
-        "description": "Simultaneous replay download requests."
+        "description": "Default/reset: restore replay download parallel request count."
       }
     },
     "openInFolder": "Open in Folder",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -651,6 +651,261 @@
     "autoexecContent": "Config File Content",
     "autoexecPlaceholder": "Add your custom console commands here...",
     "autoexecReadonlyNote": "Note: Sections marked with 'DO NOT EDIT' are managed by the mod manager and will be restored automatically.",
+    "autoexecInfoTitle": "What's an Autoexec Config?",
+    "autoexecInfoBody1": "Autoexec is a CFG file for launching a game with set convars (think console command) that will get automatically executed on launch of the game.",
+    "autoexecInfoBody2": "The mod manager uses this file to set the crosshair settings automatically without needing to run commands in the console. You can still edit the file manually if you want to add more commands.",
+    "autoexecInfoBody3": "P.S: the autoexec config can never be empty if added as launch option or else it'll crash the game.",
+    "autoexecLibraryHeading": "Command Library",
+    "autoexecLibraryDescription": "Browse verified client-safe commands and add them to your config with one click.",
+    "autoexecLibrarySearchPlaceholder": "Search commands...",
+    "autoexecLibraryEmpty": "No commands match your search.",
+    "autoexecCommandAdd": "Add",
+    "autoexecCommandAdded": "Command added to config. Save to apply.",
+    "autoexecCommandAddedBadge": "Added",
+    "autoexecEditorHeading": "Current Autoexec Config",
+    "autoexecSaving": "Saving...",
+    "autoexecClear": "Clear",
+    "autoexecClearConfirmTitle": "Clear Autoexec Config?",
+    "autoexecClearConfirmBody": "This will remove all commands from your autoexec.cfg. Managed crosshair and map sections will be restored automatically. An empty autoexec file can crash the game if the autoexec launch option is enabled.",
+    "autoexecClearConfirmAction": "Clear Config",
+    "autoexecCleared": "Autoexec config cleared.",
+    "autoexecCategories": {
+      "all": "All",
+      "performance": "Performance",
+      "network": "Network",
+      "hudUi": "HUD & UI",
+      "minimap": "Minimap",
+      "matchmakingRegion": "Matchmaking & Region",
+      "privateLobbyDefaults": "Private Lobby Defaults",
+      "mouseSensitivity": "Mouse & Sensitivity",
+      "abilityQuickcast": "Ability Quickcast",
+      "buildItems": "Build & Items",
+      "audio": "Audio",
+      "voiceChat": "Voice Chat",
+      "visualEffects": "Visual / Effects",
+      "replaySpectator": "Replay / Spectator"
+    },
+    "autoexecCommands": {
+      "fpsMax": {
+        "description": "Main FPS limit. 0 means unlimited."
+      },
+      "fpsMaxUi": {
+        "description": "FPS limit while game UI is displayed. 0 means unlimited."
+      },
+      "engineNoFocusSleep": {
+        "description": "Sleep delay when the game window is not focused. 0 keeps FPS active in background."
+      },
+      "engineLowLatencySleepAfterClientTick": {
+        "description": "Moves low-latency sleep after client simulation when low latency is active."
+      },
+      "batterySaver": {
+        "description": "Disable battery saver mode."
+      },
+      "rate": {
+        "description": "Maximum client bandwidth rate."
+      },
+      "clUpdaterate": {
+        "description": "Requested server update packets per second."
+      },
+      "clInterpRatio": {
+        "description": "Client interpolation ratio."
+      },
+      "clLagcompensation": {
+        "description": "Keep lag compensation enabled."
+      },
+      "clHudTelemetryNetMisdeliveryShow": {
+        "description": "Show missed user commands and server snapshots only in poor conditions."
+      },
+      "clHudTelemetryNetQualityGraphShow": {
+        "description": "Hide network quality graph."
+      },
+      "citadelUnitStatusUseNew": {
+        "description": "Enable new unit status bars."
+      },
+      "citadelHudVisible": {
+        "description": "Show the HUD."
+      },
+      "citadelHideReplayHud": {
+        "description": "Hide replay HUD."
+      },
+      "citadelHintSystemDisable": {
+        "description": "Disable gameplay hints."
+      },
+      "citadelAlwaysShowActiveHudStats": {
+        "description": "Always show active HUD stats."
+      },
+      "citadelShowActiveSlotPopup": {
+        "description": "Show active slot popup."
+      },
+      "citadelShowAllPurchaseToasts": {
+        "description": "Show all purchase toasts."
+      },
+      "citadelShopDefaultTab": {
+        "description": "Set default shop tab. -1 means default behavior."
+      },
+      "clAutoCursorScale": {
+        "description": "Enable automatic cursor scaling."
+      },
+      "clShowfps": {
+        "description": "Show FPS counter. 0 off, 1 FPS, 2 smooth FPS, 3 server MS, 4 FPS and log."
+      },
+      "clShowframenumber": {
+        "description": "Show frame number."
+      },
+      "clTrueviewShowStatus": {
+        "description": "Show TrueView status. 0 never, 1 only if problem, 2 always."
+      },
+      "minimapUpdateRateHz": {
+        "description": "Update minimap at 60 Hz."
+      },
+      "citadelRenderMinimap": {
+        "description": "Render the minimap."
+      },
+      "citadelMinimapUnitClickRadius": {
+        "description": "Easier minimap unit clicking."
+      },
+      "citadelMinimapPlayerWidth": {
+        "description": "Larger player icons on minimap."
+      },
+      "citadelMinimapLocalPlayerWidth": {
+        "description": "Larger local player icon on minimap."
+      },
+      "citadelMinimapMaxIconShrink": {
+        "description": "Controls how much minimap icons can shrink."
+      },
+      "citadelMinimapOverlapScanDistance": {
+        "description": "Distance used to scan overlapping minimap icons."
+      },
+      "citadelMinimapZipLineThickness": {
+        "description": "Thicker zipline lines on minimap."
+      },
+      "citadelMinimapSpectatorFowTeamView": {
+        "description": "Spectator minimap team view."
+      },
+      "mmPreferSoloOnly": {
+        "description": "Prefer matches with solo players."
+      },
+      "citadelRegionOverrideAuto": {
+        "description": "Automatic region selection."
+      },
+      "citadelRegionOverrideNa": {
+        "description": "Force North America servers."
+      },
+      "citadelRegionOverrideEu": {
+        "description": "Force Europe servers."
+      },
+      "citadelRegionOverrideAsia": {
+        "description": "Force Asia servers."
+      },
+      "citadelPrivateLobbyBotDifficulty": {
+        "description": "Private lobby bot difficulty."
+      },
+      "citadelPrivateLobbyCheatsEnabled": {
+        "description": "Disable cheats in private lobby by default."
+      },
+      "citadelPrivateLobbyDuplicateHeroesEnabled": {
+        "description": "Disable duplicate heroes in private lobby by default."
+      },
+      "citadelPrivateLobbyIsPubliclyVisible": {
+        "description": "Hide private lobby from public list."
+      },
+      "citadelPrivateLobbyRandomizeLanes": {
+        "description": "Disable random lanes in private lobby."
+      },
+      "citadelPrivateLobbyServerRegion": {
+        "description": "Private lobby server region."
+      },
+      "fovDesired": {
+        "description": "Base field of view."
+      },
+      "mYaw": {
+        "description": "Mouse yaw factor."
+      },
+      "mPitch": {
+        "description": "Mouse pitch factor."
+      },
+      "zoomSensitivityRatio": {
+        "description": "ADS / zoom sensitivity scale."
+      },
+      "clCitadelZoomIsToggle": {
+        "description": "Zoom hold behavior. false means hold, true means toggle."
+      },
+      "clCitadelQuickcastAbility1": {
+        "description": "Quickcast mode for ability 1."
+      },
+      "clCitadelQuickcastAbility2": {
+        "description": "Quickcast mode for ability 2."
+      },
+      "clCitadelQuickcastAbility3": {
+        "description": "Quickcast mode for ability 3."
+      },
+      "clCitadelQuickcastAbility4": {
+        "description": "Quickcast mode for ability 4."
+      },
+      "citadelAutoQueueBuild": {
+        "description": "Automatically queue selected build at game start."
+      },
+      "volume": {
+        "description": "Master volume."
+      },
+      "sndGamevolume": {
+        "description": "Game volume."
+      },
+      "sndGamevoicevolume": {
+        "description": "Game voice-over volume."
+      },
+      "sndVoipvolume": {
+        "description": "Voice chat volume."
+      },
+      "soundDeviceOverride": {
+        "description": "Sound device override. Empty means default device."
+      },
+      "voiceModenable": {
+        "description": "Enable voice chat."
+      },
+      "voiceVox": {
+        "description": "Use push-to-talk instead of always-on VOX."
+      },
+      "voiceThreshold": {
+        "description": "Voice activation threshold."
+      },
+      "voiceLoopback": {
+        "description": "Keep voice loopback disabled."
+      },
+      "voiceAlwaysSampleMic": {
+        "description": "Keep voice input stream closed until needed."
+      },
+      "voiceDeviceOverride": {
+        "description": "Voice capture device override. Empty means default device."
+      },
+      "clRagdollLimit": {
+        "description": "Limit visible ragdolls."
+      },
+      "violenceAblood": {
+        "description": "Draw alien blood."
+      },
+      "violenceAgibs": {
+        "description": "Show alien gibs."
+      },
+      "violenceHblood": {
+        "description": "Draw human blood."
+      },
+      "violenceHgibs": {
+        "description": "Show human gibs."
+      },
+      "citadelAutoHighlightSecondsBefore": {
+        "description": "Auto-highlight seconds before event."
+      },
+      "citadelAutoHighlightSecondsAfter": {
+        "description": "Auto-highlight seconds after event."
+      },
+      "citadelReplayManagerDownloadChunkSize": {
+        "description": "Replay download chunk size."
+      },
+      "citadelReplayManagerDownloadSimultaneousRequests": {
+        "description": "Simultaneous replay download requests."
+      }
+    },
     "openInFolder": "Open in Folder",
     "openInEditor": "Open in Editor",
     "saveChanges": "Save Changes",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -656,7 +656,8 @@
     "autoexecInfoBody2": "The mod manager uses this file to set the crosshair settings automatically without needing to run commands in the console. You can still edit the file manually if you want to add more commands.",
     "autoexecInfoBody3": "P.S: the autoexec config can never be empty if added as launch option or else it'll crash the game.",
     "autoexecLibraryHeading": "Command Library",
-    "autoexecLibraryDescription": "Browse verified client-safe commands and add them to your config with one click.",
+    "autoexecLibraryDescription": "Browse common client-side commands and add them to your config with one click.",
+    "autoexecCommandWarning": "Commands in this library are not verified for every Deadlock update. They may stop working or, in rare cases, cause unexpected game behavior. Test added commands carefully and remove anything that causes problems.",
     "autoexecLibrarySearchPlaceholder": "Search commands...",
     "autoexecLibraryEmpty": "No commands match your search.",
     "autoexecCommandAdd": "Add",
@@ -675,7 +676,7 @@
       "network": "Network",
       "hudUi": "HUD & UI",
       "minimap": "Minimap",
-      "matchmakingRegion": "Matchmaking & Region",
+      "matchmakingRegion": "Matchmaking",
       "privateLobbyDefaults": "Private Lobby Defaults",
       "mouseSensitivity": "Mouse & Sensitivity",
       "abilityQuickcast": "Ability Quickcast",
@@ -784,18 +785,6 @@
       },
       "mmPreferSoloOnly": {
         "description": "Prefer matches with solo players."
-      },
-      "citadelRegionOverrideAuto": {
-        "description": "Automatic region selection."
-      },
-      "citadelRegionOverrideNa": {
-        "description": "Force North America servers."
-      },
-      "citadelRegionOverrideEu": {
-        "description": "Force Europe servers."
-      },
-      "citadelRegionOverrideAsia": {
-        "description": "Force Asia servers."
       },
       "citadelPrivateLobbyBotDifficulty": {
         "description": "Private lobby bot difficulty."

--- a/apps/desktop/src/pages/settings.tsx
+++ b/apps/desktop/src/pages/settings.tsx
@@ -78,7 +78,7 @@ import ErrorBoundary from "@/components/shared/error-boundary";
 import PageTitle from "@/components/shared/page-title";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { getCustomSettings } from "@/lib/api-client";
-import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/launch-option";
+import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/constants";
 import { SortType } from "@/lib/constants";
 import logger from "@/lib/logger";
 import { STALE_TIME_LOCAL } from "@/lib/query-constants";

--- a/apps/desktop/src/pages/settings.tsx
+++ b/apps/desktop/src/pages/settings.tsx
@@ -78,6 +78,7 @@ import ErrorBoundary from "@/components/shared/error-boundary";
 import PageTitle from "@/components/shared/page-title";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { getCustomSettings } from "@/lib/api-client";
+import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/launch-option";
 import { SortType } from "@/lib/constants";
 import logger from "@/lib/logger";
 import { STALE_TIME_LOCAL } from "@/lib/query-constants";
@@ -127,7 +128,6 @@ const getAutoexecConfig = async () => {
   }
 };
 
-const AUTOEXEC_LAUNCH_OPTION_ID = "autoexec-launch-option";
 const CONDEBUG_LAUNCH_OPTION_ID = "condebug-launch-option";
 
 type SettingsNavItemProps = {


### PR DESCRIPTION

## Description

- Add searchable categorized command library with one-click append to autoexec.cfg
- Add clear action with destructive confirmation for the current autoexec config
- Auto-enable the Autoexec Config launch option when saving non-empty content
- Add matchmaking region presets (Auto, NA, EU, Asia) alongside solo queue option

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #491 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with] 

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<img width="2167" height="1257" alt="image" src="https://github.com/user-attachments/assets/ca6e3d51-8896-4874-b51c-ad2c89a20710" />

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Autoexec Command Library Feature

**Affected Package:** `@deadlock-mods/desktop`

### Core Functionality
Adds a searchable, categorized autoexec command library UI to the desktop application with one-click command appending to autoexec.cfg. Includes a clear action with destructive confirmation, auto-enables the autoexec launch option when saving non-empty content, and normalizes autoexec config content on load.

### UI Components (Desktop)
- **AutoexecCommandLibrary**: Main library interface with search bar, category filter chips, grouped results, and empty-state handling
- **AutoexecCategoryChips**: Horizontally scrollable category filter buttons with icons
- **AutoexecCommandRow**: Individual command display with preview, add button, and default/added badges
- **AutoexecSettings**: Enhanced component integrating library, content editor, clear confirmation, and normalization logic

### Data & Logic Layer
- **predefined-commands.ts**: Typed command catalog organized into 13 categories (performance, network, HUD/UI, minimap, matchmaking, private lobby defaults, mouse/sensitivity, ability quickcast, build items, audio, voice chat, visual effects, replay/spectator) with 100+ commands
  - **Issue Resolution:** Region override presets (`citadel_region_override`) and problematic entries (`battery_saver`, `citadel_render_minimap`) removed per review feedback
- **autoexec-content.ts**: Content normalization utilities including i18n comment repair, condebug removal, command key parsing, duplicate detection, and predefined command appending
- **use-autoexec-library-filter.ts**: Hook managing search/filter state with category grouping and result computation
- **launch-option.ts**: Helpers for enabling/disabling the autoexec launch option in persisted settings

### Tauri Backend Changes (Rust)
- **autoexec.rs**: `update_autoexec_config` now returns the updated `AutoexecConfig` instead of unit type for improved frontend sync
- **autoexec_manager.rs**: Refactored around a generic "managed section" model for autoexec.cfg blocks with shared helpers for upsert/remove operations; `update_editable_content` now returns `Result<AutoexecConfig, Error>` and writes merged content to disk

### Cross-Package Integration
- Imports from `@deadlock-mods/ui/icons` for category icons
- No database migrations, API changes, or impact to other packages (api, bot, www, docs, or shared packages)

### Bug Fixes & Validation
- Tests validate no duplicate command keys, confirm region overrides are removed, and ensure obsolete entries are excluded
- Normalization handles legacy i18n comment formats and stale condebug entries

### Minor Changes
- Updated `getAdditionalArgs` in `utils.ts` to use shared `AUTOEXEC_LAUNCH_OPTION_ID` constant and improved error handling
- Adjusted layout spacing in `ActiveCrosshairs` component
- Refactored `CrosshairCard` icon and transition styling
- Workflow formatting in `.github/workflows/nightly.yml`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deadlock-mod-manager/deadlock-mod-manager/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->