### PR TITLE
feat(desktop): duplicate mods behind experimental feature flag

### DIFF
--- a/.changeset/duplicate-mod-flag-gate.md
+++ b/.changeset/duplicate-mod-flag-gate.md
@@ -1,0 +1,6 @@
+---
+"@deadlock-mods/api": patch
+"@deadlock-mods/desktop": patch
+---
+
+Gate duplicate-mod protection and hero parser behind feature flag

--- a/apps/api/src/config/feature-flags.ts
+++ b/apps/api/src/config/feature-flags.ts
@@ -59,4 +59,11 @@ export const featureFlagDefinitions: FeatureFlagDefinition[] = [
     defaultValue: false,
     exposed: true,
   },
+  {
+    name: "duplicate-mod-protection",
+    description: "Enable duplicate hero mod conflict protection",
+    type: "boolean",
+    defaultValue: false,
+    exposed: true,
+  },
 ];

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -25,6 +25,7 @@ import { useDeepLink } from "./hooks/use-deep-link";
 import { useIngestToolInit } from "./hooks/use-ingest-tool-init";
 import { useLanguageListener } from "./hooks/use-language-listener";
 import { useDownloadsMigration } from "./hooks/use-downloads-migration";
+import { useFeatureFlag } from "./hooks/use-feature-flags";
 import { useHeroDetection } from "./hooks/use-hero-detection";
 import { useModOrderMigration } from "./hooks/use-mod-order-migration";
 import { Layout } from "./layout";
@@ -44,11 +45,15 @@ interface PendingFontInstall {
 }
 
 const App = () => {
+  const { isEnabled: isDuplicateModProtectionEnabled } = useFeatureFlag(
+    "duplicate-mod-protection",
+    false,
+  );
   useDeepLink();
   useLanguageListener();
   useModOrderMigration();
   useDownloadsMigration();
-  useHeroDetection();
+  useHeroDetection({ enabled: Boolean(isDuplicateModProtectionEnabled) });
   useIngestToolInit();
   const { t } = useTranslation();
 

--- a/apps/desktop/src/components/layout/bottom-bar.tsx
+++ b/apps/desktop/src/components/layout/bottom-bar.tsx
@@ -295,6 +295,10 @@ export const BottomBar = () => {
     "server-browser",
     false,
   );
+  const { isEnabled: isDuplicateModProtectionEnabled } = useFeatureFlag(
+    "duplicate-mod-protection",
+    false,
+  );
 
   const downloadingCount = localMods.filter(
     (mod) =>
@@ -366,7 +370,7 @@ export const BottomBar = () => {
               variant='compact'
             />
           )}
-          <HeroParserIndicator />
+          {isDuplicateModProtectionEnabled && <HeroParserIndicator />}
           <DiscordPresenceIndicator />
         </div>
 

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -29,6 +29,7 @@ import { useConfirm } from "@/components/providers/alert-dialog";
 import ErrorBoundary from "@/components/shared/error-boundary";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { useDownload } from "@/hooks/use-download";
+import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import useInstallWithCollection from "@/hooks/use-install-with-collection";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
 import useUninstall from "@/hooks/use-uninstall";
@@ -103,6 +104,10 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
   const { analytics } = useAnalyticsContext();
   const confirm = useConfirm();
   const localMods = usePersistedStore((state) => state.localMods);
+  const { isEnabled: isDuplicateModProtectionEnabled } = useFeatureFlag(
+    "duplicate-mod-protection",
+    false,
+  );
 
   const { availableFiles } = useModDownloads({
     remoteId: remoteMod?.remoteId,
@@ -236,29 +241,31 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           break;
         case ModStatus.Downloaded:
         case ModStatus.FailedToInstall: {
-          const resolvedHero = resolveLocalModHero(localMod).hero;
-          if (resolvedHero) {
-            const conflictingMod = localMods.find(
-              (m) =>
-                m.remoteId !== localMod.remoteId &&
-                m.status === ModStatus.Installed &&
-                resolveLocalModHero(m).hero === resolvedHero,
-            );
-            if (conflictingMod) {
-              const resolution = await askHeroConflict(
-                resolvedHero,
-                conflictingMod,
-                localMod,
+          if (isDuplicateModProtectionEnabled) {
+            const resolvedHero = resolveLocalModHero(localMod).hero;
+            if (resolvedHero) {
+              const conflictingMod = localMods.find(
+                (m) =>
+                  m.remoteId !== localMod.remoteId &&
+                  m.status === ModStatus.Installed &&
+                  resolveLocalModHero(m).hero === resolvedHero,
               );
-              if (resolution === "cancel") {
-                break;
-              }
-              if (resolution === "swap") {
-                await uninstall(conflictingMod, false);
-                analytics.trackModUninstalled(
-                  conflictingMod.remoteId,
-                  "user_choice",
+              if (conflictingMod) {
+                const resolution = await askHeroConflict(
+                  resolvedHero,
+                  conflictingMod,
+                  localMod,
                 );
+                if (resolution === "cancel") {
+                  break;
+                }
+                if (resolution === "swap") {
+                  await uninstall(conflictingMod, false);
+                  analytics.trackModUninstalled(
+                    conflictingMod.remoteId,
+                    "user_choice",
+                  );
+                }
               }
             }
           }
@@ -305,6 +312,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     t,
     analytics,
     remoteMod?.remoteId,
+    isDuplicateModProtectionEnabled,
   ]);
 
   const onClick = useCallback(
@@ -462,13 +470,15 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         onDownload={downloadSelectedFiles}
       />
 
-      <HeroConflictDialog
-        currentMod={heroConflict?.currentMod ?? null}
-        heroName={heroConflict?.heroName ?? ""}
-        newMod={heroConflict?.newMod ?? null}
-        onResolve={handleHeroConflictResolve}
-        open={heroConflict !== null}
-      />
+      {isDuplicateModProtectionEnabled && (
+        <HeroConflictDialog
+          currentMod={heroConflict?.currentMod ?? null}
+          heroName={heroConflict?.heroName ?? ""}
+          newMod={heroConflict?.newMod ?? null}
+          onResolve={handleHeroConflictResolve}
+          open={heroConflict !== null}
+        />
+      )}
     </ErrorBoundary>
   );
 };

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -5,6 +5,7 @@ import { ModDownloadDtoSchema } from "@deadlock-mods/shared";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { useState } from "react";
 import { detectHeroForMod } from "@/hooks/use-hero-detection";
+import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import { downloadManager } from "@/lib/download/manager";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
@@ -23,6 +24,10 @@ export const useDownload = (
   const setModStatus = usePersistedStore((state) => state.setModStatus);
   const setDetectedHero = usePersistedStore((state) => state.setDetectedHero);
   const getActiveProfile = usePersistedStore((state) => state.getActiveProfile);
+  const { isEnabled: isDuplicateModProtectionEnabled } = useFeatureFlag(
+    "duplicate-mod-protection",
+    false,
+  );
 
   const localMod = localMods.find((m) => m.remoteId === mod?.remoteId);
 
@@ -58,20 +63,22 @@ export const useDownload = (
         setIsDialogOpen(false);
         toast.success(`${mod.name} downloaded!`);
 
-        detectHeroForMod(mod.remoteId)
-          .then((result) => {
-            setDetectedHero(
-              mod.remoteId,
-              resolveDetectedHeroLabel(result),
-              result.usesCriticalPaths,
-            );
-          })
-          .catch((err) => {
-            logger
-              .withMetadata({ mod: mod.remoteId })
-              .withError(err instanceof Error ? err : new Error(String(err)))
-              .warn("Failed to detect hero after download");
-          });
+        if (isDuplicateModProtectionEnabled) {
+          detectHeroForMod(mod.remoteId)
+            .then((result) => {
+              setDetectedHero(
+                mod.remoteId,
+                resolveDetectedHeroLabel(result),
+                result.usesCriticalPaths,
+              );
+            })
+            .catch((err) => {
+              logger
+                .withMetadata({ mod: mod.remoteId })
+                .withError(err instanceof Error ? err : new Error(String(err)))
+                .warn("Failed to detect hero after download");
+            });
+        }
       },
       onError: (error) => {
         toast.error(`Failed to download ${mod.name}: ${error.message}`);

--- a/apps/desktop/src/hooks/use-hero-detection.ts
+++ b/apps/desktop/src/hooks/use-hero-detection.ts
@@ -55,7 +55,7 @@ const detectBatch = async (
   });
 };
 
-export const useHeroDetection = () => {
+export const useHeroDetection = ({ enabled }: { enabled: boolean }) => {
   const localMods = usePersistedStore((state) => state.localMods);
   const gamePath = usePersistedStore((state) => state.gamePath);
   const prevGameRunning = useRef(false);
@@ -66,10 +66,20 @@ export const useHeroDetection = () => {
     queryFn: () => isGameRunning(),
     staleTime: STALE_TIME_POLL,
     refetchInterval: 5000,
-    enabled: !!gamePath,
+    enabled: !!gamePath && enabled,
   });
 
   useEffect(() => {
+    if (enabled) {
+      return;
+    }
+    abortActiveScan();
+    resetToIdle();
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
     const wasRunning = prevGameRunning.current;
     const isRunning = gameRunning === true;
     prevGameRunning.current = isRunning;
@@ -86,19 +96,22 @@ export const useHeroDetection = () => {
       logger.info("Hero detection resumed: Deadlock stopped");
       startBackgroundScan();
     }
-  }, [gameRunning]);
+  }, [gameRunning, enabled]);
 
   // Startup: 5s after mount, scan any unindexed mods
   useEffect(() => {
+    if (!enabled) return;
+
     const timer = setTimeout(() => {
       if (pausedByGame) return;
       startBackgroundScan();
     }, 5_000);
     return () => clearTimeout(timer);
-  }, []);
+  }, [enabled]);
 
   // Reactive: when new unindexed mods appear, scan immediately
   useEffect(() => {
+    if (!enabled) return;
     if (pausedByGame) return;
 
     const unindexedCount = localMods.filter(
@@ -120,7 +133,7 @@ export const useHeroDetection = () => {
     if (activeAbortController) return;
 
     startBackgroundScan();
-  }, [localMods]);
+  }, [localMods, enabled]);
 };
 
 const runBatchedDetection = async (mods: LocalMod[], signal: AbortSignal) => {

--- a/apps/desktop/src/hooks/use-mod-processor.ts
+++ b/apps/desktop/src/hooks/use-mod-processor.ts
@@ -10,6 +10,7 @@ import { BaseDirectory, readDir } from "@tauri-apps/plugin-fs";
 import JSZip from "jszip";
 import { useTranslation } from "react-i18next";
 import { useProgress } from "@/components/downloads/progress-indicator";
+import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import { ModCategory } from "@/lib/constants";
 import {
   generateFallbackModSVG,
@@ -65,6 +66,10 @@ export const useModProcessor = () => {
     setDetectedHero,
     getActiveProfile,
   } = usePersistedStore();
+  const { isEnabled: isDuplicateModProtectionEnabled } = useFeatureFlag(
+    "duplicate-mod-protection",
+    false,
+  );
 
   const processArchive = async (
     file: File,
@@ -312,15 +317,17 @@ export const useModProcessor = () => {
     });
     setModStatus(modId, ModStatus.Downloaded);
 
-    invoke<HeroDetectionResult>("detect_mod_hero", { modId })
-      .then((result) =>
-        setDetectedHero(
-          modId,
-          resolveDetectedHeroLabel(result),
-          result.usesCriticalPaths,
-        ),
-      )
-      .catch(() => setDetectedHero(modId, null));
+    if (isDuplicateModProtectionEnabled) {
+      invoke<HeroDetectionResult>("detect_mod_hero", { modId })
+        .then((result) =>
+          setDetectedHero(
+            modId,
+            resolveDetectedHeroLabel(result),
+            result.usesCriticalPaths,
+          ),
+        )
+        .catch(() => setDetectedHero(modId, null));
+    }
 
     setProcessing(true, t("addMods.modAddedSuccess"));
     toast.success(t("addMods.addedSuccess", { name: metadata.name }));
@@ -421,15 +428,17 @@ export const useModProcessor = () => {
     });
     setModStatus(modId, ModStatus.Installed);
 
-    invoke<HeroDetectionResult>("detect_mod_hero", { modId })
-      .then((result) =>
-        setDetectedHero(
-          modId,
-          resolveDetectedHeroLabel(result),
-          result.usesCriticalPaths,
-        ),
-      )
-      .catch(() => setDetectedHero(modId, null));
+    if (isDuplicateModProtectionEnabled) {
+      invoke<HeroDetectionResult>("detect_mod_hero", { modId })
+        .then((result) =>
+          setDetectedHero(
+            modId,
+            resolveDetectedHeroLabel(result),
+            result.usesCriticalPaths,
+          ),
+        )
+        .catch(() => setDetectedHero(modId, null));
+    }
 
     setProcessing(true, t("addMods.modAddedSuccess"));
     toast.success(t("addMods.addedSuccess", { name: metadata.name }));

--- a/apps/desktop/src/pages/settings.tsx
+++ b/apps/desktop/src/pages/settings.tsx
@@ -81,6 +81,7 @@ import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { getCustomSettings } from "@/lib/api-client";
 import { AUTOEXEC_LAUNCH_OPTION_ID } from "@/lib/autoexec/constants";
 import { SortType } from "@/lib/constants";
+import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import logger from "@/lib/logger";
 import { STALE_TIME_LOCAL } from "@/lib/query-constants";
 import { usePersistedStore } from "@/lib/store";
@@ -415,6 +416,10 @@ const CustomSettingsData = ({
 const CustomSettings = ({ value }: { value?: string }) => {
   const { t } = useTranslation();
   const { clearMods, localMods: mods, getActiveProfile } = usePersistedStore();
+  const { isEnabled: isDuplicateModProtectionEnabled } = useFeatureFlag(
+    "duplicate-mod-protection",
+    false,
+  );
 
   const clearModsState = async () => {
     if (
@@ -654,11 +659,14 @@ const CustomSettings = ({ value }: { value?: string }) => {
               <GameInfoManagement />
             </Section>
 
-            <Section
-              description={t("heroParser.settingsDescription")}
-              title={t("heroParser.settingsTitle")}>
-              <HeroParserSettings />
-            </Section>
+            {isDuplicateModProtectionEnabled && (
+              <Section
+                description={t("heroParser.settingsDescription")}
+                title={t("heroParser.settingsTitle")}>
+                <HeroParserSettings />
+              </Section>
+            )}
+
           </TabsContent>
 
           <TabsContent className='mt-0 space-y-4' value='discord'>


### PR DESCRIPTION
- Added exposed duplicate-mod-protection flag with default disabled.
- Gated duplicate hero conflict dialog and install conflict handling behind the flag.
- Gated hero detection pipeline and Hero Parser UI visibility to the same flag.

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #525 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<img width="1460" height="263" alt="image" src="https://github.com/user-attachments/assets/3328ebba-08a4-4773-b7e7-856ae7756445" />

<img width="1822" height="762" alt="image" src="https://github.com/user-attachments/assets/57cd1cdf-274f-49b0-a80a-18b5c707b1f7" />

<img width="1358" height="358" alt="image" src="https://github.com/user-attachments/assets/a6e19d28-79ff-4dd8-ac28-54906aa19931" />


## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [x] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR introduces a new experimental feature flag `duplicate-mod-protection` to gate hero detection and duplicate mod conflict management functionality. The flag is disabled by default and exposed for user configuration.

## Affected Packages

- **`@deadlock-mods/api`**: Feature flag definition
- **`@deadlock-mods/desktop`**: All functional changes (hero detection, conflict dialogs, UI visibility)

## Changes

### Feature Flag Definition

A new boolean feature flag `duplicate-mod-protection` is registered in the API configuration with `exposed: true` and `defaultValue: false`. This allows it to be toggled at runtime by users.

### Desktop Application Gating

The following hero detection and conflict resolution flows are now conditionally enabled based on the flag:

- **Hero detection pipeline**: Gated in `useHeroDetection`, `useDownload`, and `useModProcessor` hooks. When disabled, active scans are aborted and hero detection state is reset to idle.
- **Hero conflict dialog and install resolution**: Conditional rendering in `ModButton` component - only executes conflict detection and displays the conflict dialog when the flag is enabled.
- **Hero Parser UI visibility**: 
  - `HeroParserIndicator` in `BottomBar` only renders when enabled
  - Hero Parser settings section in `Settings` page only renders when enabled
- **Hero detection on startup**: The `useHeroDetection` hook is conditionally enabled in the `App` component based on the flag.

### Hook Signature Change

The `useHeroDetection` hook signature changed from a no-argument hook to accept an `{ enabled: boolean }` parameter, allowing callers to control whether hero detection operates.

## Notes

No database migrations, Tauri plugin changes, or Rust FFI boundary modifications are included in this PR. The changes are isolated to the feature-flagged conditional execution of existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->