### PR TITLE
feat(desktop): add opt-in match data sharing via Steam GC

### DIFF
--- a/.changeset/match-data-sharing.md
+++ b/.changeset/match-data-sharing.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Add opt-in match data sharing. When enabled, the app recovers your local Steam login on your machine to fetch your own Deadlock match salts through Steam's Game Coordinator and contributes them to deadlock-api trackers. It never sends your token, password, or personal data, only runs while Deadlock is closed, and is throttled and hard-capped at 40 fetches per 24 hours per account.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ For security vulnerabilities, please report them **privately** through:
 ### Application Security
 
 - **Tauri Framework**: Sandboxed environment with capability-based permissions
-- **Network Access**: Limited to trusted domains (gamebanana.com, deadlockmods.app)
+- **Network Access**: Limited to trusted domains (gamebanana.com, deadlockmods.app, deadlock-api.com)
 - **File System**: Restricted access to app data and user-selected mod directories
 - **Input Validation**: All user inputs are validated and sanitized
 

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -87,6 +87,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "another-steam-totp"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da7a9955c48acfce671b92a5d671a31d0c01611eb447483d1d0c340adda0205"
+dependencies = [
+ "base64 0.22.1",
+ "hmac",
+ "sha-1",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +182,12 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayvec"
@@ -293,6 +310,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +346,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c348fb0b6d132c596eca3dcd941df48fb597aafcb07a738ec41c004b087dc99"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -345,6 +400,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +433,36 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "binrw"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53195f985e88ab94d1cc87e80049dd2929fd39e4a772c5ae96a7e5c4aad3642"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5910da05ee556b789032c8ff5a61fb99239580aa3fd0bfaa8f4d094b2aee00ad"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -418,6 +526,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -552,6 +669,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -648,6 +779,15 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -781,6 +921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +953,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1091,6 +1246,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,8 +1301,12 @@ dependencies = [
 name = "deadlock-mod-manager"
 version = "1.0.0"
 dependencies = [
+ "aes",
+ "base64 0.22.1",
+ "cbc",
  "chrono",
  "clap",
+ "crc32fast",
  "deadlock-discord-presence",
  "dirs",
  "dmp-parser",
@@ -1141,17 +1314,21 @@ dependencies = [
  "fix-path-env",
  "futures",
  "hero-parser",
+ "hex",
  "junction",
+ "keyvalues-parser",
  "keyvalues-serde",
  "log",
  "memchr",
  "notify",
+ "prost 0.14.4",
  "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sevenz-rust",
  "sha2",
+ "steam-vent",
  "steamlocate",
  "sysinfo",
  "tauri",
@@ -1178,7 +1355,9 @@ dependencies = [
  "ttf-parser",
  "unrar",
  "urlencoding",
+ "valveprotos",
  "vpk-parser",
+ "windows 0.58.0",
  "zip 6.0.0",
 ]
 
@@ -1197,6 +1376,17 @@ name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1247,8 +1437,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1726,6 +1926,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2356,7 +2562,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2623,7 +2829,17 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2875,6 +3091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,6 +3159,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3078,7 +3309,7 @@ dependencies = [
  "minidump-common 0.26.1",
  "num-traits",
  "procfs-core 0.17.0",
- "prost",
+ "prost 0.13.5",
  "range-map",
  "scroll",
  "thiserror 2.0.18",
@@ -3231,6 +3462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3594,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,12 +3628,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3975,6 +4250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +4329,15 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4145,6 +4435,27 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -4347,7 +4658,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck 0.5.0",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.4",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
 ]
 
 [[package]]
@@ -4361,6 +4701,95 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
+]
+
+[[package]]
+name = "prost-wkt"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3de5e9c9e84fcb5efa204b8e283d23e615a8bc8c777bf1d6622bb01dc61445"
+dependencies = [
+ "chrono",
+ "inventory",
+ "prost 0.14.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "typetag",
+]
+
+[[package]]
+name = "prost-wkt-build"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe500dc80e757a75e1e8fb7290e448d62dfba3105ece1d058579cb00b58151cd"
+dependencies = [
+ "heck 0.5.0",
+ "prost 0.14.4",
+ "prost-build",
+ "prost-types",
+ "quote",
+]
+
+[[package]]
+name = "prost-wkt-types"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13807eaa7e15833d06e899008371926201cdcd11d74b6d490f49130cdb3f415e"
+dependencies = [
+ "chrono",
+ "prost 0.14.4",
+ "prost-build",
+ "prost-types",
+ "prost-wkt",
+ "prost-wkt-build",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bcc343da15609eaecd65f8aa76df8dc4209d325131d8219358c0aaaebab0bf6"
+dependencies = [
+ "bytes",
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0766e3675a627c327e4b3964582594b0e8741305d628a98a5de75a1d15f99b9"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4720,7 +5149,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4759,6 +5188,23 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams 0.5.0",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-websocket"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f477f800f86d8f5c320e19d8b2b1ef0b1e773ea7c75eec6c7f442e7ec3f06d7e"
+dependencies = [
+ "async-tungstenite",
+ "futures-util",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tungstenite 0.24.0",
  "web-sys",
 ]
 
@@ -4830,6 +5276,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4890,6 +5356,8 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4953,6 +5421,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5361,6 +5830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5396,6 +5876,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5552,10 +6042,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "steam-vent"
+version = "0.4.2"
+source = "git+https://github.com/deadlock-api/steam-vent?rev=1d7b274f5c2f648aba5dab474b80c1156b409bca#1d7b274f5c2f648aba5dab474b80c1156b409bca"
+dependencies = [
+ "another-steam-totp",
+ "async-stream",
+ "base64 0.22.1",
+ "binrw",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "crc",
+ "dashmap",
+ "directories",
+ "flate2",
+ "futures-util",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "protobuf",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "reqwest-websocket",
+ "rsa",
+ "rustls",
+ "serde",
+ "serde_json",
+ "steam-vent-crypto",
+ "steam-vent-proto",
+ "steamid-ng",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.27.0",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "steam-vent-crypto"
+version = "0.2.1"
+source = "git+https://github.com/deadlock-api/steam-vent?rev=1d7b274f5c2f648aba5dab474b80c1156b409bca#1d7b274f5c2f648aba5dab474b80c1156b409bca"
+dependencies = [
+ "aes",
+ "bytes",
+ "cbc",
+ "hmac",
+ "once_cell",
+ "rand 0.8.6",
+ "rsa",
+ "sha-1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "steam-vent-proto"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769088654e0d57a1029cc2da4f8f0a3202e9b83fadebb2e623adde206ff215d"
+dependencies = [
+ "steam-vent-proto-common",
+ "steam-vent-proto-steam",
+]
+
+[[package]]
+name = "steam-vent-proto-common"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62682aa488b34d33f1045f9e4ee3c33ceef709e878524188dea4431cfe4f2131"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "steam-vent-proto-steam"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b590586d9c9c002f36e7e65d14caaed2301249a7e1badae776a8349ed4a8ce"
+dependencies = [
+ "steam-vent-proto-common",
+]
+
+[[package]]
+name = "steamid-ng"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23da1d8a59091a1e8805d1355f74181f8e13fb7b446c2de17b9fd1bacce6058"
 
 [[package]]
 name = "steamlocate"
@@ -5689,7 +6285,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5760,7 +6356,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5849,7 +6445,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6091,10 +6687,10 @@ dependencies = [
  "tauri-plugin",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "uuid 1.23.1",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6116,7 +6712,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -6251,7 +6847,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6276,7 +6872,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6546,6 +7142,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.27.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6554,7 +7178,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -6565,6 +7189,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6837,6 +7462,43 @@ checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -6872,6 +7534,30 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -7068,6 +7754,21 @@ name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "valveprotos"
+version = "0.0.0"
+source = "git+https://github.com/deadlock-api/valveprotos-rs?rev=b14c831f324e20653e50ff60372478d427800d45#b14c831f324e20653e50ff60372478d427800d45"
+dependencies = [
+ "heck 0.5.0",
+ "prost 0.14.4",
+ "prost-build",
+ "prost-types",
+ "prost-wkt",
+ "prost-wkt-build",
+ "prost-wkt-types",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -7445,6 +8146,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -7460,10 +8170,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -7484,7 +8194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -7548,6 +8258,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7570,12 +8290,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -7587,8 +8320,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -7607,9 +8340,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7673,6 +8428,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -7687,6 +8451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8156,7 +8930,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -69,7 +69,7 @@ fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 tauri-plugin-clipboard-manager = "2.3.2"
 dirs = "6"
 ttf-parser = "0.24"
-# Local Steam session recovery + GC access (see user-auth.md).
+# Local Steam session recovery + GC access.
 aes = "0.8"
 cbc = { version = "0.1", features = ["alloc"] }
 crc32fast = "1.4"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -69,6 +69,20 @@ fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 tauri-plugin-clipboard-manager = "2.3.2"
 dirs = "6"
 ttf-parser = "0.24"
+# Local Steam session recovery + GC access (see user-auth.md).
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
+crc32fast = "1.4"
+hex = "0.4"
+base64 = "0.22"
+keyvalues-parser = "0.2"
+prost = "0.14"
+steam-vent = { git = "https://github.com/deadlock-api/steam-vent", rev = "1d7b274f5c2f648aba5dab474b80c1156b409bca" }
+valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs", rev = "b14c831f324e20653e50ff60372478d427800d45", features = [
+  "gc-common",
+  "gc-client",
+  "serde",
+] }
 
 [dev-dependencies]
 tempfile = "3.27.0"
@@ -78,6 +92,10 @@ tauri-plugin-single-instance = { version = "2.4.2", features = ["deep-link"] }
 
 [target.'cfg(windows)'.dependencies]
 junction = "1"
+windows = { version = "0.58", features = [
+  "Win32_Security_Cryptography",
+  "Win32_Foundation",
+] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.10.1"

--- a/apps/desktop/src-tauri/src/commands/match_sync.rs
+++ b/apps/desktop/src-tauri/src/commands/match_sync.rs
@@ -1,0 +1,44 @@
+use crate::app_runtime::AppHandle;
+use crate::errors::Error;
+use crate::game_presence;
+use crate::match_sync::{self, MatchSyncStatusDto};
+
+#[tauri::command]
+pub async fn get_match_sync_status(app_handle: AppHandle) -> Result<MatchSyncStatusDto, Error> {
+  Ok(match_sync::status(&app_handle)?)
+}
+
+#[tauri::command]
+pub async fn set_match_sync_consent(app_handle: AppHandle, accepted: bool) -> Result<(), Error> {
+  match_sync::set_consent(&app_handle, accepted)?;
+  Ok(())
+}
+
+#[tauri::command]
+pub async fn set_match_sync_enabled(app_handle: AppHandle, enabled: bool) -> Result<(), Error> {
+  match_sync::set_enabled(&app_handle, enabled)?;
+  // Enabling starts (and disabling stops) the game-exit detect-only watcher.
+  game_presence::sync_monitoring_watcher(&app_handle);
+  Ok(())
+}
+
+#[tauri::command]
+pub async fn start_full_match_sync(app_handle: AppHandle) -> Result<(), Error> {
+  match_sync::spawn_full_sync(app_handle)?;
+  Ok(())
+}
+
+#[tauri::command]
+pub async fn cancel_full_match_sync() -> Result<(), Error> {
+  match_sync::cancel_full_sync();
+  Ok(())
+}
+
+// Re-applies the persisted opt-in on startup: starts the background worker and the
+// game-exit watcher iff the user previously opted in. A no-op otherwise.
+#[tauri::command]
+pub async fn resume_match_sync_monitoring(app_handle: AppHandle) -> Result<(), Error> {
+  match_sync::start_background_worker(app_handle.clone());
+  game_presence::sync_monitoring_watcher(&app_handle);
+  Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/match_sync.rs
+++ b/apps/desktop/src-tauri/src/commands/match_sync.rs
@@ -38,6 +38,8 @@ pub async fn cancel_full_match_sync() -> Result<(), Error> {
 // game-exit watcher iff the user previously opted in. A no-op otherwise.
 #[tauri::command]
 pub async fn resume_match_sync_monitoring(app_handle: AppHandle) -> Result<(), Error> {
+  // Startup-only cleanup of persisted state for accounts removed from Steam entirely.
+  match_sync::prune_forgotten_accounts(&app_handle);
   match_sync::start_background_worker(app_handle.clone());
   game_presence::sync_monitoring_watcher(&app_handle);
   Ok(())

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod game;
 pub mod gameinfo;
 pub mod ingest;
 pub mod logs;
+pub mod match_sync;
 pub mod mods;
 pub mod profiles;
 pub mod reports;

--- a/apps/desktop/src-tauri/src/errors.rs
+++ b/apps/desktop/src-tauri/src/errors.rs
@@ -66,8 +66,13 @@ pub enum Error {
   BackgroundTaskFailed(String),
   #[error("VPK files are in use and cannot be deleted: {0}")]
   VpkInUse(String),
-  #[error("Match sync error: {0}")]
-  MatchSync(String),
+  // subcode is a stable machine-readable tag (e.g. "consentRequired") so the
+  // frontend can branch/localize without parsing the English message.
+  #[error("Match sync error: {message}")]
+  MatchSync {
+    subcode: &'static str,
+    message: String,
+  },
 }
 
 impl serde::Serialize for Error {
@@ -76,7 +81,7 @@ impl serde::Serialize for Error {
     S: serde::Serializer,
   {
     use serde::ser::SerializeStruct;
-    let mut state = serializer.serialize_struct("Error", 2)?;
+    let mut state = serializer.serialize_struct("Error", 3)?;
 
     // Map the error variant to the corresponding kind string
     let kind = match self {
@@ -111,11 +116,41 @@ impl serde::Serialize for Error {
       Error::RollbackFailed(_) => "rollbackFailed",
       Error::BackgroundTaskFailed(_) => "backgroundTaskFailed",
       Error::VpkInUse(_) => "vpkInUse",
-      Error::MatchSync(_) => "matchSync",
+      Error::MatchSync { .. } => "matchSync",
+    };
+    let match_sync_kind: Option<&str> = match self {
+      Error::MatchSync { subcode, .. } => Some(subcode),
+      _ => None,
     };
 
     state.serialize_field("kind", kind)?;
     state.serialize_field("message", &self.to_string())?;
+    state.serialize_field("matchSyncKind", &match_sync_kind)?;
     state.end()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::Error;
+
+  #[test]
+  fn match_sync_error_serializes_its_subcode() {
+    let err = Error::MatchSync {
+      subcode: "consentRequired",
+      message: "Consent has not been accepted".into(),
+    };
+    let json = serde_json::to_value(&err).unwrap();
+    assert_eq!(json["kind"], "matchSync");
+    assert_eq!(json["matchSyncKind"], "consentRequired");
+    assert_eq!(json["message"], "Match sync error: Consent has not been accepted");
+  }
+
+  #[test]
+  fn other_errors_have_no_match_sync_subcode() {
+    let err = Error::GameNotFound;
+    let json = serde_json::to_value(&err).unwrap();
+    assert_eq!(json["kind"], "gameNotFound");
+    assert!(json["matchSyncKind"].is_null());
   }
 }

--- a/apps/desktop/src-tauri/src/errors.rs
+++ b/apps/desktop/src-tauri/src/errors.rs
@@ -66,6 +66,8 @@ pub enum Error {
   BackgroundTaskFailed(String),
   #[error("VPK files are in use and cannot be deleted: {0}")]
   VpkInUse(String),
+  #[error("Match sync error: {0}")]
+  MatchSync(String),
 }
 
 impl serde::Serialize for Error {
@@ -109,6 +111,7 @@ impl serde::Serialize for Error {
       Error::RollbackFailed(_) => "rollbackFailed",
       Error::BackgroundTaskFailed(_) => "backgroundTaskFailed",
       Error::VpkInUse(_) => "vpkInUse",
+      Error::MatchSync(_) => "matchSync",
     };
 
     state.serialize_field("kind", kind)?;

--- a/apps/desktop/src-tauri/src/game_presence.rs
+++ b/apps/desktop/src-tauri/src/game_presence.rs
@@ -122,11 +122,8 @@ pub(crate) fn resolve_game_path() -> Option<std::path::PathBuf> {
   mod_manager.find_game().ok()
 }
 
-fn spawn_watcher(app_handle: &AppHandle, presence_enabled: bool) {
-  let Some(game_path) = resolve_game_path() else {
-    log::warn!("[GamePresence] Cannot start watcher: game path not found");
-    return;
-  };
+fn spawn_watcher(app_handle: &AppHandle, presence_enabled: bool) -> Result<(), Error> {
+  let game_path = resolve_game_path().ok_or(Error::GameNotFound)?;
   let discord_presence = app_handle.state::<DiscordState>().inner().clone();
   let presence_config = LATEST_PRESENCE_CONFIG
     .lock()
@@ -143,11 +140,19 @@ fn spawn_watcher(app_handle: &AppHandle, presence_enabled: bool) {
   emit_status(Some(app_handle));
 
   let status_app = app_handle.clone();
-  let status_callback: PresenceStatusCallback =
-    Arc::new(move |phase| set_phase_emit(Some(&status_app), phase));
+  let status_running = Arc::clone(&running);
+  let status_callback: PresenceStatusCallback = Arc::new(move |phase| {
+    if status_running.load(Ordering::Relaxed) {
+      set_phase_emit(Some(&status_app), phase);
+    }
+  });
   let exit_app = app_handle.clone();
-  let exit_callback: GameExitCallback =
-    Arc::new(move || crate::match_sync::on_game_exit(exit_app.clone()));
+  let exit_running = Arc::clone(&running);
+  let exit_callback: GameExitCallback = Arc::new(move || {
+    if exit_running.load(Ordering::Relaxed) {
+      crate::match_sync::on_game_exit(exit_app.clone());
+    }
+  });
   let done_app = app_handle.clone();
   let done_flag = Arc::clone(&running);
 
@@ -173,9 +178,10 @@ fn spawn_watcher(app_handle: &AppHandle, presence_enabled: bool) {
       emit_status(Some(&done_app));
     }
   });
+  Ok(())
 }
 
-pub(crate) fn ensure_watcher(app_handle: &AppHandle) {
+pub(crate) fn ensure_watcher(app_handle: &AppHandle) -> Result<(), Error> {
   let _guard = COORDINATOR_LOCK
     .lock()
     .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -184,18 +190,18 @@ pub(crate) fn ensure_watcher(app_handle: &AppHandle) {
 
   if !presence && !monitoring {
     stop_current(Some(app_handle));
-    return;
+    return Ok(());
   }
 
   let running = is_running();
   let mode_matches = CURRENT_PRESENCE_MODE.load(Ordering::Relaxed) == presence;
   if running && mode_matches {
-    return;
+    return Ok(());
   }
   if running {
     stop_current(Some(app_handle));
   }
-  spawn_watcher(app_handle, presence);
+  spawn_watcher(app_handle, presence)
 }
 
 pub fn sync_monitoring_watcher(app_handle: &AppHandle) {
@@ -203,7 +209,9 @@ pub fn sync_monitoring_watcher(app_handle: &AppHandle) {
     crate::match_sync::should_monitor(app_handle),
     Ordering::Relaxed,
   );
-  ensure_watcher(app_handle);
+  if let Err(e) = ensure_watcher(app_handle) {
+    log::warn!("[GamePresence] Failed to start game-exit detection: {e}");
+  }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -257,7 +265,7 @@ pub async fn start_game_presence_watcher(
     *slot = Some(config);
   }
   PRESENCE_DESIRED.store(true, Ordering::Relaxed);
-  ensure_watcher(&app_handle);
+  ensure_watcher(&app_handle)?;
   log::info!("Game presence watcher requested");
   Ok(())
 }
@@ -265,7 +273,11 @@ pub async fn start_game_presence_watcher(
 #[tauri::command]
 pub async fn stop_game_presence_watcher(app_handle: AppHandle) -> Result<(), Error> {
   PRESENCE_DESIRED.store(false, Ordering::Relaxed);
-  ensure_watcher(&app_handle);
+  // Stopping presence itself always succeeds; only a fallback restart into
+  // detect-only mode (for match-sync monitoring) could fail here.
+  if let Err(e) = ensure_watcher(&app_handle) {
+    log::warn!("[GamePresence] Failed to restart in detect-only mode: {e}");
+  }
   log::info!("Game presence watcher stop requested");
   Ok(())
 }

--- a/apps/desktop/src-tauri/src/game_presence.rs
+++ b/apps/desktop/src-tauri/src/game_presence.rs
@@ -117,7 +117,7 @@ fn stop_current(app_handle: Option<&AppHandle>) {
   emit_status(app_handle);
 }
 
-fn resolve_game_path() -> Option<std::path::PathBuf> {
+pub(crate) fn resolve_game_path() -> Option<std::path::PathBuf> {
   let mut mod_manager = MANAGER.lock().ok()?;
   mod_manager.find_game().ok()
 }

--- a/apps/desktop/src-tauri/src/game_presence.rs
+++ b/apps/desktop/src-tauri/src/game_presence.rs
@@ -1,12 +1,14 @@
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::app_runtime::AppHandle;
 use serde::Serialize;
-use tauri::{Emitter, State};
+use tauri::{Emitter, Manager};
 
 pub(crate) use deadlock_discord_presence::GamePresenceWatcher;
-use deadlock_discord_presence::{HeroDataStore, PresenceBuildConfig, PresencePhase};
+use deadlock_discord_presence::{
+  GameExitCallback, HeroDataStore, PresenceBuildConfig, PresencePhase, PresenceStatusCallback,
+};
 
 use crate::commands::state::MANAGER;
 use crate::errors::Error;
@@ -55,7 +57,20 @@ impl Status {
 }
 
 static STATUS: LazyLock<AtomicU8> = LazyLock::new(|| AtomicU8::new(Status::Inactive as u8));
-static RUNNING: LazyLock<Arc<AtomicBool>> = LazyLock::new(|| Arc::new(AtomicBool::new(false)));
+// Each start gets a fresh stop flag so a mode-switch restart can stop the old loop
+// without racing the new one (they hold different Arcs).
+static CURRENT_RUNNING: LazyLock<Mutex<Option<Arc<AtomicBool>>>> =
+  LazyLock::new(|| Mutex::new(None));
+// Desired inputs deciding whether — and in which mode — the single watcher runs.
+static PRESENCE_DESIRED: AtomicBool = AtomicBool::new(false);
+static MONITORING_DESIRED: AtomicBool = AtomicBool::new(false);
+// true = the running watcher has Discord Rich Presence active.
+static CURRENT_PRESENCE_MODE: AtomicBool = AtomicBool::new(false);
+// Serializes ensure_watcher so overlapping start/stop/restart requests (dev
+// StrictMode, the presence + match-sync renderers) can't double-spawn watchers.
+static COORDINATOR_LOCK: Mutex<()> = Mutex::new(());
+static LATEST_PRESENCE_CONFIG: LazyLock<Mutex<Option<PresenceBuildConfig>>> =
+  LazyLock::new(|| Mutex::new(None));
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -74,11 +89,10 @@ pub fn snapshot() -> GamePresenceStatusDto {
 }
 
 pub(crate) fn is_running() -> bool {
-  Status::from_u8(STATUS.load(Ordering::Relaxed)) != Status::Inactive
-}
-
-pub(crate) fn running_handle() -> Arc<AtomicBool> {
-  Arc::clone(&RUNNING)
+  CURRENT_RUNNING
+    .lock()
+    .map(|guard| guard.is_some())
+    .unwrap_or(false)
 }
 
 fn emit_status(app_handle: Option<&AppHandle>) {
@@ -93,16 +107,103 @@ pub(crate) fn set_phase_emit(app_handle: Option<&AppHandle>, phase: PresencePhas
   emit_status(app_handle);
 }
 
-pub(crate) fn mark_started(app_handle: &AppHandle) {
-  RUNNING.store(true, Ordering::Relaxed);
-  STATUS.store(Status::Waiting as u8, Ordering::Relaxed);
-  emit_status(Some(app_handle));
-}
-
-pub(crate) fn mark_stopped(app_handle: Option<&AppHandle>) {
-  RUNNING.store(false, Ordering::Relaxed);
+fn stop_current(app_handle: Option<&AppHandle>) {
+  if let Ok(mut current) = CURRENT_RUNNING.lock()
+    && let Some(flag) = current.take()
+  {
+    flag.store(false, Ordering::Relaxed);
+  }
   STATUS.store(Status::Inactive as u8, Ordering::Relaxed);
   emit_status(app_handle);
+}
+
+fn resolve_game_path() -> Option<std::path::PathBuf> {
+  let mut mod_manager = MANAGER.lock().ok()?;
+  mod_manager.find_game().ok()
+}
+
+fn spawn_watcher(app_handle: &AppHandle, presence_enabled: bool) {
+  let Some(game_path) = resolve_game_path() else {
+    log::warn!("[GamePresence] Cannot start watcher: game path not found");
+    return;
+  };
+  let discord_presence = app_handle.state::<DiscordState>().inner().clone();
+  let presence_config = LATEST_PRESENCE_CONFIG
+    .lock()
+    .ok()
+    .and_then(|config| config.clone())
+    .unwrap_or_default();
+
+  let running = Arc::new(AtomicBool::new(true));
+  if let Ok(mut current) = CURRENT_RUNNING.lock() {
+    *current = Some(Arc::clone(&running));
+  }
+  CURRENT_PRESENCE_MODE.store(presence_enabled, Ordering::Relaxed);
+  STATUS.store(Status::Waiting as u8, Ordering::Relaxed);
+  emit_status(Some(app_handle));
+
+  let status_app = app_handle.clone();
+  let status_callback: PresenceStatusCallback =
+    Arc::new(move |phase| set_phase_emit(Some(&status_app), phase));
+  let exit_app = app_handle.clone();
+  let exit_callback: GameExitCallback =
+    Arc::new(move || crate::match_sync::on_game_exit(exit_app.clone()));
+  let done_app = app_handle.clone();
+  let done_flag = Arc::clone(&running);
+
+  tokio::spawn(async move {
+    let watcher = GamePresenceWatcher::new(
+      game_path,
+      running,
+      discord_presence,
+      Some(status_callback),
+      presence_config,
+    )
+    .with_presence_enabled(presence_enabled)
+    .with_game_exit_callback(exit_callback);
+    watcher.run().await;
+
+    // Only clear shared status if we are still the active watcher (not superseded
+    // by a restart), otherwise we'd stomp the newer watcher's state.
+    if let Ok(mut current) = CURRENT_RUNNING.lock()
+      && current.as_ref().is_some_and(|flag| Arc::ptr_eq(flag, &done_flag))
+    {
+      current.take();
+      STATUS.store(Status::Inactive as u8, Ordering::Relaxed);
+      emit_status(Some(&done_app));
+    }
+  });
+}
+
+pub(crate) fn ensure_watcher(app_handle: &AppHandle) {
+  let _guard = COORDINATOR_LOCK
+    .lock()
+    .unwrap_or_else(std::sync::PoisonError::into_inner);
+  let presence = PRESENCE_DESIRED.load(Ordering::Relaxed);
+  let monitoring = MONITORING_DESIRED.load(Ordering::Relaxed);
+
+  if !presence && !monitoring {
+    stop_current(Some(app_handle));
+    return;
+  }
+
+  let running = is_running();
+  let mode_matches = CURRENT_PRESENCE_MODE.load(Ordering::Relaxed) == presence;
+  if running && mode_matches {
+    return;
+  }
+  if running {
+    stop_current(Some(app_handle));
+  }
+  spawn_watcher(app_handle, presence);
+}
+
+pub fn sync_monitoring_watcher(app_handle: &AppHandle) {
+  MONITORING_DESIRED.store(
+    crate::match_sync::should_monitor(app_handle),
+    Ordering::Relaxed,
+  );
+  ensure_watcher(app_handle);
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -148,55 +249,23 @@ pub async fn get_game_presence_heroes() -> Result<Vec<GamePresenceHeroDto>, Erro
 #[tauri::command]
 pub async fn start_game_presence_watcher(
   app_handle: AppHandle,
-  discord_state: State<'_, DiscordState>,
   presence_config: Option<PresenceBuildConfig>,
 ) -> Result<(), Error> {
-  if is_running() {
-    log::info!("Game presence watcher already running");
-    return Ok(());
+  if let Some(config) = presence_config
+    && let Ok(mut slot) = LATEST_PRESENCE_CONFIG.lock()
+  {
+    *slot = Some(config);
   }
-
-  let game_path = {
-    let mut mod_manager = MANAGER.lock().unwrap();
-    mod_manager
-      .find_game()
-      .map_err(|e| Error::InvalidInput(format!("Cannot find game path: {e}")))?
-  };
-
-  mark_started(&app_handle);
-
-  let running = running_handle();
-  let app_spawn = app_handle.clone();
-  let discord_presence = discord_state.inner().clone();
-  let presence_config = presence_config.unwrap_or_default();
-
-  tokio::spawn(async move {
-    let status_app = app_spawn.clone();
-    let status_callback = Arc::new(move |phase| {
-      set_phase_emit(Some(&status_app), phase);
-    });
-    let watcher = GamePresenceWatcher::new(
-      game_path,
-      running,
-      discord_presence,
-      Some(status_callback),
-      presence_config,
-    );
-    watcher.run().await;
-    mark_stopped(Some(&app_spawn));
-  });
-
-  log::info!("Game presence watcher started");
+  PRESENCE_DESIRED.store(true, Ordering::Relaxed);
+  ensure_watcher(&app_handle);
+  log::info!("Game presence watcher requested");
   Ok(())
 }
 
 #[tauri::command]
 pub async fn stop_game_presence_watcher(app_handle: AppHandle) -> Result<(), Error> {
-  if !is_running() {
-    return Ok(());
-  }
-
-  mark_stopped(Some(&app_handle));
-  log::info!("Game presence watcher stop signal sent");
+  PRESENCE_DESIRED.store(false, Ordering::Relaxed);
+  ensure_watcher(&app_handle);
+  log::info!("Game presence watcher stop requested");
   Ok(())
 }

--- a/apps/desktop/src-tauri/src/ingest_tool/scan_cache.rs
+++ b/apps/desktop/src-tauri/src/ingest_tool/scan_cache.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const DEADLOCK_APP_ID: &str = "1422450";
 const MAX_BYTES_TO_READ: usize = 200;
 const SEARCH_SEQUENCE: &[u8; 10] = b".valve.net";
-const PATH_END_MARKERS: [u8; 6] = [b' ', b'\'', b'\0', b'\n', b'\r', b'"'];
+const PATH_END_MARKERS: [u8; 6] = *b" '\0\n\r\"";
 
 /// Get the Steam HTTP cache directory using steamlocate
 pub fn get_cache_directory() -> Option<PathBuf> {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod game_presence;
 mod hero_detector;
 mod ingest_tool;
 mod logs;
+mod match_sync;
 mod mod_manager;
 pub mod proxy;
 mod reports;
@@ -193,6 +194,12 @@ pub fn run() {
       game_presence::get_game_presence_heroes,
       game_presence::start_game_presence_watcher,
       game_presence::stop_game_presence_watcher,
+      commands::match_sync::get_match_sync_status,
+      commands::match_sync::set_match_sync_consent,
+      commands::match_sync::set_match_sync_enabled,
+      commands::match_sync::start_full_match_sync,
+      commands::match_sync::cancel_full_match_sync,
+      commands::match_sync::resume_match_sync_monitoring,
       commands::profiles::create_profile_folder,
       commands::profiles::delete_profile_folder,
       commands::profiles::switch_profile,

--- a/apps/desktop/src-tauri/src/match_sync/api_client.rs
+++ b/apps/desktop/src-tauri/src/match_sync/api_client.rs
@@ -1,0 +1,95 @@
+//! The only two deadlock-api calls this subsystem makes: read the to-fetch list and
+//! POST recovered salts to the same route the httpcache scraper uses. Split into
+//! traits so [`super::sync`] can be tested with spies.
+
+use std::future::Future;
+use std::time::Duration;
+
+use super::error::MatchSyncError;
+use super::model::{FetchScope, SaltPayload};
+
+const DEFAULT_BASE_URL: &str = "https://api.deadlock-api.com";
+const POST_MAX_RETRIES: u32 = 5;
+const POST_RETRY_DELAY: Duration = Duration::from_secs(3);
+
+pub trait BackfillSource: Send + Sync {
+  fn to_fetch(
+    &self,
+    scope: FetchScope,
+  ) -> impl Future<Output = Result<Vec<u64>, MatchSyncError>> + Send;
+}
+
+pub trait SaltsSink: Send + Sync {
+  fn post_salts(
+    &self,
+    salts: &[SaltPayload],
+  ) -> impl Future<Output = Result<(), MatchSyncError>> + Send;
+}
+
+pub struct ApiClient {
+  base_url: String,
+}
+
+impl Default for ApiClient {
+  fn default() -> Self {
+    Self {
+      base_url: DEFAULT_BASE_URL.to_string(),
+    }
+  }
+}
+
+impl ApiClient {
+  fn client(&self) -> Result<reqwest::Client, MatchSyncError> {
+    crate::proxy::build_default_http_client().map_err(|e| MatchSyncError::Api(e.to_string()))
+  }
+}
+
+impl BackfillSource for ApiClient {
+  async fn to_fetch(&self, scope: FetchScope) -> Result<Vec<u64>, MatchSyncError> {
+    let mut req = self
+      .client()?
+      .get(format!("{}/v1/matches/to-fetch", self.base_url));
+    if let FetchScope::Account(account_id) = scope {
+      req = req.query(&[("account_id", account_id)]);
+    }
+    let resp = req
+      .send()
+      .await
+      .and_then(|r| r.error_for_status())
+      .map_err(|e| MatchSyncError::Api(e.to_string()))?;
+    resp
+      .json::<Vec<u64>>()
+      .await
+      .map_err(|e| MatchSyncError::Api(format!("invalid to-fetch response: {e}")))
+  }
+}
+
+impl SaltsSink for ApiClient {
+  async fn post_salts(&self, salts: &[SaltPayload]) -> Result<(), MatchSyncError> {
+    if salts.is_empty() {
+      return Ok(());
+    }
+    let url = format!("{}/v1/matches/salts", self.base_url);
+    let mut attempt = 0;
+    loop {
+      attempt += 1;
+      let result = self
+        .client()?
+        .post(&url)
+        .json(salts)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status());
+
+      match result {
+        Ok(_) => return Ok(()),
+        // 400 means the payload itself is wrong; retrying can't help.
+        Err(e) if e.status() == Some(reqwest::StatusCode::BAD_REQUEST) => {
+          return Err(MatchSyncError::Api(e.to_string()));
+        }
+        Err(e) if attempt >= POST_MAX_RETRIES => return Err(MatchSyncError::Api(e.to_string())),
+        Err(_) => tokio::time::sleep(POST_RETRY_DELAY).await,
+      }
+    }
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/auth.rs
+++ b/apps/desktop/src-tauri/src/match_sync/auth.rs
@@ -1,5 +1,5 @@
 //! Local Steam session recovery: read the `local.vdf` ConnectCache blob and decrypt
-//! the refresh-token JWT (AES on Linux/macOS, DPAPI on Windows) per `user-auth.md`.
+//! the refresh-token JWT (AES on Linux/macOS, DPAPI on Windows).
 //! The token is a live account credential: in-memory only, never logged/persisted/sent.
 
 use std::path::{Path, PathBuf};
@@ -30,7 +30,7 @@ fn child<'a>(value: &'a Value<'a>, key: &str) -> Option<&'a Value<'a>> {
   value.get_obj()?.get(key)?.first()
 }
 
-// The auth file location differs on Windows (see user-auth.md).
+// The auth file location differs on Windows.
 #[cfg(windows)]
 fn local_vdf_path(_steam_dir: &Path) -> Result<PathBuf, MatchSyncError> {
   dirs::data_local_dir()

--- a/apps/desktop/src-tauri/src/match_sync/auth.rs
+++ b/apps/desktop/src-tauri/src/match_sync/auth.rs
@@ -23,7 +23,7 @@ impl SteamAuthProvider for LocalSteamAuth {
     let steam_dir = steam.path();
 
     let account = most_recent_account(steam_dir)?;
-    let blob = connect_cache_blob(&local_vdf_path(steam_dir), &account)?;
+    let blob = connect_cache_blob(&local_vdf_path(steam_dir)?, &account)?;
     let jwt = decrypt_blob(&blob, &account)?;
     let steam_id64 = steam_id_from_jwt(&jwt)?;
 
@@ -45,15 +45,15 @@ fn child<'a>(value: &'a Value<'a>, key: &str) -> Option<&'a Value<'a>> {
 
 // The auth file location differs on Windows (see user-auth.md).
 #[cfg(windows)]
-fn local_vdf_path(_steam_dir: &Path) -> PathBuf {
+fn local_vdf_path(_steam_dir: &Path) -> Result<PathBuf, MatchSyncError> {
   dirs::data_local_dir()
     .map(|d| d.join("Steam").join("local.vdf"))
-    .unwrap_or_else(|| PathBuf::from("local.vdf"))
+    .ok_or_else(|| err("could not resolve %LOCALAPPDATA%"))
 }
 
 #[cfg(not(windows))]
-fn local_vdf_path(steam_dir: &Path) -> PathBuf {
-  steam_dir.join("local.vdf")
+fn local_vdf_path(steam_dir: &Path) -> Result<PathBuf, MatchSyncError> {
+  Ok(steam_dir.join("local.vdf"))
 }
 
 fn most_recent_account(steam_dir: &Path) -> Result<String, MatchSyncError> {

--- a/apps/desktop/src-tauri/src/match_sync/auth.rs
+++ b/apps/desktop/src-tauri/src/match_sync/auth.rs
@@ -1,0 +1,196 @@
+//! Local Steam session recovery: read the `local.vdf` ConnectCache blob and decrypt
+//! the refresh-token JWT (AES on Linux/macOS, DPAPI on Windows) per `user-auth.md`.
+//! The token is a live account credential: in-memory only, never logged/persisted/sent.
+
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use keyvalues_parser::{Value, Vdf};
+
+use super::error::MatchSyncError;
+use super::model::AuthContext;
+
+pub trait SteamAuthProvider: Send + Sync {
+  fn recover(&self) -> Result<AuthContext, MatchSyncError>;
+}
+
+pub struct LocalSteamAuth;
+
+impl SteamAuthProvider for LocalSteamAuth {
+  fn recover(&self) -> Result<AuthContext, MatchSyncError> {
+    let steam = steamlocate::SteamDir::locate()
+      .map_err(|e| MatchSyncError::AuthUnavailable(format!("Steam not found: {e}")))?;
+    let steam_dir = steam.path();
+
+    let account = most_recent_account(steam_dir)?;
+    let blob = connect_cache_blob(&local_vdf_path(steam_dir), &account)?;
+    let jwt = decrypt_blob(&blob, &account)?;
+    let steam_id64 = steam_id_from_jwt(&jwt)?;
+
+    Ok(AuthContext {
+      account_name: account,
+      steam_id64,
+      refresh_token: jwt,
+    })
+  }
+}
+
+fn err(msg: impl Into<String>) -> MatchSyncError {
+  MatchSyncError::AuthUnavailable(msg.into())
+}
+
+fn child<'a>(value: &'a Value<'a>, key: &str) -> Option<&'a Value<'a>> {
+  value.get_obj()?.get(key)?.first()
+}
+
+// The auth file location differs on Windows (see user-auth.md).
+#[cfg(windows)]
+fn local_vdf_path(_steam_dir: &Path) -> PathBuf {
+  dirs::data_local_dir()
+    .map(|d| d.join("Steam").join("local.vdf"))
+    .unwrap_or_else(|| PathBuf::from("local.vdf"))
+}
+
+#[cfg(not(windows))]
+fn local_vdf_path(steam_dir: &Path) -> PathBuf {
+  steam_dir.join("local.vdf")
+}
+
+fn most_recent_account(steam_dir: &Path) -> Result<String, MatchSyncError> {
+  let path = steam_dir.join("config").join("loginusers.vdf");
+  let text = std::fs::read_to_string(&path)
+    .map_err(|e| err(format!("cannot read loginusers.vdf: {e}")))?;
+  let vdf = keyvalues_parser::parse(&text)
+    .map(Vdf::from)
+    .map_err(|e| err(format!("cannot parse loginusers.vdf: {e}")))?;
+  let users = vdf
+    .value
+    .get_obj()
+    .ok_or_else(|| err("loginusers.vdf has no users"))?;
+
+  let mut fallback: Option<String> = None;
+  for entries in users.values() {
+    let Some(user) = entries.first() else {
+      continue;
+    };
+    let Some(name) = child(user, "AccountName").and_then(Value::get_str) else {
+      continue;
+    };
+    fallback.get_or_insert_with(|| name.to_lowercase());
+    if child(user, "MostRecent").and_then(Value::get_str) == Some("1") {
+      return Ok(name.to_lowercase());
+    }
+  }
+
+  fallback.ok_or_else(|| err("no remembered Steam account found"))
+}
+
+fn connect_cache_blob(local_vdf: &Path, account: &str) -> Result<Vec<u8>, MatchSyncError> {
+  let text = std::fs::read_to_string(local_vdf)
+    .map_err(|e| err(format!("cannot read local.vdf: {e}")))?;
+  let vdf = keyvalues_parser::parse(&text)
+    .map(Vdf::from)
+    .map_err(|e| err(format!("cannot parse local.vdf: {e}")))?;
+
+  let cache = ["Software", "Valve", "Steam", "ConnectCache"]
+    .into_iter()
+    .try_fold(&vdf.value, child)
+    .and_then(Value::get_obj)
+    .ok_or_else(|| err("no ConnectCache in local.vdf (logged out or 'remember me' off)"))?;
+
+  let prefix = format!("{:08x}", crc32fast::hash(account.as_bytes()));
+  let hex_value = cache
+    .iter()
+    .find(|(subkey, _)| subkey.starts_with(&prefix))
+    .and_then(|(_, values)| values.first())
+    .and_then(Value::get_str)
+    .ok_or_else(|| err("no ConnectCache entry for this account"))?;
+
+  hex::decode(hex_value).map_err(|e| err(format!("invalid ConnectCache hex: {e}")))
+}
+
+#[cfg(not(windows))]
+fn decrypt_blob(blob: &[u8], account: &str) -> Result<String, MatchSyncError> {
+  use aes::Aes256;
+  use aes::cipher::{
+    BlockDecrypt, BlockDecryptMut, KeyInit, KeyIvInit, block_padding::Pkcs7,
+    generic_array::GenericArray,
+  };
+  use sha2::{Digest, Sha256};
+
+  if blob.len() < 32 {
+    return Err(err("ConnectCache blob too short"));
+  }
+  let key = Sha256::digest(account.as_bytes());
+
+  // The first block is the real IV, encrypted with AES-256-ECB.
+  let cipher = Aes256::new_from_slice(key.as_slice())
+    .map_err(|e| err(format!("aes key error: {e}")))?;
+  let mut iv = GenericArray::clone_from_slice(&blob[0..16]);
+  cipher.decrypt_block(&mut iv);
+
+  let plaintext = cbc::Decryptor::<Aes256>::new_from_slices(key.as_slice(), iv.as_slice())
+    .map_err(|e| err(format!("aes iv error: {e}")))?
+    .decrypt_padded_vec_mut::<Pkcs7>(&blob[16..])
+    .map_err(|e| err(format!("aes decrypt failed: {e}")))?;
+
+  String::from_utf8(plaintext).map_err(|e| err(format!("token is not valid UTF-8: {e}")))
+}
+
+#[cfg(windows)]
+fn decrypt_blob(blob: &[u8], account: &str) -> Result<String, MatchSyncError> {
+  use windows::Win32::Foundation::{HLOCAL, LocalFree};
+  use windows::Win32::Security::Cryptography::{CRYPT_INTEGER_BLOB, CryptUnprotectData};
+
+  // DPAPI with the ASCII account name as the mandatory optional entropy.
+  let mut data_in = CRYPT_INTEGER_BLOB {
+    cbData: blob.len() as u32,
+    pbData: blob.as_ptr() as *mut u8,
+  };
+  let entropy_bytes = account.as_bytes();
+  let mut entropy = CRYPT_INTEGER_BLOB {
+    cbData: entropy_bytes.len() as u32,
+    pbData: entropy_bytes.as_ptr() as *mut u8,
+  };
+  let mut data_out = CRYPT_INTEGER_BLOB::default();
+
+  unsafe {
+    CryptUnprotectData(
+      &mut data_in,
+      None,
+      Some(&mut entropy),
+      None,
+      None,
+      0,
+      &mut data_out,
+    )
+    .map_err(|e| err(format!("DPAPI decrypt failed: {e}")))?;
+
+    let slice = std::slice::from_raw_parts(data_out.pbData, data_out.cbData as usize);
+    let token = String::from_utf8(slice.to_vec())
+      .map_err(|e| err(format!("token is not valid UTF-8: {e}")));
+    let _ = LocalFree(HLOCAL(data_out.pbData as *mut core::ffi::c_void));
+    token
+  }
+}
+
+fn steam_id_from_jwt(jwt: &str) -> Result<u64, MatchSyncError> {
+  let payload = jwt
+    .split('.')
+    .nth(1)
+    .ok_or_else(|| err("token is not a JWT"))?;
+  let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+    .decode(payload)
+    .map_err(|e| err(format!("cannot decode token payload: {e}")))?;
+  let json: serde_json::Value =
+    serde_json::from_slice(&bytes).map_err(|e| err(format!("cannot parse token payload: {e}")))?;
+
+  if json.get("iss").and_then(serde_json::Value::as_str) != Some("steam") {
+    return Err(err("token issuer is not steam"));
+  }
+  json
+    .get("sub")
+    .and_then(serde_json::Value::as_str)
+    .and_then(|s| s.parse::<u64>().ok())
+    .ok_or_else(|| err("token has no SteamID"))
+}

--- a/apps/desktop/src-tauri/src/match_sync/auth.rs
+++ b/apps/desktop/src-tauri/src/match_sync/auth.rs
@@ -88,10 +88,15 @@ pub fn list_available_accounts() -> Result<Vec<(u64, String)>, MatchSyncError> {
     .map_err(|e| err(format!("Steam not found: {e}")))?;
   let steam_dir = steam.path();
   let local_vdf = local_vdf_path(steam_dir)?;
+  let text = std::fs::read_to_string(&local_vdf)
+    .map_err(|e| err(format!("cannot read local.vdf: {e}")))?;
+  let vdf = keyvalues_parser::parse(&text)
+    .map(Vdf::from)
+    .map_err(|e| err(format!("cannot parse local.vdf: {e}")))?;
 
   let mut available = Vec::new();
   for (steam_id64, account_name) in all_account_ids(steam_dir)? {
-    match find_connect_cache_hex(&local_vdf, &account_name) {
+    match connect_cache_hex(&vdf, &account_name) {
       Ok(Some(_)) => available.push((steam_id64, account_name)),
       Ok(None) => {}
       Err(e) => log::warn!("cannot check ConnectCache for {account_name}: {e}"),
@@ -105,18 +110,28 @@ pub fn recover_all() -> Result<Vec<AuthContext>, MatchSyncError> {
     .map_err(|e| err(format!("Steam not found: {e}")))?;
   let steam_dir = steam.path();
   let local_vdf = local_vdf_path(steam_dir)?;
+  let text = std::fs::read_to_string(&local_vdf)
+    .map_err(|e| err(format!("cannot read local.vdf: {e}")))?;
+  let vdf = keyvalues_parser::parse(&text)
+    .map(Vdf::from)
+    .map_err(|e| err(format!("cannot parse local.vdf: {e}")))?;
 
   let mut contexts = Vec::new();
   for (steam_id64, account_name) in all_account_ids(steam_dir)? {
-    let recovered = connect_cache_blob(&local_vdf, &account_name)
+    let recovered = connect_cache_blob(&vdf, &account_name)
       .and_then(|blob| decrypt_blob(&blob, &account_name))
-      .and_then(|jwt| validate_steam_jwt(&jwt).map(|()| jwt));
+      .and_then(|jwt| steam_id_from_jwt(&jwt).map(|sub| (jwt, sub)));
     match recovered {
-      Ok(refresh_token) => contexts.push(AuthContext {
+      Ok((refresh_token, sub)) if sub == steam_id64 => contexts.push(AuthContext {
         account_name,
         steam_id64,
         refresh_token,
       }),
+      // The ConnectCache lookup is keyed by account name, not steam_id64 - reject a
+      // blob whose token identity doesn't match the loginusers.vdf entry it came from.
+      Ok((_, sub)) => log::warn!(
+        "skipping account {account_name}: token SteamID {sub} does not match loginusers.vdf entry {steam_id64}"
+      ),
       Err(e) => log::warn!("skipping account {account_name}: {e}"),
     }
   }
@@ -127,16 +142,9 @@ pub fn recover_all() -> Result<Vec<AuthContext>, MatchSyncError> {
   Ok(contexts)
 }
 
-fn find_connect_cache_hex(
-  local_vdf: &Path,
-  account: &str,
-) -> Result<Option<String>, MatchSyncError> {
-  let text = std::fs::read_to_string(local_vdf)
-    .map_err(|e| err(format!("cannot read local.vdf: {e}")))?;
-  let vdf = keyvalues_parser::parse(&text)
-    .map(Vdf::from)
-    .map_err(|e| err(format!("cannot parse local.vdf: {e}")))?;
-
+// `local.vdf` is read and parsed once per caller (`list_available_accounts`/
+// `recover_all`) and shared across every account's lookup in that call's loop.
+fn connect_cache_hex(vdf: &Vdf, account: &str) -> Result<Option<String>, MatchSyncError> {
   let cache = ["Software", "Valve", "Steam", "ConnectCache"]
     .into_iter()
     .try_fold(&vdf.value, child)
@@ -154,8 +162,8 @@ fn find_connect_cache_hex(
   )
 }
 
-fn connect_cache_blob(local_vdf: &Path, account: &str) -> Result<Vec<u8>, MatchSyncError> {
-  let hex_value = find_connect_cache_hex(local_vdf, account)?
+fn connect_cache_blob(vdf: &Vdf, account: &str) -> Result<Vec<u8>, MatchSyncError> {
+  let hex_value = connect_cache_hex(vdf, account)?
     .ok_or_else(|| err("no ConnectCache entry for this account"))?;
   hex::decode(hex_value).map_err(|e| err(format!("invalid ConnectCache hex: {e}")))
 }
@@ -225,7 +233,7 @@ fn decrypt_blob(blob: &[u8], account: &str) -> Result<String, MatchSyncError> {
   }
 }
 
-fn validate_steam_jwt(jwt: &str) -> Result<(), MatchSyncError> {
+fn steam_id_from_jwt(jwt: &str) -> Result<u64, MatchSyncError> {
   let payload = jwt
     .split('.')
     .nth(1)
@@ -239,5 +247,9 @@ fn validate_steam_jwt(jwt: &str) -> Result<(), MatchSyncError> {
   if json.get("iss").and_then(serde_json::Value::as_str) != Some("steam") {
     return Err(err("token issuer is not steam"));
   }
-  Ok(())
+  json
+    .get("sub")
+    .and_then(serde_json::Value::as_str)
+    .and_then(|s| s.parse::<u64>().ok())
+    .ok_or_else(|| err("token has no SteamID"))
 }

--- a/apps/desktop/src-tauri/src/match_sync/auth.rs
+++ b/apps/desktop/src-tauri/src/match_sync/auth.rs
@@ -129,8 +129,8 @@ pub fn recover_all() -> Result<Vec<AuthContext>, MatchSyncError> {
       }),
       // The ConnectCache lookup is keyed by account name, not steam_id64 - reject a
       // blob whose token identity doesn't match the loginusers.vdf entry it came from.
-      Ok((_, sub)) => log::warn!(
-        "skipping account {account_name}: token SteamID {sub} does not match loginusers.vdf entry {steam_id64}"
+      Ok(_) => log::warn!(
+        "skipping account {account_name}: token identity does not match loginusers.vdf entry"
       ),
       Err(e) => log::warn!("skipping account {account_name}: {e}"),
     }

--- a/apps/desktop/src-tauri/src/match_sync/auth.rs
+++ b/apps/desktop/src-tauri/src/match_sync/auth.rs
@@ -14,24 +14,11 @@ pub trait SteamAuthProvider: Send + Sync {
   fn recover(&self) -> Result<AuthContext, MatchSyncError>;
 }
 
-pub struct LocalSteamAuth;
+pub struct FixedAccountAuth(pub AuthContext);
 
-impl SteamAuthProvider for LocalSteamAuth {
+impl SteamAuthProvider for FixedAccountAuth {
   fn recover(&self) -> Result<AuthContext, MatchSyncError> {
-    let steam = steamlocate::SteamDir::locate()
-      .map_err(|e| MatchSyncError::AuthUnavailable(format!("Steam not found: {e}")))?;
-    let steam_dir = steam.path();
-
-    let account = most_recent_account(steam_dir)?;
-    let blob = connect_cache_blob(&local_vdf_path(steam_dir)?, &account)?;
-    let jwt = decrypt_blob(&blob, &account)?;
-    let steam_id64 = steam_id_from_jwt(&jwt)?;
-
-    Ok(AuthContext {
-      account_name: account,
-      steam_id64,
-      refresh_token: jwt,
-    })
+    Ok(self.0.clone())
   }
 }
 
@@ -56,7 +43,7 @@ fn local_vdf_path(steam_dir: &Path) -> Result<PathBuf, MatchSyncError> {
   Ok(steam_dir.join("local.vdf"))
 }
 
-fn most_recent_account(steam_dir: &Path) -> Result<String, MatchSyncError> {
+pub fn all_account_ids(steam_dir: &Path) -> Result<Vec<(u64, String)>, MatchSyncError> {
   let path = steam_dir.join("config").join("loginusers.vdf");
   let text = std::fs::read_to_string(&path)
     .map_err(|e| err(format!("cannot read loginusers.vdf: {e}")))?;
@@ -68,24 +55,82 @@ fn most_recent_account(steam_dir: &Path) -> Result<String, MatchSyncError> {
     .get_obj()
     .ok_or_else(|| err("loginusers.vdf has no users"))?;
 
-  let mut fallback: Option<String> = None;
-  for entries in users.values() {
-    let Some(user) = entries.first() else {
+  let mut accounts = Vec::new();
+  for (key, entries) in users.iter() {
+    let Ok(steam_id64) = key.parse::<u64>() else {
+      log::warn!("skipping loginusers.vdf block with non-numeric key: {key}");
       continue;
     };
-    let Some(name) = child(user, "AccountName").and_then(Value::get_str) else {
+    let Some(name) = entries
+      .first()
+      .and_then(|user| child(user, "AccountName"))
+      .and_then(Value::get_str)
+    else {
+      log::warn!("skipping loginusers.vdf block {steam_id64} with no AccountName");
       continue;
     };
-    fallback.get_or_insert_with(|| name.to_lowercase());
-    if child(user, "MostRecent").and_then(Value::get_str) == Some("1") {
-      return Ok(name.to_lowercase());
+    accounts.push((steam_id64, name.to_lowercase()));
+  }
+  Ok(accounts)
+}
+
+// Self-locating wrapper over `all_account_ids`: every account remembered in
+// `loginusers.vdf`, regardless of current decryptability. Startup-only pruning uses
+// this so temporarily non-decryptable accounts are NOT treated as forgotten.
+pub fn all_remembered_accounts() -> Result<Vec<(u64, String)>, MatchSyncError> {
+  let steam = steamlocate::SteamDir::locate()
+    .map_err(|e| err(format!("Steam not found: {e}")))?;
+  all_account_ids(steam.path())
+}
+
+pub fn list_available_accounts() -> Result<Vec<(u64, String)>, MatchSyncError> {
+  let steam = steamlocate::SteamDir::locate()
+    .map_err(|e| err(format!("Steam not found: {e}")))?;
+  let steam_dir = steam.path();
+  let local_vdf = local_vdf_path(steam_dir)?;
+
+  let mut available = Vec::new();
+  for (steam_id64, account_name) in all_account_ids(steam_dir)? {
+    match find_connect_cache_hex(&local_vdf, &account_name) {
+      Ok(Some(_)) => available.push((steam_id64, account_name)),
+      Ok(None) => {}
+      Err(e) => log::warn!("cannot check ConnectCache for {account_name}: {e}"),
+    }
+  }
+  Ok(available)
+}
+
+pub fn recover_all() -> Result<Vec<AuthContext>, MatchSyncError> {
+  let steam = steamlocate::SteamDir::locate()
+    .map_err(|e| err(format!("Steam not found: {e}")))?;
+  let steam_dir = steam.path();
+  let local_vdf = local_vdf_path(steam_dir)?;
+
+  let mut contexts = Vec::new();
+  for (steam_id64, account_name) in all_account_ids(steam_dir)? {
+    let recovered = connect_cache_blob(&local_vdf, &account_name)
+      .and_then(|blob| decrypt_blob(&blob, &account_name))
+      .and_then(|jwt| validate_steam_jwt(&jwt).map(|()| jwt));
+    match recovered {
+      Ok(refresh_token) => contexts.push(AuthContext {
+        account_name,
+        steam_id64,
+        refresh_token,
+      }),
+      Err(e) => log::warn!("skipping account {account_name}: {e}"),
     }
   }
 
-  fallback.ok_or_else(|| err("no remembered Steam account found"))
+  if contexts.is_empty() {
+    return Err(err("no remembered Steam account found"));
+  }
+  Ok(contexts)
 }
 
-fn connect_cache_blob(local_vdf: &Path, account: &str) -> Result<Vec<u8>, MatchSyncError> {
+fn find_connect_cache_hex(
+  local_vdf: &Path,
+  account: &str,
+) -> Result<Option<String>, MatchSyncError> {
   let text = std::fs::read_to_string(local_vdf)
     .map_err(|e| err(format!("cannot read local.vdf: {e}")))?;
   let vdf = keyvalues_parser::parse(&text)
@@ -99,13 +144,19 @@ fn connect_cache_blob(local_vdf: &Path, account: &str) -> Result<Vec<u8>, MatchS
     .ok_or_else(|| err("no ConnectCache in local.vdf (logged out or 'remember me' off)"))?;
 
   let prefix = format!("{:08x}", crc32fast::hash(account.as_bytes()));
-  let hex_value = cache
-    .iter()
-    .find(|(subkey, _)| subkey.starts_with(&prefix))
-    .and_then(|(_, values)| values.first())
-    .and_then(Value::get_str)
-    .ok_or_else(|| err("no ConnectCache entry for this account"))?;
+  Ok(
+    cache
+      .iter()
+      .find(|(subkey, _)| subkey.starts_with(&prefix))
+      .and_then(|(_, values)| values.first())
+      .and_then(Value::get_str)
+      .map(str::to_owned),
+  )
+}
 
+fn connect_cache_blob(local_vdf: &Path, account: &str) -> Result<Vec<u8>, MatchSyncError> {
+  let hex_value = find_connect_cache_hex(local_vdf, account)?
+    .ok_or_else(|| err("no ConnectCache entry for this account"))?;
   hex::decode(hex_value).map_err(|e| err(format!("invalid ConnectCache hex: {e}")))
 }
 
@@ -174,7 +225,7 @@ fn decrypt_blob(blob: &[u8], account: &str) -> Result<String, MatchSyncError> {
   }
 }
 
-fn steam_id_from_jwt(jwt: &str) -> Result<u64, MatchSyncError> {
+fn validate_steam_jwt(jwt: &str) -> Result<(), MatchSyncError> {
   let payload = jwt
     .split('.')
     .nth(1)
@@ -188,9 +239,5 @@ fn steam_id_from_jwt(jwt: &str) -> Result<u64, MatchSyncError> {
   if json.get("iss").and_then(serde_json::Value::as_str) != Some("steam") {
     return Err(err("token issuer is not steam"));
   }
-  json
-    .get("sub")
-    .and_then(serde_json::Value::as_str)
-    .and_then(|s| s.parse::<u64>().ok())
-    .ok_or_else(|| err("token has no SteamID"))
+  Ok(())
 }

--- a/apps/desktop/src-tauri/src/match_sync/error.rs
+++ b/apps/desktop/src-tauri/src/match_sync/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-// Messages never include the refresh token / GC session (secrets — see user-auth.md).
+// Messages never include the refresh token / GC session (secrets).
 #[derive(Error, Debug)]
 pub enum MatchSyncError {
   #[error("Match sync is disabled")]

--- a/apps/desktop/src-tauri/src/match_sync/error.rs
+++ b/apps/desktop/src-tauri/src/match_sync/error.rs
@@ -1,0 +1,40 @@
+use thiserror::Error;
+
+// Messages never include the refresh token / GC session (secrets — see user-auth.md).
+#[derive(Error, Debug)]
+pub enum MatchSyncError {
+  #[error("Match sync is disabled")]
+  Disabled,
+
+  #[error("Consent has not been accepted")]
+  ConsentRequired,
+
+  // retry_after_secs: until the oldest in-window fetch ages out.
+  #[error("Fetch quota reached ({limit} per 24h); retry in {retry_after_secs}s")]
+  QuotaReached { limit: usize, retry_after_secs: i64 },
+
+  #[error("A sync is already in progress")]
+  AlreadyRunning,
+
+  #[error("Steam session unavailable: {0}")]
+  AuthUnavailable(String),
+
+  #[error("Steam GC unavailable: {0}")]
+  GcUnavailable(String),
+
+  // Steam GC answered but is throttling this account; back off, don't burn quota.
+  #[error("Steam GC rate-limited the request")]
+  GcRateLimited,
+
+  #[error("deadlock-api request failed: {0}")]
+  Api(String),
+
+  #[error("match-sync store error: {0}")]
+  Store(String),
+}
+
+impl From<MatchSyncError> for crate::errors::Error {
+  fn from(err: MatchSyncError) -> Self {
+    crate::errors::Error::MatchSync(err.to_string())
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/error.rs
+++ b/apps/desktop/src-tauri/src/match_sync/error.rs
@@ -26,6 +26,9 @@ pub enum MatchSyncError {
   #[error("Steam GC rate-limited the request")]
   GcRateLimited,
 
+  #[error("Deadlock is currently running; close it to fetch matches")]
+  GameRunning,
+
   #[error("deadlock-api request failed: {0}")]
   Api(String),
 

--- a/apps/desktop/src-tauri/src/match_sync/error.rs
+++ b/apps/desktop/src-tauri/src/match_sync/error.rs
@@ -36,8 +36,30 @@ pub enum MatchSyncError {
   Store(String),
 }
 
+impl MatchSyncError {
+  // A stable, machine-readable tag so the frontend can branch/localize on the
+  // specific case without parsing the English message.
+  pub fn subcode(&self) -> &'static str {
+    match self {
+      MatchSyncError::Disabled => "disabled",
+      MatchSyncError::ConsentRequired => "consentRequired",
+      MatchSyncError::QuotaReached { .. } => "quotaReached",
+      MatchSyncError::AlreadyRunning => "alreadyRunning",
+      MatchSyncError::AuthUnavailable(_) => "authUnavailable",
+      MatchSyncError::GcUnavailable(_) => "gcUnavailable",
+      MatchSyncError::GcRateLimited => "gcRateLimited",
+      MatchSyncError::GameRunning => "gameRunning",
+      MatchSyncError::Api(_) => "apiError",
+      MatchSyncError::Store(_) => "storeError",
+    }
+  }
+}
+
 impl From<MatchSyncError> for crate::errors::Error {
   fn from(err: MatchSyncError) -> Self {
-    crate::errors::Error::MatchSync(err.to_string())
+    crate::errors::Error::MatchSync {
+      subcode: err.subcode(),
+      message: err.to_string(),
+    }
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/game_check.rs
+++ b/apps/desktop/src-tauri/src/match_sync/game_check.rs
@@ -1,0 +1,34 @@
+//! While Deadlock is running, Steam routes GC traffic to the game's own pipe
+//! (user-auth.md); a second process's GC session gets nothing. Every fetch path
+//! must refuse while the game is running, not just detect it opportunistically.
+
+use std::sync::Mutex;
+
+use deadlock_discord_presence::{console_log_path, is_game_running};
+
+pub trait GameRunningCheck: Send + Sync {
+  fn is_game_running(&self) -> bool;
+}
+
+pub struct SysGameRunningCheck {
+  sys: Mutex<sysinfo::System>,
+}
+
+impl SysGameRunningCheck {
+  pub fn new() -> Self {
+    Self {
+      sys: Mutex::new(sysinfo::System::new()),
+    }
+  }
+}
+
+impl GameRunningCheck for SysGameRunningCheck {
+  fn is_game_running(&self) -> bool {
+    let Some(game_path) = crate::game_presence::resolve_game_path() else {
+      return false;
+    };
+    let log_path = console_log_path(&game_path);
+    let mut sys = self.sys.lock().unwrap_or_else(|e| e.into_inner());
+    is_game_running(&mut sys, &log_path)
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/game_check.rs
+++ b/apps/desktop/src-tauri/src/match_sync/game_check.rs
@@ -1,5 +1,5 @@
-//! While Deadlock is running, Steam routes GC traffic to the game's own pipe
-//! (user-auth.md); a second process's GC session gets nothing. Every fetch path
+//! While Deadlock is running, Steam routes GC traffic to the game's own pipe;
+//! a second process's GC session gets nothing. Every fetch path
 //! must refuse while the game is running, not just detect it opportunistically.
 
 use std::sync::Mutex;

--- a/apps/desktop/src-tauri/src/match_sync/gc_client.rs
+++ b/apps/desktop/src-tauri/src/match_sync/gc_client.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 
 use prost::Message as _;
 use steam_vent::proto::MsgKind;
-use steam_vent::{Connection, ConnectionTrait, GameCoordinator, ServerList, UntypedMessage};
+use steam_vent::{
+  Connection, ConnectionTrait, GameCoordinator, RawNetMessage, ServerList, UntypedMessage,
+};
 use tokio::sync::Mutex;
 use valveprotos::deadlock::{
   CMsgClientToGcGetMatchHistory, CMsgClientToGcGetMatchHistoryResponse,
@@ -94,6 +96,39 @@ impl SteamGcClient {
     }
     Ok(())
   }
+
+  // Poisons the session (drops it from `guard`) on any failure or timeout, so the next
+  // call reconnects instead of retrying a broken GC connection.
+  async fn send_job(
+    guard: &mut Option<GcSession>,
+    req_bytes: Vec<u8>,
+    kind: MsgKind,
+    label: &str,
+  ) -> Result<RawNetMessage, MatchSyncError> {
+    let sent = tokio::time::timeout(
+      GC_CALL_TIMEOUT,
+      guard
+        .as_ref()
+        .expect("connected above")
+        .gc
+        .job_untyped(UntypedMessage(req_bytes), kind, true),
+    )
+    .await;
+
+    match sent {
+      Ok(Ok(raw)) => Ok(raw),
+      Ok(Err(e)) => {
+        *guard = None;
+        Err(MatchSyncError::GcUnavailable(format!("{label} request failed: {e}")))
+      }
+      Err(_) => {
+        *guard = None;
+        Err(MatchSyncError::GcUnavailable(format!(
+          "{label} request timed out after {GC_CALL_TIMEOUT:?}"
+        )))
+      }
+    }
+  }
 }
 
 impl GcMatchClient for SteamGcClient {
@@ -111,29 +146,7 @@ impl GcMatchClient for SteamGcClient {
       ..Default::default()
     };
     let kind = MsgKind(EgcCitadelClientMessages::KEMsgClientToGcGetMatchHistory as i32);
-    let sent = tokio::time::timeout(
-      GC_CALL_TIMEOUT,
-      guard
-        .as_ref()
-        .expect("connected above")
-        .gc
-        .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true),
-    )
-    .await;
-
-    let raw = match sent {
-      Ok(Ok(raw)) => raw,
-      Ok(Err(e)) => {
-        *guard = None;
-        return Err(MatchSyncError::GcUnavailable(format!("history request failed: {e}")));
-      }
-      Err(_) => {
-        *guard = None;
-        return Err(MatchSyncError::GcUnavailable(format!(
-          "history request timed out after {GC_CALL_TIMEOUT:?}"
-        )));
-      }
-    };
+    let raw = Self::send_job(&mut guard, req.encode_to_vec(), kind, "history").await?;
 
     let resp = CMsgClientToGcGetMatchHistoryResponse::decode(raw.data.as_ref())
       .map_err(|e| MatchSyncError::GcUnavailable(format!("bad history response: {e}")))?;
@@ -165,29 +178,7 @@ impl GcMatchClient for SteamGcClient {
       ..Default::default()
     };
     let kind = MsgKind(EgcCitadelClientMessages::KEMsgClientToGcGetMatchMetaData as i32);
-    let sent = tokio::time::timeout(
-      GC_CALL_TIMEOUT,
-      guard
-        .as_ref()
-        .expect("connected above")
-        .gc
-        .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true),
-    )
-    .await;
-
-    let raw = match sent {
-      Ok(Ok(raw)) => raw,
-      Ok(Err(e)) => {
-        *guard = None;
-        return Err(MatchSyncError::GcUnavailable(format!("salts request failed: {e}")));
-      }
-      Err(_) => {
-        *guard = None;
-        return Err(MatchSyncError::GcUnavailable(format!(
-          "salts request timed out after {GC_CALL_TIMEOUT:?}"
-        )));
-      }
-    };
+    let raw = Self::send_job(&mut guard, req.encode_to_vec(), kind, "salts").await?;
 
     let resp = CMsgClientToGcGetMatchMetaDataResponse::decode(raw.data.as_ref())
       .map_err(|e| MatchSyncError::GcUnavailable(format!("bad salts response: {e}")))?;

--- a/apps/desktop/src-tauri/src/match_sync/gc_client.rs
+++ b/apps/desktop/src-tauri/src/match_sync/gc_client.rs
@@ -3,6 +3,7 @@
 //! user-auth.md). The subsystem never uses deadlock-api's own server-side endpoints.
 
 use std::future::Future;
+use std::time::Duration;
 
 use prost::Message as _;
 use steam_vent::proto::MsgKind;
@@ -16,6 +17,21 @@ use valveprotos::deadlock::{
 
 use super::error::MatchSyncError;
 use super::model::{AuthContext, DEADLOCK_APP_ID, MatchHistoryPage, MatchSalts};
+
+// A stalled discover/login/job call must not block cancel/disable indefinitely.
+const GC_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+async fn with_timeout<T, E: std::fmt::Display>(
+  label: &str,
+  fut: impl Future<Output = Result<T, E>>,
+) -> Result<T, MatchSyncError> {
+  match tokio::time::timeout(GC_CALL_TIMEOUT, fut).await {
+    Ok(result) => result.map_err(|e| MatchSyncError::GcUnavailable(format!("{label}: {e}"))),
+    Err(_) => Err(MatchSyncError::GcUnavailable(format!(
+      "{label}: timed out after {GC_CALL_TIMEOUT:?}"
+    ))),
+  }
+}
 
 // `impl Future + Send` keeps impls spawnable. No internal retries: a failed salt
 // fetch must cost at most one quota unit (caller rate-limits + quota-gates).
@@ -52,15 +68,13 @@ impl SteamGcClient {
   }
 
   async fn connect(ctx: &AuthContext) -> Result<GcSession, MatchSyncError> {
-    let servers = ServerList::discover()
-      .await
-      .map_err(|e| MatchSyncError::GcUnavailable(format!("server discovery failed: {e}")))?;
-    let conn = Connection::access(&servers, &ctx.account_name, &ctx.refresh_token)
-      .await
-      .map_err(|e| MatchSyncError::GcUnavailable(format!("CM login failed: {e}")))?;
-    let gc = GameCoordinator::new(&conn, DEADLOCK_APP_ID)
-      .await
-      .map_err(|e| MatchSyncError::GcUnavailable(format!("GC handshake failed: {e}")))?;
+    let servers = with_timeout("server discovery", ServerList::discover()).await?;
+    let conn = with_timeout(
+      "CM login",
+      Connection::access(&servers, &ctx.account_name, &ctx.refresh_token),
+    )
+    .await?;
+    let gc = with_timeout("GC handshake", GameCoordinator::new(&conn, DEADLOCK_APP_ID)).await?;
     Ok(GcSession {
       steam_id64: ctx.steam_id64,
       gc,
@@ -96,18 +110,27 @@ impl GcMatchClient for SteamGcClient {
       ..Default::default()
     };
     let kind = MsgKind(EgcCitadelClientMessages::KEMsgClientToGcGetMatchHistory as i32);
-    let sent = guard
-      .as_ref()
-      .expect("connected above")
-      .gc
-      .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true)
-      .await;
+    let sent = tokio::time::timeout(
+      GC_CALL_TIMEOUT,
+      guard
+        .as_ref()
+        .expect("connected above")
+        .gc
+        .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true),
+    )
+    .await;
 
     let raw = match sent {
-      Ok(raw) => raw,
-      Err(e) => {
+      Ok(Ok(raw)) => raw,
+      Ok(Err(e)) => {
         *guard = None;
         return Err(MatchSyncError::GcUnavailable(format!("history request failed: {e}")));
+      }
+      Err(_) => {
+        *guard = None;
+        return Err(MatchSyncError::GcUnavailable(format!(
+          "history request timed out after {GC_CALL_TIMEOUT:?}"
+        )));
       }
     };
 
@@ -141,18 +164,27 @@ impl GcMatchClient for SteamGcClient {
       ..Default::default()
     };
     let kind = MsgKind(EgcCitadelClientMessages::KEMsgClientToGcGetMatchMetaData as i32);
-    let sent = guard
-      .as_ref()
-      .expect("connected above")
-      .gc
-      .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true)
-      .await;
+    let sent = tokio::time::timeout(
+      GC_CALL_TIMEOUT,
+      guard
+        .as_ref()
+        .expect("connected above")
+        .gc
+        .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true),
+    )
+    .await;
 
     let raw = match sent {
-      Ok(raw) => raw,
-      Err(e) => {
+      Ok(Ok(raw)) => raw,
+      Ok(Err(e)) => {
         *guard = None;
         return Err(MatchSyncError::GcUnavailable(format!("salts request failed: {e}")));
+      }
+      Err(_) => {
+        *guard = None;
+        return Err(MatchSyncError::GcUnavailable(format!(
+          "salts request timed out after {GC_CALL_TIMEOUT:?}"
+        )));
       }
     };
 

--- a/apps/desktop/src-tauri/src/match_sync/gc_client.rs
+++ b/apps/desktop/src-tauri/src/match_sync/gc_client.rs
@@ -3,6 +3,7 @@
 //! user-auth.md). The subsystem never uses deadlock-api's own server-side endpoints.
 
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use prost::Message as _;
@@ -208,5 +209,25 @@ impl GcMatchClient for SteamGcClient {
       metadata_salt: resp.metadata_salt,
       replay_salt: resp.replay_salt,
     })
+  }
+}
+
+// Lets the per-account resource registry in `mod.rs` hand out a shared
+// `Arc<SteamGcClient>` while still satisfying `SyncEngine`'s `G: GcMatchClient` bound.
+impl GcMatchClient for Arc<SteamGcClient> {
+  fn fetch_match_history(
+    &self,
+    ctx: &AuthContext,
+    cursor: Option<u64>,
+  ) -> impl Future<Output = Result<MatchHistoryPage, MatchSyncError>> + Send {
+    (**self).fetch_match_history(ctx, cursor)
+  }
+
+  fn fetch_match_salts(
+    &self,
+    ctx: &AuthContext,
+    match_id: u64,
+  ) -> impl Future<Output = Result<MatchSalts, MatchSyncError>> + Send {
+    (**self).fetch_match_salts(ctx, match_id)
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/gc_client.rs
+++ b/apps/desktop/src-tauri/src/match_sync/gc_client.rs
@@ -1,6 +1,6 @@
 //! The Steam Game Coordinator boundary: recover per-match salts and history
-//! client-side through the user's own account (`steam-vent` + `CMsgClientToGc*` per
-//! user-auth.md). The subsystem never uses deadlock-api's own server-side endpoints.
+//! client-side through the user's own account (`steam-vent` + `CMsgClientToGc*`).
+//! The subsystem never uses deadlock-api's own server-side endpoints.
 
 use std::future::Future;
 use std::sync::Arc;

--- a/apps/desktop/src-tauri/src/match_sync/gc_client.rs
+++ b/apps/desktop/src-tauri/src/match_sync/gc_client.rs
@@ -1,0 +1,180 @@
+//! The Steam Game Coordinator boundary: recover per-match salts and history
+//! client-side through the user's own account (`steam-vent` + `CMsgClientToGc*` per
+//! user-auth.md). The subsystem never uses deadlock-api's own server-side endpoints.
+
+use std::future::Future;
+
+use prost::Message as _;
+use steam_vent::proto::MsgKind;
+use steam_vent::{Connection, ConnectionTrait, GameCoordinator, ServerList, UntypedMessage};
+use tokio::sync::Mutex;
+use valveprotos::deadlock::{
+  CMsgClientToGcGetMatchHistory, CMsgClientToGcGetMatchHistoryResponse,
+  CMsgClientToGcGetMatchMetaData, CMsgClientToGcGetMatchMetaDataResponse, EgcCitadelClientMessages,
+  c_msg_client_to_gc_get_match_history_response, c_msg_client_to_gc_get_match_meta_data_response,
+};
+
+use super::error::MatchSyncError;
+use super::model::{AuthContext, DEADLOCK_APP_ID, MatchHistoryPage, MatchSalts};
+
+// `impl Future + Send` keeps impls spawnable. No internal retries: a failed salt
+// fetch must cost at most one quota unit (caller rate-limits + quota-gates).
+pub trait GcMatchClient: Send + Sync {
+  fn fetch_match_history(
+    &self,
+    ctx: &AuthContext,
+    cursor: Option<u64>,
+  ) -> impl Future<Output = Result<MatchHistoryPage, MatchSyncError>> + Send;
+
+  fn fetch_match_salts(
+    &self,
+    ctx: &AuthContext,
+    match_id: u64,
+  ) -> impl Future<Output = Result<MatchSalts, MatchSyncError>> + Send;
+}
+
+struct GcSession {
+  steam_id64: u64,
+  gc: GameCoordinator,
+  // Held only to keep the CM connection alive for the GC session.
+  _conn: Connection,
+}
+
+pub struct SteamGcClient {
+  session: Mutex<Option<GcSession>>,
+}
+
+impl SteamGcClient {
+  pub fn new() -> Self {
+    Self {
+      session: Mutex::new(None),
+    }
+  }
+
+  async fn connect(ctx: &AuthContext) -> Result<GcSession, MatchSyncError> {
+    let servers = ServerList::discover()
+      .await
+      .map_err(|e| MatchSyncError::GcUnavailable(format!("server discovery failed: {e}")))?;
+    let conn = Connection::access(&servers, &ctx.account_name, &ctx.refresh_token)
+      .await
+      .map_err(|e| MatchSyncError::GcUnavailable(format!("CM login failed: {e}")))?;
+    let gc = GameCoordinator::new(&conn, DEADLOCK_APP_ID)
+      .await
+      .map_err(|e| MatchSyncError::GcUnavailable(format!("GC handshake failed: {e}")))?;
+    Ok(GcSession {
+      steam_id64: ctx.steam_id64,
+      gc,
+      _conn: conn,
+    })
+  }
+
+  async fn ensure_connected(
+    &self,
+    guard: &mut Option<GcSession>,
+    ctx: &AuthContext,
+  ) -> Result<(), MatchSyncError> {
+    let stale = guard.as_ref().is_none_or(|s| s.steam_id64 != ctx.steam_id64);
+    if stale {
+      *guard = Some(Self::connect(ctx).await?);
+    }
+    Ok(())
+  }
+}
+
+impl GcMatchClient for SteamGcClient {
+  async fn fetch_match_history(
+    &self,
+    ctx: &AuthContext,
+    cursor: Option<u64>,
+  ) -> Result<MatchHistoryPage, MatchSyncError> {
+    let mut guard = self.session.lock().await;
+    self.ensure_connected(&mut guard, ctx).await?;
+
+    let req = CMsgClientToGcGetMatchHistory {
+      account_id: Some(ctx.account_id()),
+      continue_cursor: cursor,
+      ..Default::default()
+    };
+    let kind = MsgKind(EgcCitadelClientMessages::KEMsgClientToGcGetMatchHistory as i32);
+    let sent = guard
+      .as_ref()
+      .expect("connected above")
+      .gc
+      .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true)
+      .await;
+
+    let raw = match sent {
+      Ok(raw) => raw,
+      Err(e) => {
+        *guard = None;
+        return Err(MatchSyncError::GcUnavailable(format!("history request failed: {e}")));
+      }
+    };
+
+    let resp = CMsgClientToGcGetMatchHistoryResponse::decode(raw.data.as_ref())
+      .map_err(|e| MatchSyncError::GcUnavailable(format!("bad history response: {e}")))?;
+
+    let success = c_msg_client_to_gc_get_match_history_response::EResult::KEResultSuccess as i32;
+    if resp.result.is_some_and(|r| r != success) {
+      return Err(MatchSyncError::GcUnavailable(format!(
+        "history result {:?}",
+        resp.result
+      )));
+    }
+
+    Ok(MatchHistoryPage {
+      match_ids: resp.matches.iter().filter_map(|m| m.match_id).collect(),
+      next_cursor: resp.continue_cursor.filter(|&c| c != 0),
+    })
+  }
+
+  async fn fetch_match_salts(
+    &self,
+    ctx: &AuthContext,
+    match_id: u64,
+  ) -> Result<MatchSalts, MatchSyncError> {
+    let mut guard = self.session.lock().await;
+    self.ensure_connected(&mut guard, ctx).await?;
+
+    let req = CMsgClientToGcGetMatchMetaData {
+      match_id: Some(match_id),
+      ..Default::default()
+    };
+    let kind = MsgKind(EgcCitadelClientMessages::KEMsgClientToGcGetMatchMetaData as i32);
+    let sent = guard
+      .as_ref()
+      .expect("connected above")
+      .gc
+      .job_untyped(UntypedMessage(req.encode_to_vec()), kind, true)
+      .await;
+
+    let raw = match sent {
+      Ok(raw) => raw,
+      Err(e) => {
+        *guard = None;
+        return Err(MatchSyncError::GcUnavailable(format!("salts request failed: {e}")));
+      }
+    };
+
+    let resp = CMsgClientToGcGetMatchMetaDataResponse::decode(raw.data.as_ref())
+      .map_err(|e| MatchSyncError::GcUnavailable(format!("bad salts response: {e}")))?;
+
+    use c_msg_client_to_gc_get_match_meta_data_response::EResult;
+    match resp.result {
+      Some(r) if r == EResult::KEResultRateLimited as i32 => {
+        return Err(MatchSyncError::GcRateLimited);
+      }
+      Some(r) if r != EResult::KEResultSuccess as i32 => {
+        return Err(MatchSyncError::GcUnavailable(format!("salts result {r}")));
+      }
+      _ => {}
+    }
+
+    Ok(MatchSalts {
+      match_id,
+      cluster_id: resp.replay_group_id,
+      metadata_salt: resp.metadata_salt,
+      replay_salt: resp.replay_salt,
+    })
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/mod.rs
+++ b/apps/desktop/src-tauri/src/match_sync/mod.rs
@@ -1,0 +1,287 @@
+mod api_client;
+mod auth;
+mod error;
+mod gc_client;
+mod model;
+mod quota;
+pub mod settings;
+mod sync;
+mod throttle;
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::Emitter;
+use tokio::sync::Mutex;
+
+use crate::app_runtime::AppHandle;
+
+use api_client::ApiClient;
+use auth::LocalSteamAuth;
+use gc_client::SteamGcClient;
+use model::{FETCH_QUOTA_LIMIT, SyncProgress};
+use sync::{SyncEngine, SyncPersistence};
+use throttle::Throttle;
+
+pub use error::MatchSyncError;
+
+// One GC request every 2 minutes: GetMatchMetaData is rate-limited per-account by
+// Steam's GC, and a fast throttle (the old 2s value) reliably tripped that limit.
+const GC_MIN_INTERVAL: Duration = Duration::from_secs(2 * 60);
+// How often the background worker does a pass while the feature is enabled.
+const BACKGROUND_PASS_INTERVAL_SECS: u64 = 15 * 60;
+const PROGRESS_EVENT: &str = "match-sync-progress";
+const ERROR_EVENT: &str = "match-sync-error";
+
+#[derive(Clone, Serialize)]
+struct MatchSyncErrorPayload {
+  message: String,
+}
+
+fn emit_error(app: &AppHandle, err: &MatchSyncError) {
+  let _ = app.emit(
+    ERROR_EVENT,
+    MatchSyncErrorPayload {
+      message: err.to_string(),
+    },
+  );
+}
+
+// One serializer for every run so concurrent syncs can't race the persisted quota
+// (a lost update there would let the hard cap be exceeded).
+static SYNC_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static FULL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
+static FULL_SYNC_CANCEL: AtomicBool = AtomicBool::new(false);
+static BACKGROUND_RUNNING: AtomicBool = AtomicBool::new(false);
+static GC_REQUEST_COUNTER: LazyLock<Arc<AtomicU64>> =
+  LazyLock::new(|| Arc::new(AtomicU64::new(0)));
+static THROTTLE: LazyLock<Arc<Throttle>> =
+  LazyLock::new(|| Arc::new(Throttle::new(GC_MIN_INTERVAL)));
+
+struct AppPersistence {
+  app: AppHandle,
+}
+
+impl SyncPersistence for AppPersistence {
+  fn now(&self) -> i64 {
+    settings::now_secs()
+  }
+  fn load_quota(&self) -> quota::QuotaWindow {
+    settings::load_quota(&self.app).unwrap_or_else(|e| {
+      log::error!("match-sync: failed to load quota: {e}");
+      quota::QuotaWindow::new(Vec::new(), FETCH_QUOTA_LIMIT, model::FETCH_QUOTA_WINDOW_SECS)
+    })
+  }
+  fn save_quota(&self, quota: &quota::QuotaWindow) {
+    if let Err(e) = settings::save_quota(&self.app, quota) {
+      log::error!("match-sync: failed to persist quota: {e}");
+    }
+  }
+  fn load_fetched(&self) -> Vec<u64> {
+    settings::load_fetched_ids(&self.app).unwrap_or_default()
+  }
+  fn persist_fetched(&self, ids: &[u64]) {
+    if let Err(e) = settings::save_fetched_ids(&self.app, ids) {
+      log::error!("match-sync: failed to persist fetched ids: {e}");
+    }
+  }
+  fn set_full_sync_complete(&self, complete: bool) {
+    if let Err(e) = settings::set_full_sync_complete(&self.app, complete) {
+      log::error!("match-sync: failed to persist full-sync completion: {e}");
+    }
+  }
+  fn emit_progress(&self, progress: &SyncProgress) {
+    let _ = self.app.emit(PROGRESS_EVENT, progress);
+  }
+}
+
+type ProdEngine = SyncEngine<LocalSteamAuth, SteamGcClient, ApiClient, ApiClient, AppPersistence>;
+
+fn build_engine(app: AppHandle) -> ProdEngine {
+  SyncEngine::new(
+    LocalSteamAuth,
+    SteamGcClient::new(),
+    ApiClient::default(),
+    ApiClient::default(),
+    AppPersistence { app },
+    Arc::clone(&THROTTLE),
+    Arc::clone(&GC_REQUEST_COUNTER),
+  )
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchSyncStatusDto {
+  pub enabled: bool,
+  pub consent_accepted: bool,
+  pub full_sync_running: bool,
+  pub full_sync_complete: bool,
+  pub quota_limit: u32,
+  pub quota_remaining: u32,
+  pub quota_reset_at: Option<i64>,
+  pub session_fetches: u64,
+}
+
+pub fn status(app: &AppHandle) -> Result<MatchSyncStatusDto, MatchSyncError> {
+  let config = settings::load_config(app)?;
+  let quota = settings::load_quota(app)?;
+  let now = settings::now_secs();
+  Ok(MatchSyncStatusDto {
+    enabled: config.enabled,
+    consent_accepted: config.consent_accepted,
+    full_sync_running: FULL_SYNC_RUNNING.load(Ordering::Relaxed),
+    full_sync_complete: config.full_sync_complete,
+    quota_limit: FETCH_QUOTA_LIMIT as u32,
+    quota_remaining: quota.remaining(now) as u32,
+    quota_reset_at: quota.reset_at(now),
+    session_fetches: GC_REQUEST_COUNTER.load(Ordering::Relaxed),
+  })
+}
+
+pub fn set_consent(app: &AppHandle, accepted: bool) -> Result<(), MatchSyncError> {
+  settings::set_consent(app, accepted)
+}
+
+pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), MatchSyncError> {
+  if enabled {
+    if !settings::load_config(app)?.consent_accepted {
+      return Err(MatchSyncError::ConsentRequired);
+    }
+  } else {
+    cancel_full_sync();
+  }
+  settings::set_enabled(app, enabled)?;
+  if enabled {
+    start_background_worker(app.clone());
+  }
+  Ok(())
+}
+
+pub fn cancel_full_sync() {
+  FULL_SYNC_CANCEL.store(true, Ordering::Relaxed);
+}
+
+pub fn spawn_full_sync(app: AppHandle) -> Result<(), MatchSyncError> {
+  let config = settings::load_config(&app)?;
+  if !config.consent_accepted {
+    return Err(MatchSyncError::ConsentRequired);
+  }
+  if !config.enabled {
+    return Err(MatchSyncError::Disabled);
+  }
+  if FULL_SYNC_RUNNING
+    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+    .is_err()
+  {
+    return Err(MatchSyncError::AlreadyRunning);
+  }
+  FULL_SYNC_CANCEL.store(false, Ordering::Relaxed);
+
+  tokio::spawn(async move {
+    let _guard = SYNC_LOCK.lock().await;
+    let engine = build_engine(app.clone());
+    match engine
+      .run_full_sync_if_enabled(&config, &FULL_SYNC_CANCEL)
+      .await
+    {
+      Ok(p) => log::info!("match-sync: full sync finished: {p:?}"),
+      Err(e) => {
+        log::warn!("match-sync: full sync failed: {e}");
+        emit_error(&app, &e);
+      }
+    }
+    FULL_SYNC_RUNNING.store(false, Ordering::Relaxed);
+  });
+  Ok(())
+}
+
+// Called by the game-presence watcher on the "game closed" transition. Fires one
+// immediate background pass; a no-op unless the user has opted in.
+pub fn on_game_exit(app: AppHandle) {
+  tokio::spawn(async move {
+    background_pass(&app).await;
+  });
+}
+
+pub fn should_monitor(app: &AppHandle) -> bool {
+  settings::load_config(app)
+    .map(|c| c.is_active())
+    .unwrap_or(false)
+}
+
+// A single background pass under the shared lock (single-flight with full sync and
+// with other passes). Skips entirely when the 24h quota is already spent.
+async fn background_pass(app: &AppHandle) {
+  let config = match settings::load_config(app) {
+    Ok(c) if c.is_active() => c,
+    _ => return,
+  };
+  if settings::load_quota(app)
+    .map(|q| q.remaining(settings::now_secs()) == 0)
+    .unwrap_or(true)
+  {
+    return;
+  }
+  let Ok(guard) = SYNC_LOCK.try_lock() else {
+    return;
+  };
+  let engine = build_engine(app.clone());
+  match engine.run_background_pass(&config).await {
+    Ok(Some(p)) => log::info!("match-sync: background pass finished: {p:?}"),
+    Ok(None) => {}
+    Err(e) => log::warn!("match-sync: background pass failed: {e}"),
+  }
+  drop(guard);
+}
+
+// While the feature is enabled, keep doing background passes on an interval (up to
+// the 24h quota). Single instance; stops promptly when the feature is disabled.
+pub fn start_background_worker(app: AppHandle) {
+  if !should_monitor(&app) {
+    return;
+  }
+  if BACKGROUND_RUNNING
+    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+    .is_err()
+  {
+    return;
+  }
+  tokio::spawn(async move {
+    while should_monitor(&app) {
+      background_pass(&app).await;
+      let mut slept = 0;
+      while slept < BACKGROUND_PASS_INTERVAL_SECS && should_monitor(&app) {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        slept += 5;
+      }
+    }
+    BACKGROUND_RUNNING.store(false, Ordering::Relaxed);
+  });
+}
+
+#[cfg(test)]
+mod config_tests {
+  use super::model::MatchSyncConfig;
+
+  #[test]
+  fn default_config_is_inactive() {
+    let c = MatchSyncConfig::default();
+    assert!(!c.enabled);
+    assert!(!c.consent_accepted);
+    assert!(!c.is_active());
+  }
+
+  #[test]
+  fn active_requires_both_enabled_and_consent() {
+    let mut c = MatchSyncConfig {
+      enabled: true,
+      consent_accepted: false,
+      ..MatchSyncConfig::default()
+    };
+    assert!(!c.is_active());
+    c.consent_accepted = true;
+    assert!(c.is_active());
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/mod.rs
+++ b/apps/desktop/src-tauri/src/match_sync/mod.rs
@@ -56,6 +56,7 @@ static SYNC_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 static FULL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static FULL_SYNC_CANCEL: AtomicBool = AtomicBool::new(false);
 static BACKGROUND_RUNNING: AtomicBool = AtomicBool::new(false);
+static BACKGROUND_CANCEL: AtomicBool = AtomicBool::new(false);
 static GC_REQUEST_COUNTER: LazyLock<Arc<AtomicU64>> =
   LazyLock::new(|| Arc::new(AtomicU64::new(0)));
 static THROTTLE: LazyLock<Arc<Throttle>> =
@@ -69,16 +70,11 @@ impl SyncPersistence for AppPersistence {
   fn now(&self) -> i64 {
     settings::now_secs()
   }
-  fn load_quota(&self) -> quota::QuotaWindow {
-    settings::load_quota(&self.app).unwrap_or_else(|e| {
-      log::error!("match-sync: failed to load quota: {e}");
-      quota::QuotaWindow::new(Vec::new(), FETCH_QUOTA_LIMIT, model::FETCH_QUOTA_WINDOW_SECS)
-    })
+  fn load_quota(&self) -> Result<quota::QuotaWindow, MatchSyncError> {
+    settings::load_quota(&self.app)
   }
-  fn save_quota(&self, quota: &quota::QuotaWindow) {
-    if let Err(e) = settings::save_quota(&self.app, quota) {
-      log::error!("match-sync: failed to persist quota: {e}");
-    }
+  fn save_quota(&self, quota: &quota::QuotaWindow) -> Result<(), MatchSyncError> {
+    settings::save_quota(&self.app, quota)
   }
   fn load_fetched(&self) -> Vec<u64> {
     settings::load_fetched_ids(&self.app).unwrap_or_default()
@@ -150,6 +146,9 @@ pub fn status(app: &AppHandle) -> Result<MatchSyncStatusDto, MatchSyncError> {
 }
 
 pub fn set_consent(app: &AppHandle, accepted: bool) -> Result<(), MatchSyncError> {
+  if !accepted {
+    cancel_background_work();
+  }
   settings::set_consent(app, accepted)
 }
 
@@ -159,13 +158,20 @@ pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), MatchSyncError>
       return Err(MatchSyncError::ConsentRequired);
     }
   } else {
-    cancel_full_sync();
+    cancel_background_work();
   }
   settings::set_enabled(app, enabled)?;
   if enabled {
     start_background_worker(app.clone());
   }
   Ok(())
+}
+
+// Stops both the one-time full sync and any in-flight background pass immediately,
+// so opt-out takes effect right away rather than after the current pass finishes.
+fn cancel_background_work() {
+  FULL_SYNC_CANCEL.store(true, Ordering::Relaxed);
+  BACKGROUND_CANCEL.store(true, Ordering::Relaxed);
 }
 
 pub fn cancel_full_sync() {
@@ -235,7 +241,7 @@ async fn background_pass(app: &AppHandle) {
     return;
   };
   let engine = build_engine(app.clone());
-  match engine.run_background_pass(&config).await {
+  match engine.run_background_pass(&config, &BACKGROUND_CANCEL).await {
     Ok(Some(p)) => log::info!("match-sync: background pass finished: {p:?}"),
     Ok(None) => {}
     Err(e) => log::warn!("match-sync: background pass failed: {e}"),
@@ -253,6 +259,7 @@ pub fn start_background_worker(app: AppHandle) {
   {
     return;
   }
+  BACKGROUND_CANCEL.store(false, Ordering::Relaxed);
   tokio::spawn(async move {
     while should_monitor(&app) {
       background_pass(&app).await;
@@ -263,6 +270,11 @@ pub fn start_background_worker(app: AppHandle) {
       }
     }
     BACKGROUND_RUNNING.store(false, Ordering::Relaxed);
+    // A quick disable/re-enable while this task was still shutting down could have
+    // seen BACKGROUND_RUNNING as true and returned early; make sure that isn't lost.
+    if should_monitor(&app) {
+      start_background_worker(app);
+    }
   });
 }
 

--- a/apps/desktop/src-tauri/src/match_sync/mod.rs
+++ b/apps/desktop/src-tauri/src/match_sync/mod.rs
@@ -285,7 +285,6 @@ pub fn status(app: &AppHandle) -> Result<MatchSyncStatusDto, MatchSyncError> {
         quota_remaining: quota.remaining(now) as u32,
         quota_reset_at: quota.reset_at(now),
         full_sync_complete: settings::load_full_sync_complete(app, steam_id64),
-        available: true,
         gc_unavailable: gc_backoff_active(
           settings::load_gc_backoff_until(app, steam_id64),
           now,
@@ -376,21 +375,26 @@ pub fn spawn_full_sync(app: AppHandle) -> Result<(), MatchSyncError> {
   Ok(())
 }
 
-// Sequentially full-syncs every currently-decryptable account, each with its own quota
-// bucket and throttle. Cancellation is checked between accounts (a quota-exhausted run
-// and a cancelled run both return Ok, so the flag is the only reliable signal here).
-async fn run_full_sync_batch(app: &AppHandle, config: &model::MatchSyncConfig) {
-  let contexts = match auth::recover_all() {
-    Ok(c) => c,
-    Err(e) => {
-      log::warn!("match-sync: full sync failed: {e}");
-      emit_error(app, &e);
-      return;
-    }
-  };
+// Shared per-account loop for both the one-time full sync and the recurring background
+// pass: check cancel, skip accounts under GC backoff (and any pass-specific skip),
+// build an engine, run it, log/report the result, then update GC backoff. Cancellation
+// is checked between accounts (a quota-exhausted run and a cancelled run both return
+// Ok, so the flag is the only reliable signal here).
+async fn run_account_batch<F, Fut>(
+  app: &AppHandle,
+  contexts: &[AuthContext],
+  cancel: &AtomicBool,
+  label: &str,
+  notify_on_error: bool,
+  skip_if: impl Fn(&AppHandle, &AuthContext, i64) -> bool,
+  mut run_engine: F,
+) where
+  F: FnMut(ProdEngine) -> Fut,
+  Fut: std::future::Future<Output = Result<Option<SyncProgress>, MatchSyncError>>,
+{
   let total = contexts.len() as u32;
   for (i, ctx) in contexts.iter().enumerate() {
-    if FULL_SYNC_CANCEL.load(Ordering::Relaxed) {
+    if cancel.load(Ordering::Relaxed) {
       break;
     }
     let now = settings::now_secs();
@@ -403,16 +407,20 @@ async fn run_full_sync_batch(app: &AppHandle, config: &model::MatchSyncConfig) {
       );
       continue;
     }
+    if skip_if(app, ctx, now) {
+      continue;
+    }
     let gc_error_seen = Arc::new(AtomicBool::new(false));
     let engine = build_engine(app.clone(), ctx, i as u32 + 1, total, Arc::clone(&gc_error_seen));
-    let result = engine
-      .run_full_sync_if_enabled(config, &FULL_SYNC_CANCEL)
-      .await;
+    let result = run_engine(engine).await;
     match &result {
-      Ok(p) => log::info!("match-sync: full sync finished for {}: {p:?}", ctx.account_name),
+      Ok(Some(p)) => log::info!("match-sync: {label} finished for {}: {p:?}", ctx.account_name),
+      Ok(None) => {}
       Err(e) => {
-        log::warn!("match-sync: full sync failed for {}: {e}", ctx.account_name);
-        emit_error(app, e);
+        log::warn!("match-sync: {label} failed for {}: {e}", ctx.account_name);
+        if notify_on_error {
+          emit_error(app, e);
+        }
       }
     }
     apply_gc_backoff(app, ctx, backoff, gc_error_seen.load(Ordering::Relaxed), now);
@@ -420,6 +428,34 @@ async fn run_full_sync_batch(app: &AppHandle, config: &model::MatchSyncConfig) {
       break;
     }
   }
+}
+
+// Sequentially full-syncs every currently-decryptable account, each with its own quota
+// bucket and throttle.
+async fn run_full_sync_batch(app: &AppHandle, config: &model::MatchSyncConfig) {
+  let contexts = match auth::recover_all() {
+    Ok(c) => c,
+    Err(e) => {
+      log::warn!("match-sync: full sync failed: {e}");
+      emit_error(app, &e);
+      return;
+    }
+  };
+  run_account_batch(
+    app,
+    &contexts,
+    &FULL_SYNC_CANCEL,
+    "full sync",
+    true,
+    |_, _, _| false,
+    |engine| async move {
+      engine
+        .run_full_sync_if_enabled(config, &FULL_SYNC_CANCEL)
+        .await
+        .map(Some)
+    },
+  )
+  .await;
 }
 
 // Called by the game-presence watcher on the "game closed" transition.
@@ -453,42 +489,23 @@ async fn background_pass(app: &AppHandle) {
       return;
     }
   };
-  let total = contexts.len() as u32;
-  for (i, ctx) in contexts.iter().enumerate() {
-    if BACKGROUND_CANCEL.load(Ordering::Relaxed) {
-      break;
-    }
-    let now = settings::now_secs();
-    let backoff = settings::load_gc_backoff_until(app, ctx.steam_id64);
-    if gc_backoff_active(backoff, now) {
-      log::info!(
-        "match-sync: skipping {}, GC unavailable until {:?}",
-        ctx.account_name,
-        backoff
-      );
-      continue;
-    }
-    let spent = settings::load_quota(app, ctx.steam_id64)
-      .map(|q| q.remaining(now) == 0)
-      .unwrap_or(true);
-    if spent {
-      continue;
-    }
-    let gc_error_seen = Arc::new(AtomicBool::new(false));
-    let engine = build_engine(app.clone(), ctx, i as u32 + 1, total, Arc::clone(&gc_error_seen));
-    let result = engine.run_background_pass(&config, &BACKGROUND_CANCEL).await;
-    match &result {
-      Ok(Some(p)) => {
-        log::info!("match-sync: background pass finished for {}: {p:?}", ctx.account_name)
-      }
-      Ok(None) => {}
-      Err(e) => log::warn!("match-sync: background pass failed for {}: {e}", ctx.account_name),
-    }
-    apply_gc_backoff(app, ctx, backoff, gc_error_seen.load(Ordering::Relaxed), now);
-    if let BatchControl::Abort = batch_control(&result) {
-      break;
-    }
-  }
+  run_account_batch(
+    app,
+    &contexts,
+    &BACKGROUND_CANCEL,
+    "background pass",
+    false,
+    |app, ctx, now| {
+      settings::load_quota(app, ctx.steam_id64)
+        .map(|q| q.remaining(now) == 0)
+        .unwrap_or(true)
+    },
+    |engine| {
+      let config = &config;
+      async move { engine.run_background_pass(config, &BACKGROUND_CANCEL).await }
+    },
+  )
+  .await;
 }
 
 pub fn start_background_worker(app: AppHandle) {

--- a/apps/desktop/src-tauri/src/match_sync/mod.rs
+++ b/apps/desktop/src-tauri/src/match_sync/mod.rs
@@ -9,6 +9,7 @@ pub mod settings;
 mod sync;
 mod throttle;
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
@@ -20,10 +21,10 @@ use tokio::sync::Mutex;
 use crate::app_runtime::AppHandle;
 
 use api_client::ApiClient;
-use auth::LocalSteamAuth;
+use auth::FixedAccountAuth;
 use game_check::SysGameRunningCheck;
 use gc_client::SteamGcClient;
-use model::{FETCH_QUOTA_LIMIT, SyncProgress};
+use model::{AccountStatus, AuthContext, FETCH_QUOTA_LIMIT, FETCH_QUOTA_WINDOW_SECS, SyncProgress};
 use sync::{SyncEngine, SyncPersistence};
 use throttle::Throttle;
 
@@ -50,20 +51,63 @@ fn emit_error(app: &AppHandle, err: &MatchSyncError) {
   );
 }
 
-// One serializer for every run so concurrent syncs can't race the persisted quota
-// (a lost update there would let the hard cap be exceeded).
+// One serializer for every run so concurrent syncs can't race a per-account persisted
+// quota (a lost update there would let the hard cap be exceeded).
 static SYNC_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 static FULL_SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 static FULL_SYNC_CANCEL: AtomicBool = AtomicBool::new(false);
 static BACKGROUND_RUNNING: AtomicBool = AtomicBool::new(false);
 static BACKGROUND_CANCEL: AtomicBool = AtomicBool::new(false);
+// Aggregate across all accounts: session_fetches is a simple per-session total.
 static GC_REQUEST_COUNTER: LazyLock<Arc<AtomicU64>> =
   LazyLock::new(|| Arc::new(AtomicU64::new(0)));
-static THROTTLE: LazyLock<Arc<Throttle>> =
-  LazyLock::new(|| Arc::new(Throttle::new(GC_MIN_INTERVAL)));
+
+// Each account gets its own independent throttle (2-min GC spacing) and its own GC
+// session, keyed by steam_id64. Never hold this lock across an `.await`.
+struct AccountResources {
+  throttle: Arc<Throttle>,
+  gc_client: Arc<SteamGcClient>,
+}
+
+static ACCOUNT_RESOURCES: LazyLock<std::sync::Mutex<HashMap<u64, Arc<AccountResources>>>> =
+  LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+fn resources_for(steam_id64: u64) -> Arc<AccountResources> {
+  let mut map = ACCOUNT_RESOURCES.lock().unwrap();
+  Arc::clone(map.entry(steam_id64).or_insert_with(|| {
+    Arc::new(AccountResources {
+      throttle: Arc::new(Throttle::new(GC_MIN_INTERVAL)),
+      gc_client: Arc::new(SteamGcClient::new()),
+    })
+  }))
+}
+
+fn prune_resources(current_ids: &[u64]) {
+  let mut map = ACCOUNT_RESOURCES.lock().unwrap();
+  map.retain(|id, _| current_ids.contains(id));
+}
 
 struct AppPersistence {
   app: AppHandle,
+  steam_id64: u64,
+  account_name: String,
+  account_index: u32,
+  account_total: u32,
+  // Set when the engine swallows a GC failure for this account (see
+  // `SyncPersistence::record_gc_error`). The run still returns Ok, so this shared flag
+  // is the orchestrator's only view into "this account's GC connection is broken".
+  gc_error_seen: Arc<AtomicBool>,
+}
+
+// Wraps the engine's per-account `SyncProgress` with which account (of how many) it
+// belongs to, so the UI can show "account X of N" during a long sequential batch.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MatchSyncProgressEvent<'a> {
+  account_name: &'a str,
+  account_index: u32,
+  account_total: u32,
+  progress: &'a SyncProgress,
 }
 
 impl SyncPersistence for AppPersistence {
@@ -71,49 +115,141 @@ impl SyncPersistence for AppPersistence {
     settings::now_secs()
   }
   fn load_quota(&self) -> Result<quota::QuotaWindow, MatchSyncError> {
-    settings::load_quota(&self.app)
+    settings::load_quota(&self.app, self.steam_id64)
   }
   fn save_quota(&self, quota: &quota::QuotaWindow) -> Result<(), MatchSyncError> {
-    settings::save_quota(&self.app, quota)
+    settings::save_quota(&self.app, self.steam_id64, quota)
   }
   fn load_fetched(&self) -> Vec<u64> {
-    settings::load_fetched_ids(&self.app).unwrap_or_default()
+    settings::load_fetched_ids(&self.app, self.steam_id64).unwrap_or_default()
   }
   fn persist_fetched(&self, ids: &[u64]) {
-    if let Err(e) = settings::save_fetched_ids(&self.app, ids) {
+    if let Err(e) = settings::save_fetched_ids(&self.app, self.steam_id64, ids) {
       log::error!("match-sync: failed to persist fetched ids: {e}");
     }
   }
   fn set_full_sync_complete(&self, complete: bool) {
-    if let Err(e) = settings::set_full_sync_complete(&self.app, complete) {
+    if let Err(e) = settings::set_full_sync_complete(&self.app, self.steam_id64, complete) {
       log::error!("match-sync: failed to persist full-sync completion: {e}");
     }
   }
   fn emit_progress(&self, progress: &SyncProgress) {
-    let _ = self.app.emit(PROGRESS_EVENT, progress);
+    let _ = self.app.emit(
+      PROGRESS_EVENT,
+      MatchSyncProgressEvent {
+        account_name: &self.account_name,
+        account_index: self.account_index,
+        account_total: self.account_total,
+        progress,
+      },
+    );
+  }
+  fn record_gc_error(&self, err: &MatchSyncError) {
+    // Only a broken GC connection warrants a backoff; the hook is only ever called from
+    // GC swallow points, but match defensively so a future caller can't misfire it.
+    if matches!(err, MatchSyncError::GcUnavailable(_)) {
+      self.gc_error_seen.store(true, Ordering::Relaxed);
+    }
   }
 }
 
 type ProdEngine = SyncEngine<
-  LocalSteamAuth,
-  SteamGcClient,
+  FixedAccountAuth,
+  Arc<SteamGcClient>,
   ApiClient,
   ApiClient,
   AppPersistence,
   SysGameRunningCheck,
 >;
 
-fn build_engine(app: AppHandle) -> ProdEngine {
+fn build_engine(
+  app: AppHandle,
+  ctx: &AuthContext,
+  account_index: u32,
+  account_total: u32,
+  gc_error_seen: Arc<AtomicBool>,
+) -> ProdEngine {
+  let resources = resources_for(ctx.steam_id64);
   SyncEngine::new(
-    LocalSteamAuth,
-    SteamGcClient::new(),
+    FixedAccountAuth(ctx.clone()),
+    Arc::clone(&resources.gc_client),
     ApiClient::default(),
     ApiClient::default(),
-    AppPersistence { app },
+    AppPersistence {
+      app,
+      steam_id64: ctx.steam_id64,
+      account_name: ctx.account_name.clone(),
+      account_index,
+      account_total,
+      gc_error_seen,
+    },
     SysGameRunningCheck::new(),
-    Arc::clone(&THROTTLE),
+    Arc::clone(&resources.throttle),
     Arc::clone(&GC_REQUEST_COUNTER),
   )
+}
+
+// The batch-level decision for one account's engine result: `GameRunning` is a
+// machine-wide wall (every remaining account would hit it immediately), so it aborts
+// the whole batch; every other outcome — Ok (finished / quota-reached / rate-limited)
+// or a per-account Err — is local, so the batch moves on to the next account.
+enum BatchControl {
+  Continue,
+  Abort,
+}
+
+fn batch_control<T>(result: &Result<T, MatchSyncError>) -> BatchControl {
+  match result {
+    Err(MatchSyncError::GameRunning) => BatchControl::Abort,
+    _ => BatchControl::Continue,
+  }
+}
+
+// An account whose GC handshake is known-broken (e.g. it doesn't own the game) fails
+// identically every pass; back it off for a day so the loops skip it instead of
+// re-paying the connect/timeout cost each tick.
+const GC_BACKOFF_SECS: i64 = 24 * 60 * 60;
+
+fn gc_backoff_active(backoff_until: Option<i64>, now: i64) -> bool {
+  backoff_until.is_some_and(|until| now < until)
+}
+
+// The backoff a run's GC-error flag implies: `Some(deadline)` when the account saw a
+// swallowed GC failure this run, `None` to clear (a once-broken account that starts
+// working again must not stay skipped). GC failures never reach the run's outer
+// `Result` (the engine swallows them best-effort), so this is driven by the shared flag
+// the engine sets via `record_gc_error`, not by inspecting the returned result.
+fn gc_backoff_from_flag(gc_error_seen: bool, now: i64) -> Option<i64> {
+  gc_error_seen.then_some(now + GC_BACKOFF_SECS)
+}
+
+fn apply_gc_backoff(
+  app: &AppHandle,
+  ctx: &AuthContext,
+  prev: Option<i64>,
+  gc_error_seen: bool,
+  now: i64,
+) {
+  match gc_backoff_from_flag(gc_error_seen, now) {
+    Some(until) => {
+      if let Err(e) = settings::set_gc_backoff_until(app, ctx.steam_id64, Some(until)) {
+        log::warn!(
+          "match-sync: failed to persist GC backoff for {}: {e}",
+          ctx.account_name
+        );
+      }
+    }
+    None => {
+      if prev.is_some()
+        && let Err(e) = settings::set_gc_backoff_until(app, ctx.steam_id64, None)
+      {
+        log::warn!(
+          "match-sync: failed to clear GC backoff for {}: {e}",
+          ctx.account_name
+        );
+      }
+    }
+  }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -122,26 +258,48 @@ pub struct MatchSyncStatusDto {
   pub enabled: bool,
   pub consent_accepted: bool,
   pub full_sync_running: bool,
-  pub full_sync_complete: bool,
-  pub quota_limit: u32,
-  pub quota_remaining: u32,
-  pub quota_reset_at: Option<i64>,
   pub session_fetches: u64,
+  pub accounts: Vec<AccountStatus>,
 }
 
 pub fn status(app: &AppHandle) -> Result<MatchSyncStatusDto, MatchSyncError> {
   let config = settings::load_config(app)?;
-  let quota = settings::load_quota(app)?;
   let now = settings::now_secs();
+  // Cheap, no-decrypt discovery: an unreachable Steam/vdf is a valid empty state, not
+  // a reason to fail the ~2s frontend poll.
+  let available = auth::list_available_accounts().unwrap_or_default();
+  let ids: Vec<u64> = available.iter().map(|(id, _)| *id).collect();
+  prune_resources(&ids);
+
+  let accounts = available
+    .into_iter()
+    .map(|(steam_id64, account_name)| {
+      let quota = settings::load_quota(app, steam_id64).unwrap_or_else(|e| {
+        log::warn!("match-sync: quota load failed for {steam_id64}: {e}");
+        quota::QuotaWindow::new(Vec::new(), FETCH_QUOTA_LIMIT, FETCH_QUOTA_WINDOW_SECS)
+      });
+      AccountStatus {
+        steam_id64,
+        account_name,
+        quota_limit: FETCH_QUOTA_LIMIT as u32,
+        quota_remaining: quota.remaining(now) as u32,
+        quota_reset_at: quota.reset_at(now),
+        full_sync_complete: settings::load_full_sync_complete(app, steam_id64),
+        available: true,
+        gc_unavailable: gc_backoff_active(
+          settings::load_gc_backoff_until(app, steam_id64),
+          now,
+        ),
+      }
+    })
+    .collect();
+
   Ok(MatchSyncStatusDto {
     enabled: config.enabled,
     consent_accepted: config.consent_accepted,
     full_sync_running: FULL_SYNC_RUNNING.load(Ordering::Relaxed),
-    full_sync_complete: config.full_sync_complete,
-    quota_limit: FETCH_QUOTA_LIMIT as u32,
-    quota_remaining: quota.remaining(now) as u32,
-    quota_reset_at: quota.reset_at(now),
     session_fetches: GC_REQUEST_COUNTER.load(Ordering::Relaxed),
+    accounts,
   })
 }
 
@@ -165,6 +323,22 @@ pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), MatchSyncError>
     start_background_worker(app.clone());
   }
   Ok(())
+}
+
+// Drops persisted per-account state (quota/fetched/completion) and in-memory resources
+// for accounts no longer remembered in loginusers.vdf AT ALL. Startup-only: temporarily
+// non-decryptable accounts stay remembered, so they are never pruned here.
+pub fn prune_forgotten_accounts(app: &AppHandle) {
+  match auth::all_remembered_accounts() {
+    Ok(accounts) => {
+      let ids: Vec<u64> = accounts.iter().map(|(id, _)| *id).collect();
+      prune_resources(&ids);
+      if let Err(e) = settings::prune_forgotten_accounts(app, &ids) {
+        log::warn!("match-sync: failed to prune forgotten accounts: {e}");
+      }
+    }
+    Err(e) => log::warn!("match-sync: could not list remembered accounts for pruning: {e}"),
+  }
 }
 
 // Stops both the one-time full sync and any in-flight background pass immediately,
@@ -196,20 +370,56 @@ pub fn spawn_full_sync(app: AppHandle) -> Result<(), MatchSyncError> {
 
   tokio::spawn(async move {
     let _guard = SYNC_LOCK.lock().await;
-    let engine = build_engine(app.clone());
-    match engine
-      .run_full_sync_if_enabled(&config, &FULL_SYNC_CANCEL)
-      .await
-    {
-      Ok(p) => log::info!("match-sync: full sync finished: {p:?}"),
-      Err(e) => {
-        log::warn!("match-sync: full sync failed: {e}");
-        emit_error(&app, &e);
-      }
-    }
+    run_full_sync_batch(&app, &config).await;
     FULL_SYNC_RUNNING.store(false, Ordering::Relaxed);
   });
   Ok(())
+}
+
+// Sequentially full-syncs every currently-decryptable account, each with its own quota
+// bucket and throttle. Cancellation is checked between accounts (a quota-exhausted run
+// and a cancelled run both return Ok, so the flag is the only reliable signal here).
+async fn run_full_sync_batch(app: &AppHandle, config: &model::MatchSyncConfig) {
+  let contexts = match auth::recover_all() {
+    Ok(c) => c,
+    Err(e) => {
+      log::warn!("match-sync: full sync failed: {e}");
+      emit_error(app, &e);
+      return;
+    }
+  };
+  let total = contexts.len() as u32;
+  for (i, ctx) in contexts.iter().enumerate() {
+    if FULL_SYNC_CANCEL.load(Ordering::Relaxed) {
+      break;
+    }
+    let now = settings::now_secs();
+    let backoff = settings::load_gc_backoff_until(app, ctx.steam_id64);
+    if gc_backoff_active(backoff, now) {
+      log::info!(
+        "match-sync: skipping {}, GC unavailable until {:?}",
+        ctx.account_name,
+        backoff
+      );
+      continue;
+    }
+    let gc_error_seen = Arc::new(AtomicBool::new(false));
+    let engine = build_engine(app.clone(), ctx, i as u32 + 1, total, Arc::clone(&gc_error_seen));
+    let result = engine
+      .run_full_sync_if_enabled(config, &FULL_SYNC_CANCEL)
+      .await;
+    match &result {
+      Ok(p) => log::info!("match-sync: full sync finished for {}: {p:?}", ctx.account_name),
+      Err(e) => {
+        log::warn!("match-sync: full sync failed for {}: {e}", ctx.account_name);
+        emit_error(app, e);
+      }
+    }
+    apply_gc_backoff(app, ctx, backoff, gc_error_seen.load(Ordering::Relaxed), now);
+    if let BatchControl::Abort = batch_control(&result) {
+      break;
+    }
+  }
 }
 
 // Called by the game-presence watcher on the "game closed" transition.
@@ -225,28 +435,60 @@ pub fn should_monitor(app: &AppHandle) -> bool {
     .unwrap_or(false)
 }
 
-// Skips entirely when the 24h quota is already spent, avoiding a connect for nothing.
+// One sequential pass over every currently-decryptable account. Each account's spent
+// quota is checked before connecting (independent buckets), so an exhausted account is
+// skipped without blocking the others.
 async fn background_pass(app: &AppHandle) {
   let config = match settings::load_config(app) {
     Ok(c) if c.is_active() => c,
     _ => return,
   };
-  if settings::load_quota(app)
-    .map(|q| q.remaining(settings::now_secs()) == 0)
-    .unwrap_or(true)
-  {
-    return;
-  }
-  let Ok(guard) = SYNC_LOCK.try_lock() else {
+  let Ok(_guard) = SYNC_LOCK.try_lock() else {
     return;
   };
-  let engine = build_engine(app.clone());
-  match engine.run_background_pass(&config, &BACKGROUND_CANCEL).await {
-    Ok(Some(p)) => log::info!("match-sync: background pass finished: {p:?}"),
-    Ok(None) => {}
-    Err(e) => log::warn!("match-sync: background pass failed: {e}"),
+  let contexts = match auth::recover_all() {
+    Ok(c) => c,
+    Err(e) => {
+      log::warn!("match-sync: background pass could not recover any account: {e}");
+      return;
+    }
+  };
+  let total = contexts.len() as u32;
+  for (i, ctx) in contexts.iter().enumerate() {
+    if BACKGROUND_CANCEL.load(Ordering::Relaxed) {
+      break;
+    }
+    let now = settings::now_secs();
+    let backoff = settings::load_gc_backoff_until(app, ctx.steam_id64);
+    if gc_backoff_active(backoff, now) {
+      log::info!(
+        "match-sync: skipping {}, GC unavailable until {:?}",
+        ctx.account_name,
+        backoff
+      );
+      continue;
+    }
+    let spent = settings::load_quota(app, ctx.steam_id64)
+      .map(|q| q.remaining(now) == 0)
+      .unwrap_or(true);
+    if spent {
+      continue;
+    }
+    let gc_error_seen = Arc::new(AtomicBool::new(false));
+    let engine = build_engine(app.clone(), ctx, i as u32 + 1, total, Arc::clone(&gc_error_seen));
+    let result = engine.run_background_pass(&config, &BACKGROUND_CANCEL).await;
+    match &result {
+      Ok(Some(p)) => {
+        log::info!("match-sync: background pass finished for {}: {p:?}", ctx.account_name)
+      }
+      Ok(None) => {}
+      Err(e) => log::warn!("match-sync: background pass failed for {}: {e}", ctx.account_name),
+    }
+    apply_gc_backoff(app, ctx, backoff, gc_error_seen.load(Ordering::Relaxed), now);
+    if let BatchControl::Abort = batch_control(&result) {
+      break;
+    }
   }
-  drop(guard);
 }
 
 pub fn start_background_worker(app: AppHandle) {
@@ -287,10 +529,93 @@ mod config_tests {
     let mut c = MatchSyncConfig {
       enabled: true,
       consent_accepted: false,
-      ..MatchSyncConfig::default()
     };
     assert!(!c.is_active());
     c.consent_accepted = true;
     assert!(c.is_active());
+  }
+}
+
+#[cfg(test)]
+mod batch_tests {
+  use super::*;
+
+  // Mirrors the real per-account loop's control flow (check-cancel-then-attempt, then
+  // decide abort/continue from the engine's result) using the REAL `batch_control`, so
+  // the stop/continue/abort decision is exercised directly against hand-crafted result
+  // sequences without wiring full engine/GC/auth spies end to end.
+  fn drive_batch<T>(
+    results: &[Result<T, MatchSyncError>],
+    mut cancelled_before: impl FnMut(usize) -> bool,
+  ) -> Vec<usize> {
+    let mut attempted = Vec::new();
+    for (i, result) in results.iter().enumerate() {
+      if cancelled_before(i) {
+        break;
+      }
+      attempted.push(i);
+      if let BatchControl::Abort = batch_control(result) {
+        break;
+      }
+    }
+    attempted
+  }
+
+  #[test]
+  fn quota_reached_first_account_still_runs_the_second() {
+    // Both are Ok: a quota-reached run is indistinguishable from a finished one at this
+    // level, and neither is a reason to stop the batch.
+    let results: Vec<Result<(), MatchSyncError>> = vec![Ok(()), Ok(())];
+    assert_eq!(drive_batch(&results, |_| false), vec![0, 1]);
+  }
+
+  #[test]
+  fn game_running_aborts_the_whole_batch() {
+    let results: Vec<Result<(), MatchSyncError>> =
+      vec![Err(MatchSyncError::GameRunning), Ok(())];
+    assert_eq!(drive_batch(&results, |_| false), vec![0]);
+  }
+
+  #[test]
+  fn cancel_before_second_account_skips_it() {
+    let results: Vec<Result<(), MatchSyncError>> = vec![Ok(()), Ok(())];
+    // Cancel flips true only once the first account has completed.
+    assert_eq!(drive_batch(&results, |i| i >= 1), vec![0]);
+  }
+
+  #[test]
+  fn generic_error_on_first_account_still_runs_the_second() {
+    let results: Vec<Result<(), MatchSyncError>> =
+      vec![Err(MatchSyncError::Disabled), Ok(())];
+    assert_eq!(drive_batch(&results, |_| false), vec![0, 1]);
+  }
+}
+
+#[cfg(test)]
+mod gc_backoff_tests {
+  use super::*;
+
+  const NOW: i64 = 1_000_000;
+
+  #[test]
+  fn future_backoff_skips_the_account() {
+    assert!(gc_backoff_active(Some(NOW + 60), NOW));
+  }
+
+  #[test]
+  fn past_or_unset_backoff_does_not_skip() {
+    assert!(!gc_backoff_active(Some(NOW - 1), NOW));
+    assert!(!gc_backoff_active(Some(NOW), NOW));
+    assert!(!gc_backoff_active(None, NOW));
+  }
+
+  #[test]
+  fn gc_error_flag_sets_a_day_out_backoff() {
+    assert_eq!(gc_backoff_from_flag(true, NOW), Some(NOW + GC_BACKOFF_SECS));
+  }
+
+  #[test]
+  fn no_gc_error_flag_clears_backoff() {
+    assert_eq!(gc_backoff_from_flag(false, NOW), None);
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/mod.rs
+++ b/apps/desktop/src-tauri/src/match_sync/mod.rs
@@ -1,6 +1,7 @@
 mod api_client;
 mod auth;
 mod error;
+mod game_check;
 mod gc_client;
 mod model;
 mod quota;
@@ -20,6 +21,7 @@ use crate::app_runtime::AppHandle;
 
 use api_client::ApiClient;
 use auth::LocalSteamAuth;
+use game_check::SysGameRunningCheck;
 use gc_client::SteamGcClient;
 use model::{FETCH_QUOTA_LIMIT, SyncProgress};
 use sync::{SyncEngine, SyncPersistence};
@@ -30,7 +32,6 @@ pub use error::MatchSyncError;
 // One GC request every 2 minutes: GetMatchMetaData is rate-limited per-account by
 // Steam's GC, and a fast throttle (the old 2s value) reliably tripped that limit.
 const GC_MIN_INTERVAL: Duration = Duration::from_secs(2 * 60);
-// How often the background worker does a pass while the feature is enabled.
 const BACKGROUND_PASS_INTERVAL_SECS: u64 = 15 * 60;
 const PROGRESS_EVENT: &str = "match-sync-progress";
 const ERROR_EVENT: &str = "match-sync-error";
@@ -97,7 +98,14 @@ impl SyncPersistence for AppPersistence {
   }
 }
 
-type ProdEngine = SyncEngine<LocalSteamAuth, SteamGcClient, ApiClient, ApiClient, AppPersistence>;
+type ProdEngine = SyncEngine<
+  LocalSteamAuth,
+  SteamGcClient,
+  ApiClient,
+  ApiClient,
+  AppPersistence,
+  SysGameRunningCheck,
+>;
 
 fn build_engine(app: AppHandle) -> ProdEngine {
   SyncEngine::new(
@@ -106,6 +114,7 @@ fn build_engine(app: AppHandle) -> ProdEngine {
     ApiClient::default(),
     ApiClient::default(),
     AppPersistence { app },
+    SysGameRunningCheck::new(),
     Arc::clone(&THROTTLE),
     Arc::clone(&GC_REQUEST_COUNTER),
   )
@@ -197,8 +206,7 @@ pub fn spawn_full_sync(app: AppHandle) -> Result<(), MatchSyncError> {
   Ok(())
 }
 
-// Called by the game-presence watcher on the "game closed" transition. Fires one
-// immediate background pass; a no-op unless the user has opted in.
+// Called by the game-presence watcher on the "game closed" transition.
 pub fn on_game_exit(app: AppHandle) {
   tokio::spawn(async move {
     background_pass(&app).await;
@@ -211,8 +219,7 @@ pub fn should_monitor(app: &AppHandle) -> bool {
     .unwrap_or(false)
 }
 
-// A single background pass under the shared lock (single-flight with full sync and
-// with other passes). Skips entirely when the 24h quota is already spent.
+// Skips entirely when the 24h quota is already spent, avoiding a connect for nothing.
 async fn background_pass(app: &AppHandle) {
   let config = match settings::load_config(app) {
     Ok(c) if c.is_active() => c,
@@ -236,8 +243,6 @@ async fn background_pass(app: &AppHandle) {
   drop(guard);
 }
 
-// While the feature is enabled, keep doing background passes on an interval (up to
-// the 24h quota). Single instance; stops promptly when the feature is disabled.
 pub fn start_background_worker(app: AppHandle) {
   if !should_monitor(&app) {
     return;
@@ -264,14 +269,6 @@ pub fn start_background_worker(app: AppHandle) {
 #[cfg(test)]
 mod config_tests {
   use super::model::MatchSyncConfig;
-
-  #[test]
-  fn default_config_is_inactive() {
-    let c = MatchSyncConfig::default();
-    assert!(!c.enabled);
-    assert!(!c.consent_accepted);
-    assert!(!c.is_active());
-  }
 
   #[test]
   fn active_requires_both_enabled_and_consent() {

--- a/apps/desktop/src-tauri/src/match_sync/model.rs
+++ b/apps/desktop/src-tauri/src/match_sync/model.rs
@@ -84,13 +84,25 @@ pub struct MatchHistoryPage {
 pub struct MatchSyncConfig {
   pub enabled: bool,
   pub consent_accepted: bool,
-  pub full_sync_complete: bool,
 }
 
 impl MatchSyncConfig {
   pub fn is_active(&self) -> bool {
     self.enabled && self.consent_accepted
   }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountStatus {
+  pub steam_id64: u64,
+  pub account_name: String,
+  pub quota_limit: u32,
+  pub quota_remaining: u32,
+  pub quota_reset_at: Option<i64>,
+  pub full_sync_complete: bool,
+  pub available: bool,
+  pub gc_unavailable: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/apps/desktop/src-tauri/src/match_sync/model.rs
+++ b/apps/desktop/src-tauri/src/match_sync/model.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 
 pub const DEADLOCK_APP_ID: u32 = 1422450;
 
-// Hard cap on GC match-salt fetches per rolling 24h, across the whole subsystem
-// (full sync + monitoring + backfill). Persisted so it survives restarts.
 pub const FETCH_QUOTA_LIMIT: usize = 40;
 pub const FETCH_QUOTA_WINDOW_SECS: i64 = 24 * 60 * 60;
 
@@ -16,13 +14,11 @@ pub const INGEST_USERNAME: &str = "Mod Manager";
 pub struct AuthContext {
   pub account_name: String,
   pub steam_id64: u64,
-  // Read by the real GC client (stubbed); redacted from Debug.
-  #[allow(dead_code)]
   pub refresh_token: String,
 }
 
 impl AuthContext {
-  // deadlock-api's `account_id` is the 32-bit Steam3 id.
+  // deadlock-api expects the 32-bit Steam3 account id, not the SteamID64.
   pub fn account_id(&self) -> u32 {
     (self.steam_id64 & 0xFFFF_FFFF) as u32
   }
@@ -92,7 +88,6 @@ pub struct MatchSyncConfig {
 }
 
 impl MatchSyncConfig {
-  // The master gate: enabling (with consent) is what drives all background fetching.
   pub fn is_active(&self) -> bool {
     self.enabled && self.consent_accepted
   }

--- a/apps/desktop/src-tauri/src/match_sync/model.rs
+++ b/apps/desktop/src-tauri/src/match_sync/model.rs
@@ -8,7 +8,7 @@ pub const FETCH_QUOTA_WINDOW_SECS: i64 = 24 * 60 * 60;
 // Matches the httpcache scraper so both ingest sources look identical server-side.
 pub const INGEST_USERNAME: &str = "Mod Manager";
 
-// refresh_token is a live account credential (user-auth.md): in-memory only, never
+// refresh_token is a live account credential: in-memory only, never
 // logged/persisted/sent. Debug is hand-written to keep it out of logs.
 #[derive(Clone)]
 pub struct AuthContext {

--- a/apps/desktop/src-tauri/src/match_sync/model.rs
+++ b/apps/desktop/src-tauri/src/match_sync/model.rs
@@ -5,6 +5,12 @@ pub const DEADLOCK_APP_ID: u32 = 1422450;
 pub const FETCH_QUOTA_LIMIT: usize = 40;
 pub const FETCH_QUOTA_WINDOW_SECS: i64 = 24 * 60 * 60;
 
+// Quota slots the background pass keeps free from global backfill, so a user's own
+// freshly-played matches (fetched first, and not subject to this reserve) always have
+// headroom against a bottomless global to-fetch list. Sized for ~4 matches/day plus
+// margin for two sessions straddling the rolling 24h window.
+pub const BACKFILL_QUOTA_RESERVE: usize = 8;
+
 // Matches the httpcache scraper so both ingest sources look identical server-side.
 pub const INGEST_USERNAME: &str = "Mod Manager";
 

--- a/apps/desktop/src-tauri/src/match_sync/model.rs
+++ b/apps/desktop/src-tauri/src/match_sync/model.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+
+pub const DEADLOCK_APP_ID: u32 = 1422450;
+
+// Hard cap on GC match-salt fetches per rolling 24h, across the whole subsystem
+// (full sync + monitoring + backfill). Persisted so it survives restarts.
+pub const FETCH_QUOTA_LIMIT: usize = 40;
+pub const FETCH_QUOTA_WINDOW_SECS: i64 = 24 * 60 * 60;
+
+// Matches the httpcache scraper so both ingest sources look identical server-side.
+pub const INGEST_USERNAME: &str = "Mod Manager";
+
+// refresh_token is a live account credential (user-auth.md): in-memory only, never
+// logged/persisted/sent. Debug is hand-written to keep it out of logs.
+#[derive(Clone)]
+pub struct AuthContext {
+  pub account_name: String,
+  pub steam_id64: u64,
+  // Read by the real GC client (stubbed); redacted from Debug.
+  #[allow(dead_code)]
+  pub refresh_token: String,
+}
+
+impl AuthContext {
+  // deadlock-api's `account_id` is the 32-bit Steam3 id.
+  pub fn account_id(&self) -> u32 {
+    (self.steam_id64 & 0xFFFF_FFFF) as u32
+  }
+}
+
+impl std::fmt::Debug for AuthContext {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("AuthContext")
+      .field("account_name", &self.account_name)
+      .field("steam_id64", &self.steam_id64)
+      .field("refresh_token", &"<redacted>")
+      .finish()
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchSalts {
+  pub match_id: u64,
+  pub cluster_id: Option<u32>,
+  pub metadata_salt: Option<u32>,
+  pub replay_salt: Option<u32>,
+}
+
+// One element of the `POST /v1/matches/salts` body; field names/nullability must
+// match what the scraper already sends.
+#[derive(Serialize, Debug, Clone)]
+pub struct SaltPayload {
+  pub match_id: u64,
+  pub cluster_id: Option<u32>,
+  pub metadata_salt: Option<u32>,
+  pub replay_salt: Option<u32>,
+  pub username: Option<String>,
+}
+
+impl From<&MatchSalts> for SaltPayload {
+  fn from(s: &MatchSalts) -> Self {
+    SaltPayload {
+      match_id: s.match_id,
+      cluster_id: s.cluster_id,
+      metadata_salt: s.metadata_salt,
+      replay_salt: s.replay_salt,
+      username: Some(INGEST_USERNAME.to_string()),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FetchScope {
+  Account(u32),
+  Global,
+}
+
+// One page of the GC `GetMatchHistory` response. `next_cursor` is the continuation
+// token for the next (older) page, or None when history is exhausted.
+#[derive(Debug, Clone, Default)]
+pub struct MatchHistoryPage {
+  pub match_ids: Vec<u64>,
+  pub next_cursor: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchSyncConfig {
+  pub enabled: bool,
+  pub consent_accepted: bool,
+  pub full_sync_complete: bool,
+}
+
+impl MatchSyncConfig {
+  // The master gate: enabling (with consent) is what drives all background fetching.
+  pub fn is_active(&self) -> bool {
+    self.enabled && self.consent_accepted
+  }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncProgress {
+  pub fetched: u32,
+  pub skipped: u32,
+  pub backfilled: u32,
+  pub running: bool,
+  pub quota_reached: bool,
+  pub rate_limited: bool,
+  pub quota_remaining: u32,
+}

--- a/apps/desktop/src-tauri/src/match_sync/model.rs
+++ b/apps/desktop/src-tauri/src/match_sync/model.rs
@@ -101,7 +101,6 @@ pub struct AccountStatus {
   pub quota_remaining: u32,
   pub quota_reset_at: Option<i64>,
   pub full_sync_complete: bool,
-  pub available: bool,
   pub gc_unavailable: bool,
 }
 

--- a/apps/desktop/src-tauri/src/match_sync/quota.rs
+++ b/apps/desktop/src-tauri/src/match_sync/quota.rs
@@ -1,0 +1,155 @@
+//! Rolling-window fetch quota — the hard cap on Steam GC match-salt fetches.
+//! Pure and clock-injected so it unit-tests without a store or real clock;
+//! persistence lives in [`super::settings`].
+
+#[derive(Debug, Clone)]
+pub struct QuotaWindow {
+  hits: Vec<i64>,
+  limit: usize,
+  window_secs: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuotaExhausted {
+  pub limit: usize,
+  pub retry_after_secs: i64,
+}
+
+impl QuotaWindow {
+  pub fn new(hits: Vec<i64>, limit: usize, window_secs: i64) -> Self {
+    Self {
+      hits,
+      limit,
+      window_secs,
+    }
+  }
+
+  fn prune(&mut self, now: i64) {
+    let cutoff = now - self.window_secs;
+    self.hits.retain(|&t| t > cutoff);
+  }
+
+  pub fn remaining(&self, now: i64) -> usize {
+    let cutoff = now - self.window_secs;
+    let used = self.hits.iter().filter(|&&t| t > cutoff).count();
+    self.limit.saturating_sub(used)
+  }
+
+  pub fn reset_at(&self, now: i64) -> Option<i64> {
+    if self.remaining(now) > 0 {
+      return None;
+    }
+    let cutoff = now - self.window_secs;
+    self
+      .hits
+      .iter()
+      .filter(|&&t| t > cutoff)
+      .min()
+      .map(|&oldest| oldest + self.window_secs)
+  }
+
+  // On success records `now`; caller must persist snapshot(). Nothing mutates on failure.
+  pub fn try_consume(&mut self, now: i64) -> Result<(), QuotaExhausted> {
+    self.prune(now);
+    if self.hits.len() >= self.limit {
+      let oldest = self.hits.iter().min().copied().unwrap_or(now);
+      let retry_after_secs = (oldest + self.window_secs - now).max(1);
+      return Err(QuotaExhausted {
+        limit: self.limit,
+        retry_after_secs,
+      });
+    }
+    self.hits.push(now);
+    Ok(())
+  }
+
+  pub fn snapshot(&self) -> Vec<i64> {
+    self.hits.clone()
+  }
+
+  // Marks the whole window as consumed as of `now` (e.g. Steam itself rate-limited
+  // us): remaining(now) becomes 0 and capacity frees up 24h from `now`, same as if
+  // all `limit` requests had genuinely succeeded right now.
+  pub fn exhaust(&mut self, now: i64) {
+    self.prune(now);
+    let needed = self.limit.saturating_sub(self.hits.len());
+    self.hits.extend(std::iter::repeat_n(now, needed));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const LIMIT: usize = 40;
+  const WINDOW: i64 = 24 * 60 * 60;
+
+  fn window() -> QuotaWindow {
+    QuotaWindow::new(Vec::new(), LIMIT, WINDOW)
+  }
+
+  #[test]
+  fn allows_up_to_limit_then_blocks() {
+    let mut q = window();
+    let now = 1_000_000;
+    for _ in 0..LIMIT {
+      assert!(q.try_consume(now).is_ok());
+    }
+    assert_eq!(q.remaining(now), 0);
+    let err = q.try_consume(now).unwrap_err();
+    assert_eq!(err.limit, LIMIT);
+    // The 71st fetch must wait a full window since all hits share `now`.
+    assert_eq!(err.retry_after_secs, WINDOW);
+  }
+
+  #[test]
+  fn frees_capacity_as_hits_age_out() {
+    let mut q = window();
+    let start = 1_000_000;
+    for _ in 0..LIMIT {
+      q.try_consume(start).unwrap();
+    }
+    // Still blocked one second before the window elapses.
+    assert!(q.try_consume(start + WINDOW - 1).is_err());
+    // Exactly one slot frees up the moment the oldest ages out.
+    let later = start + WINDOW + 1;
+    assert_eq!(q.remaining(later), LIMIT);
+    assert!(q.try_consume(later).is_ok());
+  }
+
+  #[test]
+  fn reset_at_reports_next_free_slot() {
+    let mut q = window();
+    let now = 500;
+    for _ in 0..LIMIT {
+      q.try_consume(now).unwrap();
+    }
+    assert_eq!(q.reset_at(now), Some(now + WINDOW));
+    // Not full -> no reset time.
+    let mut q2 = window();
+    q2.try_consume(now).unwrap();
+    assert_eq!(q2.reset_at(now), None);
+  }
+
+  #[test]
+  fn snapshot_is_pruned_after_consume() {
+    let mut q = QuotaWindow::new(vec![1, 2, 3], LIMIT, WINDOW);
+    // A consume far in the future prunes the ancient entries.
+    q.try_consume(WINDOW + 100).unwrap();
+    assert_eq!(q.snapshot(), vec![WINDOW + 100]);
+  }
+
+  #[test]
+  fn exhaust_blocks_for_a_full_window_from_now() {
+    let mut q = window();
+    let now = 1_000_000;
+    q.try_consume(now).unwrap();
+    q.exhaust(now);
+    assert_eq!(q.remaining(now), 0);
+    assert_eq!(q.snapshot().len(), LIMIT);
+    assert_eq!(q.reset_at(now), Some(now + WINDOW));
+    // Blocked right up until the window elapses from the moment of exhaustion.
+    assert_eq!(q.remaining(now + WINDOW - 1), 0);
+    assert_eq!(q.remaining(now + WINDOW + 1), LIMIT);
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/quota.rs
+++ b/apps/desktop/src-tauri/src/match_sync/quota.rs
@@ -67,9 +67,7 @@ impl QuotaWindow {
     self.hits.clone()
   }
 
-  // Marks the whole window as consumed as of `now` (e.g. Steam itself rate-limited
-  // us): remaining(now) becomes 0 and capacity frees up 24h from `now`, same as if
-  // all `limit` requests had genuinely succeeded right now.
+  // For when Steam itself rate-limits us: treat the window as fully used from `now`.
   pub fn exhaust(&mut self, now: i64) {
     self.prune(now);
     let needed = self.limit.saturating_sub(self.hits.len());
@@ -134,7 +132,6 @@ mod tests {
   #[test]
   fn snapshot_is_pruned_after_consume() {
     let mut q = QuotaWindow::new(vec![1, 2, 3], LIMIT, WINDOW);
-    // A consume far in the future prunes the ancient entries.
     q.try_consume(WINDOW + 100).unwrap();
     assert_eq!(q.snapshot(), vec![WINDOW + 100]);
   }

--- a/apps/desktop/src-tauri/src/match_sync/settings.rs
+++ b/apps/desktop/src-tauri/src/match_sync/settings.rs
@@ -56,6 +56,10 @@ pub fn load_config(app: &AppHandle) -> Result<MatchSyncConfig, MatchSyncError> {
 pub fn set_consent(app: &AppHandle, accepted: bool) -> Result<(), MatchSyncError> {
   let store = store(app)?;
   store.set(KEY_CONSENT, accepted);
+  // enabled=true with consent_accepted=false is never a valid persisted state.
+  if !accepted {
+    store.set(KEY_ENABLED, false);
+  }
   save(&store)
 }
 

--- a/apps/desktop/src-tauri/src/match_sync/settings.rs
+++ b/apps/desktop/src-tauri/src/match_sync/settings.rs
@@ -1,0 +1,112 @@
+//! Persisted, off-by-default state for match-sync, in its own store file so writes
+//! never race the zustand-managed `state.json`. The quota timestamps live here too,
+//! which is what makes the daily fetch cap survive reboots and app restarts.
+
+use std::sync::Arc;
+
+use tauri_plugin_store::{Store, StoreExt};
+
+use crate::app_runtime::{AppHandle, AppRuntime};
+
+use super::error::MatchSyncError;
+use super::model::{FETCH_QUOTA_LIMIT, FETCH_QUOTA_WINDOW_SECS, MatchSyncConfig};
+use super::quota::QuotaWindow;
+
+const STORE_FILE: &str = "match-sync.json";
+
+const KEY_ENABLED: &str = "enabled";
+const KEY_CONSENT: &str = "consent_accepted";
+const KEY_FETCHED_IDS: &str = "fetched_ids";
+const KEY_QUOTA_HITS: &str = "quota_hits";
+const KEY_FULL_SYNC_COMPLETE: &str = "full_sync_complete";
+
+const MAX_FETCHED_IDS: usize = 10_000;
+
+pub fn now_secs() -> i64 {
+  chrono::Utc::now().timestamp()
+}
+
+fn store(app: &AppHandle) -> Result<Arc<Store<AppRuntime>>, MatchSyncError> {
+  app
+    .store(STORE_FILE)
+    .map_err(|e| MatchSyncError::Store(e.to_string()))
+}
+
+fn get_bool(store: &Store<AppRuntime>, key: &str, default: bool) -> bool {
+  store
+    .get(key)
+    .and_then(|v| v.as_bool())
+    .unwrap_or(default)
+}
+
+fn save(store: &Store<AppRuntime>) -> Result<(), MatchSyncError> {
+  store.save().map_err(|e| MatchSyncError::Store(e.to_string()))
+}
+
+pub fn load_config(app: &AppHandle) -> Result<MatchSyncConfig, MatchSyncError> {
+  let store = store(app)?;
+  let default = MatchSyncConfig::default();
+  Ok(MatchSyncConfig {
+    enabled: get_bool(&store, KEY_ENABLED, default.enabled),
+    consent_accepted: get_bool(&store, KEY_CONSENT, default.consent_accepted),
+    full_sync_complete: get_bool(&store, KEY_FULL_SYNC_COMPLETE, default.full_sync_complete),
+  })
+}
+
+pub fn set_consent(app: &AppHandle, accepted: bool) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  store.set(KEY_CONSENT, accepted);
+  save(&store)
+}
+
+pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  store.set(KEY_ENABLED, enabled);
+  save(&store)
+}
+
+pub fn set_full_sync_complete(app: &AppHandle, complete: bool) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  store.set(KEY_FULL_SYNC_COMPLETE, complete);
+  save(&store)
+}
+
+pub fn load_fetched_ids(app: &AppHandle) -> Result<Vec<u64>, MatchSyncError> {
+  let store = store(app)?;
+  Ok(
+    store
+      .get(KEY_FETCHED_IDS)
+      .and_then(|v| serde_json::from_value::<Vec<u64>>(v).ok())
+      .unwrap_or_default(),
+  )
+}
+
+pub fn save_fetched_ids(app: &AppHandle, ids: &[u64]) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  let trimmed = if ids.len() > MAX_FETCHED_IDS {
+    &ids[ids.len() - MAX_FETCHED_IDS..]
+  } else {
+    ids
+  };
+  store.set(KEY_FETCHED_IDS, serde_json::json!(trimmed));
+  save(&store)
+}
+
+pub fn load_quota(app: &AppHandle) -> Result<QuotaWindow, MatchSyncError> {
+  let store = store(app)?;
+  let hits = store
+    .get(KEY_QUOTA_HITS)
+    .and_then(|v| serde_json::from_value::<Vec<i64>>(v).ok())
+    .unwrap_or_default();
+  Ok(QuotaWindow::new(
+    hits,
+    FETCH_QUOTA_LIMIT,
+    FETCH_QUOTA_WINDOW_SECS,
+  ))
+}
+
+pub fn save_quota(app: &AppHandle, quota: &QuotaWindow) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  store.set(KEY_QUOTA_HITS, serde_json::json!(quota.snapshot()));
+  save(&store)
+}

--- a/apps/desktop/src-tauri/src/match_sync/settings.rs
+++ b/apps/desktop/src-tauri/src/match_sync/settings.rs
@@ -19,6 +19,7 @@ const KEY_CONSENT: &str = "consent_accepted";
 const KEY_FETCHED_IDS: &str = "fetched_ids";
 const KEY_QUOTA_HITS: &str = "quota_hits";
 const KEY_FULL_SYNC_COMPLETE: &str = "full_sync_complete";
+const KEY_GC_BACKOFF: &str = "gc_backoff_until";
 
 const MAX_FETCHED_IDS: usize = 10_000;
 
@@ -49,7 +50,6 @@ pub fn load_config(app: &AppHandle) -> Result<MatchSyncConfig, MatchSyncError> {
   Ok(MatchSyncConfig {
     enabled: get_bool(&store, KEY_ENABLED, default.enabled),
     consent_accepted: get_bool(&store, KEY_CONSENT, default.consent_accepted),
-    full_sync_complete: get_bool(&store, KEY_FULL_SYNC_COMPLETE, default.full_sync_complete),
   })
 }
 
@@ -69,37 +69,80 @@ pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<(), MatchSyncError>
   save(&store)
 }
 
-pub fn set_full_sync_complete(app: &AppHandle, complete: bool) -> Result<(), MatchSyncError> {
+pub fn load_full_sync_complete(app: &AppHandle, steam_id64: u64) -> bool {
+  match store(app) {
+    Ok(store) => get_bool(&store, &format!("{KEY_FULL_SYNC_COMPLETE}::{steam_id64}"), false),
+    Err(_) => false,
+  }
+}
+
+pub fn set_full_sync_complete(
+  app: &AppHandle,
+  steam_id64: u64,
+  complete: bool,
+) -> Result<(), MatchSyncError> {
   let store = store(app)?;
-  store.set(KEY_FULL_SYNC_COMPLETE, complete);
+  store.set(format!("{KEY_FULL_SYNC_COMPLETE}::{steam_id64}"), complete);
   save(&store)
 }
 
-pub fn load_fetched_ids(app: &AppHandle) -> Result<Vec<u64>, MatchSyncError> {
+pub fn load_fetched_ids(app: &AppHandle, steam_id64: u64) -> Result<Vec<u64>, MatchSyncError> {
   let store = store(app)?;
   Ok(
     store
-      .get(KEY_FETCHED_IDS)
+      .get(format!("{KEY_FETCHED_IDS}::{steam_id64}"))
       .and_then(|v| serde_json::from_value::<Vec<u64>>(v).ok())
       .unwrap_or_default(),
   )
 }
 
-pub fn save_fetched_ids(app: &AppHandle, ids: &[u64]) -> Result<(), MatchSyncError> {
+pub fn save_fetched_ids(
+  app: &AppHandle,
+  steam_id64: u64,
+  ids: &[u64],
+) -> Result<(), MatchSyncError> {
   let store = store(app)?;
   let trimmed = if ids.len() > MAX_FETCHED_IDS {
     &ids[ids.len() - MAX_FETCHED_IDS..]
   } else {
     ids
   };
-  store.set(KEY_FETCHED_IDS, serde_json::json!(trimmed));
+  store.set(
+    format!("{KEY_FETCHED_IDS}::{steam_id64}"),
+    serde_json::json!(trimmed),
+  );
   save(&store)
 }
 
-pub fn load_quota(app: &AppHandle) -> Result<QuotaWindow, MatchSyncError> {
+// Unix timestamp until which this account's GC handshake is known-broken (e.g. it
+// doesn't own the game), so the loops can skip it instead of re-paying the connect cost.
+pub fn load_gc_backoff_until(app: &AppHandle, steam_id64: u64) -> Option<i64> {
+  store(app)
+    .ok()?
+    .get(format!("{KEY_GC_BACKOFF}::{steam_id64}"))
+    .and_then(|v| v.as_i64())
+}
+
+pub fn set_gc_backoff_until(
+  app: &AppHandle,
+  steam_id64: u64,
+  until: Option<i64>,
+) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  let key = format!("{KEY_GC_BACKOFF}::{steam_id64}");
+  match until {
+    Some(ts) => store.set(key, ts),
+    None => {
+      store.delete(key);
+    }
+  }
+  save(&store)
+}
+
+pub fn load_quota(app: &AppHandle, steam_id64: u64) -> Result<QuotaWindow, MatchSyncError> {
   let store = store(app)?;
   let hits = store
-    .get(KEY_QUOTA_HITS)
+    .get(format!("{KEY_QUOTA_HITS}::{steam_id64}"))
     .and_then(|v| serde_json::from_value::<Vec<i64>>(v).ok())
     .unwrap_or_default();
   Ok(QuotaWindow::new(
@@ -109,8 +152,47 @@ pub fn load_quota(app: &AppHandle) -> Result<QuotaWindow, MatchSyncError> {
   ))
 }
 
-pub fn save_quota(app: &AppHandle, quota: &QuotaWindow) -> Result<(), MatchSyncError> {
+pub fn save_quota(
+  app: &AppHandle,
+  steam_id64: u64,
+  quota: &QuotaWindow,
+) -> Result<(), MatchSyncError> {
   let store = store(app)?;
-  store.set(KEY_QUOTA_HITS, serde_json::json!(quota.snapshot()));
+  store.set(
+    format!("{KEY_QUOTA_HITS}::{steam_id64}"),
+    serde_json::json!(quota.snapshot()),
+  );
+  save(&store)
+}
+
+pub fn prune_forgotten_accounts(
+  app: &AppHandle,
+  current_ids: &[u64],
+) -> Result<(), MatchSyncError> {
+  let store = store(app)?;
+  let prefixes = [
+    KEY_QUOTA_HITS,
+    KEY_FETCHED_IDS,
+    KEY_FULL_SYNC_COMPLETE,
+    KEY_GC_BACKOFF,
+  ];
+  let stale: Vec<String> = store
+    .keys()
+    .into_iter()
+    .filter(|key| {
+      prefixes.iter().any(|prefix| {
+        key
+          .strip_prefix(&format!("{prefix}::"))
+          .and_then(|id| id.parse::<u64>().ok())
+          .is_some_and(|id| !current_ids.contains(&id))
+      })
+    })
+    .collect();
+  if stale.is_empty() {
+    return Ok(());
+  }
+  for key in stale {
+    store.delete(key);
+  }
   save(&store)
 }

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -152,13 +152,13 @@ where
       st.progress.quota_remaining = 0;
       return Ok(FetchStep::QuotaReached);
     }
-    // Re-checked here, not just at pass-start: the game can launch mid-pass, and
-    // this is the actual GC choke point that must never race its own session.
+    self.throttle.acquire().await;
+    // Re-checked here, not just at pass-start, and after the throttle wait (up to
+    // GC_MIN_INTERVAL), not before it: the game can launch during that sleep, and this
+    // is the actual GC choke point that must never race the game's own session.
     if self.game_check.is_game_running() {
       return Err(MatchSyncError::GameRunning);
     }
-
-    self.throttle.acquire().await;
     self.counter.fetch_add(1, Ordering::Relaxed);
 
     let salts = match self.gc.fetch_match_salts(ctx, match_id).await {
@@ -229,10 +229,11 @@ where
     ctx: &AuthContext,
     cursor: Option<u64>,
   ) -> Result<MatchHistoryPage, MatchSyncError> {
+    self.throttle.acquire().await;
+    // Checked after the throttle wait, not before: the game may launch during the sleep.
     if self.game_check.is_game_running() {
       return Err(MatchSyncError::GameRunning);
     }
-    self.throttle.acquire().await;
     self.gc.fetch_match_history(ctx, cursor).await
   }
 

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use super::api_client::{BackfillSource, SaltsSink};
 use super::auth::SteamAuthProvider;
 use super::error::MatchSyncError;
+use super::game_check::GameRunningCheck;
 use super::gc_client::GcMatchClient;
 use super::model::{
   AuthContext, FetchScope, MatchHistoryPage, MatchSyncConfig, SaltPayload, SyncProgress,
@@ -49,7 +50,6 @@ struct RunState {
   progress: SyncProgress,
 }
 
-// Newest first, dropping ids already acted on this run.
 fn newest_first_fresh(ids: Vec<u64>, processed: &HashSet<u64>) -> Vec<u64> {
   let mut ids: Vec<u64> = ids.into_iter().filter(|id| !processed.contains(id)).collect();
   ids.sort_unstable_by(|a, b| b.cmp(a));
@@ -57,23 +57,25 @@ fn newest_first_fresh(ids: Vec<u64>, processed: &HashSet<u64>) -> Vec<u64> {
   ids
 }
 
-pub struct SyncEngine<A, G, S, B, P> {
+pub struct SyncEngine<A, G, S, B, P, R> {
   auth: A,
   gc: G,
   sink: S,
   backfill: B,
   persistence: P,
+  game_check: R,
   throttle: Arc<Throttle>,
   counter: Arc<AtomicU64>,
 }
 
-impl<A, G, S, B, P> SyncEngine<A, G, S, B, P>
+impl<A, G, S, B, P, R> SyncEngine<A, G, S, B, P, R>
 where
   A: SteamAuthProvider,
   G: GcMatchClient,
   S: SaltsSink,
   B: BackfillSource,
   P: SyncPersistence,
+  R: GameRunningCheck,
 {
   pub fn new(
     auth: A,
@@ -81,6 +83,7 @@ where
     sink: S,
     backfill: B,
     persistence: P,
+    game_check: R,
     throttle: Arc<Throttle>,
     counter: Arc<AtomicU64>,
   ) -> Self {
@@ -90,6 +93,7 @@ where
       sink,
       backfill,
       persistence,
+      game_check,
       throttle,
       counter,
     }
@@ -152,7 +156,7 @@ where
         self.persistence.save_quota(&st.quota);
         st.progress.rate_limited = true;
         st.progress.quota_reached = true;
-        st.progress.quota_remaining = 0;
+        st.progress.quota_remaining = st.quota.remaining(now) as u32;
         return Ok(FetchStep::RateLimited);
       }
       // Any other failure fetched nothing, so it must not count against the cap.
@@ -162,7 +166,6 @@ where
       }
     };
 
-    // Only a real salt fetch counts; record + persist so the cap survives restarts.
     let _ = st.quota.try_consume(now);
     self.persistence.save_quota(&st.quota);
 
@@ -248,6 +251,9 @@ where
     cancel: &AtomicBool,
     st: &mut RunState,
   ) -> Result<(), MatchSyncError> {
+    if self.game_check.is_game_running() {
+      return Err(MatchSyncError::GameRunning);
+    }
     let ctx = self.auth.recover()?;
     let account_id = ctx.account_id();
 
@@ -293,12 +299,13 @@ where
   }
 
   // One background pass: the user's own new matches, then global backfill, all
-  // bounded by the shared 24h quota. A no-op unless the user has opted in.
+  // bounded by the shared 24h quota. A no-op unless the user has opted in, or
+  // while Deadlock is running (Steam routes GC traffic to the game's own pipe).
   pub async fn run_background_pass(
     &self,
     config: &MatchSyncConfig,
   ) -> Result<Option<SyncProgress>, MatchSyncError> {
-    if !config.is_active() {
+    if !config.is_active() || self.game_check.is_game_running() {
       return Ok(None);
     }
     Some(self.run_background().await).transpose()
@@ -474,10 +481,28 @@ mod tests {
     }
   }
 
+  #[derive(Default)]
+  struct SpyGameCheck {
+    running: bool,
+  }
+  impl GameRunningCheck for SpyGameCheck {
+    fn is_game_running(&self) -> bool {
+      self.running
+    }
+  }
+
   fn engine(
     gc: SpyGc,
     backfill: SpyBackfill,
-  ) -> SyncEngine<SpyAuth, SpyGc, SpySink, SpyBackfill, MemPersistence> {
+  ) -> SyncEngine<SpyAuth, SpyGc, SpySink, SpyBackfill, MemPersistence, SpyGameCheck> {
+    engine_with_game_check(gc, backfill, SpyGameCheck::default())
+  }
+
+  fn engine_with_game_check(
+    gc: SpyGc,
+    backfill: SpyBackfill,
+    game_check: SpyGameCheck,
+  ) -> SyncEngine<SpyAuth, SpyGc, SpySink, SpyBackfill, MemPersistence, SpyGameCheck> {
     SyncEngine::new(
       SpyAuth::default(),
       gc,
@@ -487,6 +512,7 @@ mod tests {
         now: 1_000_000,
         ..Default::default()
       },
+      game_check,
       Arc::new(Throttle::new(Duration::ZERO)),
       Arc::new(AtomicU64::new(0)),
     )
@@ -512,10 +538,8 @@ mod tests {
     );
     let config = MatchSyncConfig::default();
 
-    // Monitoring: no-op, and no dependency is touched.
     let out = eng.run_background_pass(&config).await.unwrap();
     assert!(out.is_none());
-    // Full sync: refuses.
     assert!(eng.run_full_sync_if_enabled(&config, &AtomicBool::new(false)).await.is_err());
 
     assert_eq!(eng.auth.calls.load(Ordering::Relaxed), 0);
@@ -677,6 +701,39 @@ mod tests {
       .await
       .unwrap();
     assert_eq!(p.fetched, 0);
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+  }
+
+  #[tokio::test]
+  async fn refuses_while_game_is_running() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![9],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine_with_game_check(
+      SpyGc::default(),
+      backfill,
+      SpyGameCheck { running: true },
+    );
+
+    assert!(matches!(
+      eng.run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+        .await,
+      Err(MatchSyncError::GameRunning)
+    ));
+    assert_eq!(eng.auth.calls.load(Ordering::Relaxed), 0);
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+
+    // Background pass treats it as a quiet no-op, not an error.
+    assert!(
+      eng
+        .run_background_pass(&active_config())
+        .await
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(eng.auth.calls.load(Ordering::Relaxed), 0);
     assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -146,6 +146,11 @@ where
       st.progress.quota_remaining = 0;
       return Ok(FetchStep::QuotaReached);
     }
+    // Re-checked here, not just at pass-start: the game can launch mid-pass, and
+    // this is the actual GC choke point that must never race its own session.
+    if self.game_check.is_game_running() {
+      return Err(MatchSyncError::GameRunning);
+    }
 
     self.throttle.acquire().await;
     self.counter.fetch_add(1, Ordering::Relaxed);
@@ -217,6 +222,9 @@ where
     ctx: &AuthContext,
     cursor: Option<u64>,
   ) -> Result<MatchHistoryPage, MatchSyncError> {
+    if self.game_check.is_game_running() {
+      return Err(MatchSyncError::GameRunning);
+    }
     self.throttle.acquire().await;
     self.gc.fetch_match_history(ctx, cursor).await
   }
@@ -273,6 +281,7 @@ where
       }
       let page = match self.gc_history_page(&ctx, cursor).await {
         Ok(page) => page,
+        Err(MatchSyncError::GameRunning) => return Err(MatchSyncError::GameRunning),
         Err(e) => {
           log::warn!("match-sync: GC match history unavailable: {e}");
           break;
@@ -331,6 +340,21 @@ where
     if cancel.load(Ordering::Relaxed) {
       return Ok(self.finish(st));
     }
+    // Emit immediately so the UI reflects "running" even if auth fails below.
+    self.persistence.emit_progress(&st.progress);
+    let result = self.run_background_inner(cancel, &mut st).await;
+    // Always clear the running state, even on error (e.g. a save_quota or
+    // post_salts failure mid-pass), so the UI never sticks on "running".
+    st.progress.running = false;
+    self.persistence.emit_progress(&st.progress);
+    result.map(|()| st.progress)
+  }
+
+  async fn run_background_inner(
+    &self,
+    cancel: &AtomicBool,
+    st: &mut RunState,
+  ) -> Result<(), MatchSyncError> {
     let ctx = self.auth.recover()?;
     let account_id = ctx.account_id();
 
@@ -338,6 +362,7 @@ where
     // list, newest first. Both best-effort so one being down still syncs the other.
     let mut own_ids = match self.gc_history_page(&ctx, None).await {
       Ok(page) => page.match_ids,
+      Err(MatchSyncError::GameRunning) => return Err(MatchSyncError::GameRunning),
       Err(e) => {
         log::warn!("match-sync: GC match history unavailable: {e}");
         Vec::new()
@@ -348,7 +373,7 @@ where
       Err(e) => log::warn!("match-sync: account to-fetch unavailable: {e}"),
     }
     let own = newest_first_fresh(own_ids, &st.processed);
-    let control = self.process_ids(&ctx, own, false, Some(cancel), &mut st).await?;
+    let control = self.process_ids(&ctx, own, false, Some(cancel), st).await?;
 
     // Backfill globally-missing matches with whatever of the 24h quota is left over,
     // fully in the background. The user's own matches always go first.
@@ -363,14 +388,14 @@ where
               .into_iter()
               .take(budget)
               .collect();
-            self.process_ids(&ctx, picks, true, Some(cancel), &mut st).await?;
+            self.process_ids(&ctx, picks, true, Some(cancel), st).await?;
           }
           Err(e) => log::warn!("match-sync: global to-fetch unavailable: {e}"),
         }
       }
     }
 
-    Ok(self.finish(st))
+    Ok(())
   }
 }
 
@@ -478,6 +503,7 @@ mod tests {
     progress_events: AtomicU64,
     fail_load_quota: bool,
     fail_save_quota: bool,
+    last_progress_running: Mutex<Option<bool>>,
   }
   impl SyncPersistence for MemPersistence {
     fn now(&self) -> i64 {
@@ -505,18 +531,30 @@ mod tests {
     fn set_full_sync_complete(&self, complete: bool) {
       *self.complete.lock().unwrap() = complete;
     }
-    fn emit_progress(&self, _progress: &SyncProgress) {
+    fn emit_progress(&self, progress: &SyncProgress) {
       self.progress_events.fetch_add(1, Ordering::Relaxed);
+      *self.last_progress_running.lock().unwrap() = Some(progress.running);
     }
   }
 
   #[derive(Default)]
   struct SpyGameCheck {
     running: bool,
+    // Simulates the game launching mid-pass: is_game_running() starts returning
+    // true starting from this call number (1-indexed) across the whole engine.
+    // 0 (the default) means never trips this way.
+    trip_after_calls: usize,
+    calls: std::sync::atomic::AtomicUsize,
   }
   impl GameRunningCheck for SpyGameCheck {
     fn is_game_running(&self) -> bool {
-      self.running
+      if self.running {
+        return true;
+      }
+      if self.trip_after_calls == 0 {
+        return false;
+      }
+      self.calls.fetch_add(1, Ordering::Relaxed) + 1 >= self.trip_after_calls
     }
   }
 
@@ -801,7 +839,10 @@ mod tests {
     let eng = engine_with_game_check(
       SpyGc::default(),
       backfill,
-      SpyGameCheck { running: true },
+      SpyGameCheck {
+        running: true,
+        ..Default::default()
+      },
     );
 
     assert!(matches!(
@@ -877,6 +918,64 @@ mod tests {
       Err(MatchSyncError::Store(_))
     ));
     // The fetch that couldn't be persisted must not be reported as posted.
+    assert!(eng.sink.posted.lock().unwrap().is_empty());
+  }
+
+  #[tokio::test]
+  async fn background_pass_finalizes_progress_as_not_running_on_mid_pass_failure() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine_with_persistence(
+      SpyGc::default(),
+      backfill,
+      SpyGameCheck::default(),
+      MemPersistence {
+        now: 1_000_000,
+        fail_save_quota: true,
+        ..Default::default()
+      },
+    );
+
+    assert!(
+      eng
+        .run_background_pass(&active_config(), &AtomicBool::new(false))
+        .await
+        .is_err()
+    );
+    // Even though the pass aborted mid-fetch, the last emitted progress must
+    // reflect "not running" so the UI never sticks on a stale "running" state.
+    assert_eq!(
+      *eng.persistence.last_progress_running.lock().unwrap(),
+      Some(false)
+    );
+  }
+
+  #[tokio::test]
+  async fn game_launching_mid_pass_aborts_the_run() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3, 4, 5],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    // Not running for the pass-start check or the history page, but flips true on
+    // the first salt fetch (the actual GC choke point, not just pass-start).
+    let eng = engine_with_game_check(
+      SpyGc::default(),
+      backfill,
+      SpyGameCheck {
+        trip_after_calls: 3,
+        ..Default::default()
+      },
+    );
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+      .await;
+    assert!(matches!(p, Err(MatchSyncError::GameRunning)));
+    // Aborted at the first match, not after walking the whole list.
     assert!(eng.sink.posted.lock().unwrap().is_empty());
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -26,6 +26,11 @@ pub trait SyncPersistence: Send + Sync {
   fn persist_fetched(&self, ids: &[u64]);
   fn set_full_sync_complete(&self, complete: bool);
   fn emit_progress(&self, progress: &SyncProgress);
+  // Observability hook for GC failures that the engine deliberately swallows as
+  // best-effort resilience (so one dead source doesn't block the other). Lets the
+  // orchestrator back off an account whose GC connection is broken, even though the
+  // run itself still returns Ok. Default no-op: most callers don't care.
+  fn record_gc_error(&self, _err: &MatchSyncError) {}
 }
 
 enum FetchStep {
@@ -171,6 +176,7 @@ where
       // Any other failure fetched nothing, so it must not count against the cap.
       Err(e) => {
         log::warn!("match-sync: GC fetch failed for {match_id}: {e}");
+        self.persistence.record_gc_error(&e);
         return Ok(FetchStep::RetryLater);
       }
     };
@@ -284,6 +290,7 @@ where
         Err(MatchSyncError::GameRunning) => return Err(MatchSyncError::GameRunning),
         Err(e) => {
           log::warn!("match-sync: GC match history unavailable: {e}");
+          self.persistence.record_gc_error(&e);
           break;
         }
       };
@@ -365,6 +372,7 @@ where
       Err(MatchSyncError::GameRunning) => return Err(MatchSyncError::GameRunning),
       Err(e) => {
         log::warn!("match-sync: GC match history unavailable: {e}");
+        self.persistence.record_gc_error(&e);
         Vec::new()
       }
     };
@@ -429,6 +437,7 @@ mod tests {
   struct SpyGc {
     calls: AtomicU64,
     fail: bool,
+    fail_history: bool,
     rate_limited: bool,
     history: Vec<u64>,
   }
@@ -439,6 +448,9 @@ mod tests {
       _cursor: Option<u64>,
     ) -> Result<MatchHistoryPage, MatchSyncError> {
       self.calls.fetch_add(1, Ordering::Relaxed);
+      if self.fail_history {
+        return Err(MatchSyncError::GcUnavailable("spy history".into()));
+      }
       Ok(MatchHistoryPage {
         match_ids: self.history.clone(),
         next_cursor: None,
@@ -501,6 +513,7 @@ mod tests {
     fetched: Mutex<Vec<u64>>,
     complete: Mutex<bool>,
     progress_events: AtomicU64,
+    gc_errors: AtomicU64,
     fail_load_quota: bool,
     fail_save_quota: bool,
     last_progress_running: Mutex<Option<bool>>,
@@ -534,6 +547,9 @@ mod tests {
     fn emit_progress(&self, progress: &SyncProgress) {
       self.progress_events.fetch_add(1, Ordering::Relaxed);
       *self.last_progress_running.lock().unwrap() = Some(progress.running);
+    }
+    fn record_gc_error(&self, _err: &MatchSyncError) {
+      self.gc_errors.fetch_add(1, Ordering::Relaxed);
     }
   }
 
@@ -603,7 +619,6 @@ mod tests {
     MatchSyncConfig {
       enabled: true,
       consent_accepted: true,
-      full_sync_complete: false,
     }
   }
 
@@ -977,5 +992,54 @@ mod tests {
     assert!(matches!(p, Err(MatchSyncError::GameRunning)));
     // Aborted at the first match, not after walking the whole list.
     assert!(eng.sink.posted.lock().unwrap().is_empty());
+  }
+
+  #[tokio::test]
+  async fn swallowed_salt_gc_error_is_still_reported_via_hook() {
+    // A salt-fetch GcUnavailable is swallowed to Ok (best-effort), but the orchestrator
+    // needs to see it to back the account off — the hook is that channel.
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(
+      SpyGc {
+        fail: true,
+        ..Default::default()
+      },
+      backfill,
+    );
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+      .await
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert!(eng.persistence.gc_errors.load(Ordering::Relaxed) > 0);
+  }
+
+  #[tokio::test]
+  async fn swallowed_history_gc_error_is_still_reported_via_hook() {
+    // A history-page GcUnavailable is likewise swallowed (Vec::new / break) but must
+    // reach the hook so a broken-handshake account (e.g. no game ownership) backs off.
+    let backfill = SpyBackfill {
+      account: vec![],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(
+      SpyGc {
+        fail_history: true,
+        ..Default::default()
+      },
+      backfill,
+    );
+
+    eng
+      .run_background_pass(&active_config(), &AtomicBool::new(false))
+      .await
+      .unwrap();
+    assert!(eng.persistence.gc_errors.load(Ordering::Relaxed) > 0);
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -20,8 +20,8 @@ use super::throttle::Throttle;
 
 pub trait SyncPersistence: Send + Sync {
   fn now(&self) -> i64;
-  fn load_quota(&self) -> QuotaWindow;
-  fn save_quota(&self, quota: &QuotaWindow);
+  fn load_quota(&self) -> Result<QuotaWindow, MatchSyncError>;
+  fn save_quota(&self, quota: &QuotaWindow) -> Result<(), MatchSyncError>;
   fn load_fetched(&self) -> Vec<u64>;
   fn persist_fetched(&self, ids: &[u64]);
   fn set_full_sync_complete(&self, complete: bool);
@@ -32,6 +32,10 @@ enum FetchStep {
   Done,
   QuotaReached,
   RateLimited,
+  // A non-rate-limit GC failure: this match was NOT fetched, so it must not be
+  // treated as caught-up (a sticky to-fetch list could otherwise "complete" a
+  // sync that never actually posted this match's salts).
+  RetryLater,
 }
 
 enum LoopControl {
@@ -99,12 +103,12 @@ where
     }
   }
 
-  fn new_run_state(&self) -> RunState {
+  fn new_run_state(&self) -> Result<RunState, MatchSyncError> {
     let fetched_order = self.persistence.load_fetched();
     let fetched_set: HashSet<u64> = fetched_order.iter().copied().collect();
-    let quota = self.persistence.load_quota();
+    let quota = self.persistence.load_quota()?;
     let remaining = quota.remaining(self.persistence.now()) as u32;
-    RunState {
+    Ok(RunState {
       fetched_set,
       processed: HashSet::new(),
       fetched_order,
@@ -118,7 +122,7 @@ where
         rate_limited: false,
         quota_remaining: remaining,
       },
-    }
+    })
   }
 
   async fn fetch_one(
@@ -153,7 +157,7 @@ where
       Err(MatchSyncError::GcRateLimited) => {
         log::warn!("match-sync: Steam GC rate-limited; treating quota as exhausted for 24h");
         st.quota.exhaust(now);
-        self.persistence.save_quota(&st.quota);
+        self.persistence.save_quota(&st.quota)?;
         st.progress.rate_limited = true;
         st.progress.quota_reached = true;
         st.progress.quota_remaining = st.quota.remaining(now) as u32;
@@ -162,12 +166,12 @@ where
       // Any other failure fetched nothing, so it must not count against the cap.
       Err(e) => {
         log::warn!("match-sync: GC fetch failed for {match_id}: {e}");
-        return Ok(FetchStep::Done);
+        return Ok(FetchStep::RetryLater);
       }
     };
 
     let _ = st.quota.try_consume(now);
-    self.persistence.save_quota(&st.quota);
+    self.persistence.save_quota(&st.quota)?;
 
     self.sink.post_salts(&[SaltPayload::from(&salts)]).await?;
 
@@ -199,7 +203,9 @@ where
       }
       match self.fetch_one(ctx, id, is_backfill, st).await? {
         FetchStep::Done => {}
-        FetchStep::QuotaReached | FetchStep::RateLimited => return Ok(LoopControl::Stop),
+        FetchStep::QuotaReached | FetchStep::RateLimited | FetchStep::RetryLater => {
+          return Ok(LoopControl::Stop);
+        }
       }
     }
     Ok(LoopControl::Continue)
@@ -236,7 +242,7 @@ where
   }
 
   async fn run_full_sync(&self, cancel: &AtomicBool) -> Result<SyncProgress, MatchSyncError> {
-    let mut st = self.new_run_state();
+    let mut st = self.new_run_state()?;
     // Emit immediately so the UI reflects "running" even if auth fails below.
     self.persistence.emit_progress(&st.progress);
     let result = self.full_sync_inner(cancel, &mut st).await;
@@ -260,6 +266,7 @@ where
     // 1. Paginate the GC match history newest-first, interleaving salt fetches so we
     //    stop paging the moment the 24h quota runs out.
     let mut cursor: Option<u64> = None;
+    let mut history_complete = false;
     loop {
       if cancel.load(Ordering::Relaxed) {
         return Ok(());
@@ -277,7 +284,10 @@ where
       }
       match page.next_cursor {
         Some(next) => cursor = Some(next),
-        None => break,
+        None => {
+          history_complete = true;
+          break;
+        }
       }
     }
 
@@ -289,7 +299,11 @@ where
       let ids = self.backfill.to_fetch(FetchScope::Account(account_id)).await?;
       let fresh = newest_first_fresh(ids, &st.processed);
       if fresh.is_empty() {
-        self.persistence.set_full_sync_complete(true);
+        // Only the account's own matches were walked here; the Steam history walk
+        // must have finished too, or this isn't really "caught up" yet.
+        if history_complete {
+          self.persistence.set_full_sync_complete(true);
+        }
         return Ok(());
       }
       if let LoopControl::Stop = self.process_ids(&ctx, fresh, false, Some(cancel), st).await? {
@@ -304,17 +318,21 @@ where
   pub async fn run_background_pass(
     &self,
     config: &MatchSyncConfig,
+    cancel: &AtomicBool,
   ) -> Result<Option<SyncProgress>, MatchSyncError> {
     if !config.is_active() || self.game_check.is_game_running() {
       return Ok(None);
     }
-    Some(self.run_background().await).transpose()
+    Some(self.run_background(cancel).await).transpose()
   }
 
-  async fn run_background(&self) -> Result<SyncProgress, MatchSyncError> {
+  async fn run_background(&self, cancel: &AtomicBool) -> Result<SyncProgress, MatchSyncError> {
+    let mut st = self.new_run_state()?;
+    if cancel.load(Ordering::Relaxed) {
+      return Ok(self.finish(st));
+    }
     let ctx = self.auth.recover()?;
     let account_id = ctx.account_id();
-    let mut st = self.new_run_state();
 
     // Own matches = the newest GC history page ∪ deadlock-api's missing-for-account
     // list, newest first. Both best-effort so one being down still syncs the other.
@@ -330,11 +348,13 @@ where
       Err(e) => log::warn!("match-sync: account to-fetch unavailable: {e}"),
     }
     let own = newest_first_fresh(own_ids, &st.processed);
-    let control = self.process_ids(&ctx, own, false, None, &mut st).await?;
+    let control = self.process_ids(&ctx, own, false, Some(cancel), &mut st).await?;
 
     // Backfill globally-missing matches with whatever of the 24h quota is left over,
     // fully in the background. The user's own matches always go first.
-    if let LoopControl::Continue = control {
+    if let LoopControl::Continue = control
+      && !cancel.load(Ordering::Relaxed)
+    {
       let budget = st.quota.remaining(self.persistence.now());
       if budget > 0 {
         match self.backfill.to_fetch(FetchScope::Global).await {
@@ -343,7 +363,7 @@ where
               .into_iter()
               .take(budget)
               .collect();
-            self.process_ids(&ctx, picks, true, None, &mut st).await?;
+            self.process_ids(&ctx, picks, true, Some(cancel), &mut st).await?;
           }
           Err(e) => log::warn!("match-sync: global to-fetch unavailable: {e}"),
         }
@@ -456,16 +476,25 @@ mod tests {
     fetched: Mutex<Vec<u64>>,
     complete: Mutex<bool>,
     progress_events: AtomicU64,
+    fail_load_quota: bool,
+    fail_save_quota: bool,
   }
   impl SyncPersistence for MemPersistence {
     fn now(&self) -> i64 {
       self.now
     }
-    fn load_quota(&self) -> QuotaWindow {
-      QuotaWindow::new(self.quota_hits.lock().unwrap().clone(), LIMIT, WINDOW)
+    fn load_quota(&self) -> Result<QuotaWindow, MatchSyncError> {
+      if self.fail_load_quota {
+        return Err(MatchSyncError::Store("spy load failure".into()));
+      }
+      Ok(QuotaWindow::new(self.quota_hits.lock().unwrap().clone(), LIMIT, WINDOW))
     }
-    fn save_quota(&self, quota: &QuotaWindow) {
+    fn save_quota(&self, quota: &QuotaWindow) -> Result<(), MatchSyncError> {
+      if self.fail_save_quota {
+        return Err(MatchSyncError::Store("spy save failure".into()));
+      }
       *self.quota_hits.lock().unwrap() = quota.snapshot();
+      Ok(())
     }
     fn load_fetched(&self) -> Vec<u64> {
       self.fetched.lock().unwrap().clone()
@@ -503,15 +532,29 @@ mod tests {
     backfill: SpyBackfill,
     game_check: SpyGameCheck,
   ) -> SyncEngine<SpyAuth, SpyGc, SpySink, SpyBackfill, MemPersistence, SpyGameCheck> {
+    engine_with_persistence(
+      gc,
+      backfill,
+      game_check,
+      MemPersistence {
+        now: 1_000_000,
+        ..Default::default()
+      },
+    )
+  }
+
+  fn engine_with_persistence(
+    gc: SpyGc,
+    backfill: SpyBackfill,
+    game_check: SpyGameCheck,
+    persistence: MemPersistence,
+  ) -> SyncEngine<SpyAuth, SpyGc, SpySink, SpyBackfill, MemPersistence, SpyGameCheck> {
     SyncEngine::new(
       SpyAuth::default(),
       gc,
       SpySink::default(),
       backfill,
-      MemPersistence {
-        now: 1_000_000,
-        ..Default::default()
-      },
+      persistence,
       game_check,
       Arc::new(Throttle::new(Duration::ZERO)),
       Arc::new(AtomicU64::new(0)),
@@ -538,7 +581,7 @@ mod tests {
     );
     let config = MatchSyncConfig::default();
 
-    let out = eng.run_background_pass(&config).await.unwrap();
+    let out = eng.run_background_pass(&config, &AtomicBool::new(false)).await.unwrap();
     assert!(out.is_none());
     assert!(eng.run_full_sync_if_enabled(&config, &AtomicBool::new(false)).await.is_err());
 
@@ -616,7 +659,7 @@ mod tests {
     );
 
     let p = eng
-      .run_background_pass(&active_config())
+      .run_background_pass(&active_config(), &AtomicBool::new(false))
       .await
       .unwrap()
       .unwrap();
@@ -655,6 +698,31 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn sticky_to_fetch_failure_does_not_falsely_complete_the_sync() {
+    // deadlock-api's to-fetch list is sticky: it keeps listing an id until it's
+    // actually ingested. A transient GC failure must not make that look "caught up".
+    let backfill = SpyBackfill {
+      account: vec![1],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(
+      SpyGc {
+        fail: true,
+        ..Default::default()
+      },
+      backfill,
+    );
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+      .await
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert!(!*eng.persistence.complete.lock().unwrap());
+  }
+
+  #[tokio::test]
   async fn rate_limit_stops_the_pass_and_exhausts_quota_for_24h() {
     let backfill = SpyBackfill {
       account: vec![1, 2, 3],
@@ -670,7 +738,7 @@ mod tests {
     );
 
     let p = eng
-      .run_background_pass(&active_config())
+      .run_background_pass(&active_config(), &AtomicBool::new(false))
       .await
       .unwrap()
       .unwrap();
@@ -705,6 +773,25 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn cancel_stops_background_pass() {
+    let backfill = SpyBackfill {
+      account: (1..=50).collect(),
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(SpyGc::default(), backfill);
+    let cancel = AtomicBool::new(true);
+
+    let p = eng
+      .run_background_pass(&active_config(), &cancel)
+      .await
+      .unwrap()
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+  }
+
+  #[tokio::test]
   async fn refuses_while_game_is_running() {
     let backfill = SpyBackfill {
       account: vec![1, 2, 3],
@@ -728,12 +815,68 @@ mod tests {
     // Background pass treats it as a quiet no-op, not an error.
     assert!(
       eng
-        .run_background_pass(&active_config())
+        .run_background_pass(&active_config(), &AtomicBool::new(false))
         .await
         .unwrap()
         .is_none()
     );
     assert_eq!(eng.auth.calls.load(Ordering::Relaxed), 0);
     assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+  }
+
+  #[tokio::test]
+  async fn fails_closed_when_quota_cannot_be_loaded() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine_with_persistence(
+      SpyGc::default(),
+      backfill,
+      SpyGameCheck::default(),
+      MemPersistence {
+        now: 1_000_000,
+        fail_load_quota: true,
+        ..Default::default()
+      },
+    );
+
+    assert!(matches!(
+      eng
+        .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+        .await,
+      Err(MatchSyncError::Store(_))
+    ));
+    // A quota we couldn't read must not be treated as empty (full headroom).
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+  }
+
+  #[tokio::test]
+  async fn stops_fetching_when_quota_cannot_be_saved() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine_with_persistence(
+      SpyGc::default(),
+      backfill,
+      SpyGameCheck::default(),
+      MemPersistence {
+        now: 1_000_000,
+        fail_save_quota: true,
+        ..Default::default()
+      },
+    );
+
+    assert!(matches!(
+      eng
+        .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+        .await,
+      Err(MatchSyncError::Store(_))
+    ));
+    // The fetch that couldn't be persisted must not be reported as posted.
+    assert!(eng.sink.posted.lock().unwrap().is_empty());
   }
 }

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -13,7 +13,8 @@ use super::error::MatchSyncError;
 use super::game_check::GameRunningCheck;
 use super::gc_client::GcMatchClient;
 use super::model::{
-  AuthContext, FetchScope, MatchHistoryPage, MatchSyncConfig, SaltPayload, SyncProgress,
+  AuthContext, BACKFILL_QUOTA_RESERVE, FetchScope, MatchHistoryPage, MatchSyncConfig, SaltPayload,
+  SyncProgress,
 };
 use super::quota::QuotaWindow;
 use super::throttle::Throttle;
@@ -388,7 +389,12 @@ where
     if let LoopControl::Continue = control
       && !cancel.load(Ordering::Relaxed)
     {
-      let budget = st.quota.remaining(self.persistence.now());
+      // Keep a reserve untouched so the user's own matches — always fetched first, and
+      // not subject to this cap — retain headroom against a bottomless global list.
+      let budget = st
+        .quota
+        .remaining(self.persistence.now())
+        .saturating_sub(BACKFILL_QUOTA_RESERVE);
       if budget > 0 {
         match self.backfill.to_fetch(FetchScope::Global).await {
           Ok(global) => {
@@ -723,6 +729,27 @@ mod tests {
     let posted = eng.sink.posted.lock().unwrap();
     assert_eq!(&posted[..3], &[102, 101, 100], "own matches, newest first, deduped");
     assert_eq!(posted.len(), 10);
+  }
+
+  #[tokio::test]
+  async fn background_backfill_leaves_reserve_for_own_matches() {
+    // No own matches, a bottomless global list: backfill must stop at LIMIT - reserve
+    // rather than drain the whole bucket, so a later-played match keeps headroom.
+    let backfill = SpyBackfill {
+      account: vec![],
+      global: (1..=200).collect(),
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(SpyGc::default(), backfill);
+
+    let p = eng
+      .run_background_pass(&active_config(), &AtomicBool::new(false))
+      .await
+      .unwrap()
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert_eq!(p.backfilled as usize, LIMIT - BACKFILL_QUOTA_RESERVE);
+    assert_eq!(p.quota_remaining as usize, BACKFILL_QUOTA_RESERVE);
   }
 
   #[tokio::test]

--- a/apps/desktop/src-tauri/src/match_sync/sync.rs
+++ b/apps/desktop/src-tauri/src/match_sync/sync.rs
@@ -1,0 +1,682 @@
+//! Sync orchestration. Generic over its dependencies so the whole pipeline is
+//! unit-testable with spies. All GC fetches funnel through `fetch_one`, the single
+//! choke point that enforces: already-fetched skip → persisted quota → throttle →
+//! counter. `*_if_enabled` are the off-by-default gate.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use super::api_client::{BackfillSource, SaltsSink};
+use super::auth::SteamAuthProvider;
+use super::error::MatchSyncError;
+use super::gc_client::GcMatchClient;
+use super::model::{
+  AuthContext, FetchScope, MatchHistoryPage, MatchSyncConfig, SaltPayload, SyncProgress,
+};
+use super::quota::QuotaWindow;
+use super::throttle::Throttle;
+
+pub trait SyncPersistence: Send + Sync {
+  fn now(&self) -> i64;
+  fn load_quota(&self) -> QuotaWindow;
+  fn save_quota(&self, quota: &QuotaWindow);
+  fn load_fetched(&self) -> Vec<u64>;
+  fn persist_fetched(&self, ids: &[u64]);
+  fn set_full_sync_complete(&self, complete: bool);
+  fn emit_progress(&self, progress: &SyncProgress);
+}
+
+enum FetchStep {
+  Done,
+  QuotaReached,
+  RateLimited,
+}
+
+enum LoopControl {
+  Continue,
+  Stop,
+}
+
+struct RunState {
+  // Persisted, successfully-ingested ids (idempotency across runs + quota protection).
+  fetched_set: HashSet<u64>,
+  // Every id acted on this run (incl. failures/skips) so a sticky to-fetch list or a
+  // failing GC can't re-offer the same id and spin/burn quota.
+  processed: HashSet<u64>,
+  fetched_order: Vec<u64>,
+  quota: QuotaWindow,
+  progress: SyncProgress,
+}
+
+// Newest first, dropping ids already acted on this run.
+fn newest_first_fresh(ids: Vec<u64>, processed: &HashSet<u64>) -> Vec<u64> {
+  let mut ids: Vec<u64> = ids.into_iter().filter(|id| !processed.contains(id)).collect();
+  ids.sort_unstable_by(|a, b| b.cmp(a));
+  ids.dedup();
+  ids
+}
+
+pub struct SyncEngine<A, G, S, B, P> {
+  auth: A,
+  gc: G,
+  sink: S,
+  backfill: B,
+  persistence: P,
+  throttle: Arc<Throttle>,
+  counter: Arc<AtomicU64>,
+}
+
+impl<A, G, S, B, P> SyncEngine<A, G, S, B, P>
+where
+  A: SteamAuthProvider,
+  G: GcMatchClient,
+  S: SaltsSink,
+  B: BackfillSource,
+  P: SyncPersistence,
+{
+  pub fn new(
+    auth: A,
+    gc: G,
+    sink: S,
+    backfill: B,
+    persistence: P,
+    throttle: Arc<Throttle>,
+    counter: Arc<AtomicU64>,
+  ) -> Self {
+    Self {
+      auth,
+      gc,
+      sink,
+      backfill,
+      persistence,
+      throttle,
+      counter,
+    }
+  }
+
+  fn new_run_state(&self) -> RunState {
+    let fetched_order = self.persistence.load_fetched();
+    let fetched_set: HashSet<u64> = fetched_order.iter().copied().collect();
+    let quota = self.persistence.load_quota();
+    let remaining = quota.remaining(self.persistence.now()) as u32;
+    RunState {
+      fetched_set,
+      processed: HashSet::new(),
+      fetched_order,
+      quota,
+      progress: SyncProgress {
+        fetched: 0,
+        skipped: 0,
+        backfilled: 0,
+        running: true,
+        quota_reached: false,
+        rate_limited: false,
+        quota_remaining: remaining,
+      },
+    }
+  }
+
+  async fn fetch_one(
+    &self,
+    ctx: &AuthContext,
+    match_id: u64,
+    is_backfill: bool,
+    st: &mut RunState,
+  ) -> Result<FetchStep, MatchSyncError> {
+    st.processed.insert(match_id);
+
+    if st.fetched_set.contains(&match_id) {
+      st.progress.skipped += 1;
+      return Ok(FetchStep::Done);
+    }
+
+    let now = self.persistence.now();
+    // The 24h cap counts successful salt fetches; check headroom before requesting.
+    if st.quota.remaining(now) == 0 {
+      st.progress.quota_reached = true;
+      st.progress.quota_remaining = 0;
+      return Ok(FetchStep::QuotaReached);
+    }
+
+    self.throttle.acquire().await;
+    self.counter.fetch_add(1, Ordering::Relaxed);
+
+    let salts = match self.gc.fetch_match_salts(ctx, match_id).await {
+      Ok(salts) => salts,
+      // Steam itself is rate-limiting this account: treat the 24h bucket as fully
+      // spent so we stop hammering it and only try again once it naturally frees up.
+      Err(MatchSyncError::GcRateLimited) => {
+        log::warn!("match-sync: Steam GC rate-limited; treating quota as exhausted for 24h");
+        st.quota.exhaust(now);
+        self.persistence.save_quota(&st.quota);
+        st.progress.rate_limited = true;
+        st.progress.quota_reached = true;
+        st.progress.quota_remaining = 0;
+        return Ok(FetchStep::RateLimited);
+      }
+      // Any other failure fetched nothing, so it must not count against the cap.
+      Err(e) => {
+        log::warn!("match-sync: GC fetch failed for {match_id}: {e}");
+        return Ok(FetchStep::Done);
+      }
+    };
+
+    // Only a real salt fetch counts; record + persist so the cap survives restarts.
+    let _ = st.quota.try_consume(now);
+    self.persistence.save_quota(&st.quota);
+
+    self.sink.post_salts(&[SaltPayload::from(&salts)]).await?;
+
+    st.fetched_set.insert(match_id);
+    st.fetched_order.push(match_id);
+    self.persistence.persist_fetched(&st.fetched_order);
+
+    if is_backfill {
+      st.progress.backfilled += 1;
+    } else {
+      st.progress.fetched += 1;
+    }
+    st.progress.quota_remaining = st.quota.remaining(now) as u32;
+    self.persistence.emit_progress(&st.progress);
+    Ok(FetchStep::Done)
+  }
+
+  async fn process_ids(
+    &self,
+    ctx: &AuthContext,
+    ids: Vec<u64>,
+    is_backfill: bool,
+    cancel: Option<&AtomicBool>,
+    st: &mut RunState,
+  ) -> Result<LoopControl, MatchSyncError> {
+    for id in ids {
+      if cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+        return Ok(LoopControl::Stop);
+      }
+      match self.fetch_one(ctx, id, is_backfill, st).await? {
+        FetchStep::Done => {}
+        FetchStep::QuotaReached | FetchStep::RateLimited => return Ok(LoopControl::Stop),
+      }
+    }
+    Ok(LoopControl::Continue)
+  }
+
+  // Throttled, not quota-counted: a history query is not a salt fetch.
+  async fn gc_history_page(
+    &self,
+    ctx: &AuthContext,
+    cursor: Option<u64>,
+  ) -> Result<MatchHistoryPage, MatchSyncError> {
+    self.throttle.acquire().await;
+    self.gc.fetch_match_history(ctx, cursor).await
+  }
+
+  fn finish(&self, mut st: RunState) -> SyncProgress {
+    st.progress.running = false;
+    self.persistence.emit_progress(&st.progress);
+    st.progress
+  }
+
+  pub async fn run_full_sync_if_enabled(
+    &self,
+    config: &MatchSyncConfig,
+    cancel: &AtomicBool,
+  ) -> Result<SyncProgress, MatchSyncError> {
+    if !config.consent_accepted {
+      return Err(MatchSyncError::ConsentRequired);
+    }
+    if !config.enabled {
+      return Err(MatchSyncError::Disabled);
+    }
+    self.run_full_sync(cancel).await
+  }
+
+  async fn run_full_sync(&self, cancel: &AtomicBool) -> Result<SyncProgress, MatchSyncError> {
+    let mut st = self.new_run_state();
+    // Emit immediately so the UI reflects "running" even if auth fails below.
+    self.persistence.emit_progress(&st.progress);
+    let result = self.full_sync_inner(cancel, &mut st).await;
+    // Always clear the running state, even on error, so the UI never sticks.
+    st.progress.running = false;
+    self.persistence.emit_progress(&st.progress);
+    result.map(|()| st.progress)
+  }
+
+  async fn full_sync_inner(
+    &self,
+    cancel: &AtomicBool,
+    st: &mut RunState,
+  ) -> Result<(), MatchSyncError> {
+    let ctx = self.auth.recover()?;
+    let account_id = ctx.account_id();
+
+    // 1. Paginate the GC match history newest-first, interleaving salt fetches so we
+    //    stop paging the moment the 24h quota runs out.
+    let mut cursor: Option<u64> = None;
+    loop {
+      if cancel.load(Ordering::Relaxed) {
+        return Ok(());
+      }
+      let page = match self.gc_history_page(&ctx, cursor).await {
+        Ok(page) => page,
+        Err(e) => {
+          log::warn!("match-sync: GC match history unavailable: {e}");
+          break;
+        }
+      };
+      let fresh = newest_first_fresh(page.match_ids, &st.processed);
+      if let LoopControl::Stop = self.process_ids(&ctx, fresh, false, Some(cancel), st).await? {
+        return Ok(());
+      }
+      match page.next_cursor {
+        Some(next) => cursor = Some(next),
+        None => break,
+      }
+    }
+
+    // 2. Drain deadlock-api's "missing for this account" list until empty or quota.
+    loop {
+      if cancel.load(Ordering::Relaxed) {
+        return Ok(());
+      }
+      let ids = self.backfill.to_fetch(FetchScope::Account(account_id)).await?;
+      let fresh = newest_first_fresh(ids, &st.processed);
+      if fresh.is_empty() {
+        self.persistence.set_full_sync_complete(true);
+        return Ok(());
+      }
+      if let LoopControl::Stop = self.process_ids(&ctx, fresh, false, Some(cancel), st).await? {
+        return Ok(());
+      }
+    }
+  }
+
+  // One background pass: the user's own new matches, then global backfill, all
+  // bounded by the shared 24h quota. A no-op unless the user has opted in.
+  pub async fn run_background_pass(
+    &self,
+    config: &MatchSyncConfig,
+  ) -> Result<Option<SyncProgress>, MatchSyncError> {
+    if !config.is_active() {
+      return Ok(None);
+    }
+    Some(self.run_background().await).transpose()
+  }
+
+  async fn run_background(&self) -> Result<SyncProgress, MatchSyncError> {
+    let ctx = self.auth.recover()?;
+    let account_id = ctx.account_id();
+    let mut st = self.new_run_state();
+
+    // Own matches = the newest GC history page ∪ deadlock-api's missing-for-account
+    // list, newest first. Both best-effort so one being down still syncs the other.
+    let mut own_ids = match self.gc_history_page(&ctx, None).await {
+      Ok(page) => page.match_ids,
+      Err(e) => {
+        log::warn!("match-sync: GC match history unavailable: {e}");
+        Vec::new()
+      }
+    };
+    match self.backfill.to_fetch(FetchScope::Account(account_id)).await {
+      Ok(ids) => own_ids.extend(ids),
+      Err(e) => log::warn!("match-sync: account to-fetch unavailable: {e}"),
+    }
+    let own = newest_first_fresh(own_ids, &st.processed);
+    let control = self.process_ids(&ctx, own, false, None, &mut st).await?;
+
+    // Backfill globally-missing matches with whatever of the 24h quota is left over,
+    // fully in the background. The user's own matches always go first.
+    if let LoopControl::Continue = control {
+      let budget = st.quota.remaining(self.persistence.now());
+      if budget > 0 {
+        match self.backfill.to_fetch(FetchScope::Global).await {
+          Ok(global) => {
+            let picks: Vec<u64> = newest_first_fresh(global, &st.processed)
+              .into_iter()
+              .take(budget)
+              .collect();
+            self.process_ids(&ctx, picks, true, None, &mut st).await?;
+          }
+          Err(e) => log::warn!("match-sync: global to-fetch unavailable: {e}"),
+        }
+      }
+    }
+
+    Ok(self.finish(st))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::match_sync::model::{AuthContext, MatchHistoryPage, MatchSalts};
+  use crate::match_sync::quota::QuotaWindow;
+  use std::sync::Mutex;
+  use std::time::Duration;
+
+  const LIMIT: usize = 40;
+  const WINDOW: i64 = 24 * 60 * 60;
+
+  #[derive(Default)]
+  struct SpyAuth {
+    calls: AtomicU64,
+  }
+  impl SteamAuthProvider for SpyAuth {
+    fn recover(&self) -> Result<AuthContext, MatchSyncError> {
+      self.calls.fetch_add(1, Ordering::Relaxed);
+      Ok(AuthContext {
+        account_name: "spy".into(),
+        steam_id64: 76561197960265728 + 42,
+        refresh_token: "secret".into(),
+      })
+    }
+  }
+
+  #[derive(Default)]
+  struct SpyGc {
+    calls: AtomicU64,
+    fail: bool,
+    rate_limited: bool,
+    history: Vec<u64>,
+  }
+  impl GcMatchClient for SpyGc {
+    async fn fetch_match_history(
+      &self,
+      _ctx: &AuthContext,
+      _cursor: Option<u64>,
+    ) -> Result<MatchHistoryPage, MatchSyncError> {
+      self.calls.fetch_add(1, Ordering::Relaxed);
+      Ok(MatchHistoryPage {
+        match_ids: self.history.clone(),
+        next_cursor: None,
+      })
+    }
+    async fn fetch_match_salts(
+      &self,
+      _ctx: &AuthContext,
+      match_id: u64,
+    ) -> Result<MatchSalts, MatchSyncError> {
+      self.calls.fetch_add(1, Ordering::Relaxed);
+      if self.rate_limited {
+        return Err(MatchSyncError::GcRateLimited);
+      }
+      if self.fail {
+        return Err(MatchSyncError::GcUnavailable("spy".into()));
+      }
+      Ok(MatchSalts {
+        match_id,
+        cluster_id: Some(1),
+        metadata_salt: Some(2),
+        replay_salt: Some(3),
+      })
+    }
+  }
+
+  #[derive(Default)]
+  struct SpySink {
+    posted: Mutex<Vec<u64>>,
+  }
+  impl SaltsSink for SpySink {
+    async fn post_salts(&self, salts: &[SaltPayload]) -> Result<(), MatchSyncError> {
+      let mut p = self.posted.lock().unwrap();
+      p.extend(salts.iter().map(|s| s.match_id));
+      Ok(())
+    }
+  }
+
+  // Sticky, like the real endpoint: it keeps listing the same ids until they are
+  // ingested, so run termination must come from the run-local `processed` set.
+  struct SpyBackfill {
+    account: Vec<u64>,
+    global: Vec<u64>,
+    calls: AtomicU64,
+  }
+  impl BackfillSource for SpyBackfill {
+    async fn to_fetch(&self, scope: FetchScope) -> Result<Vec<u64>, MatchSyncError> {
+      self.calls.fetch_add(1, Ordering::Relaxed);
+      match scope {
+        FetchScope::Account(_) => Ok(self.account.clone()),
+        FetchScope::Global => Ok(self.global.clone()),
+      }
+    }
+  }
+
+  #[derive(Default)]
+  struct MemPersistence {
+    now: i64,
+    quota_hits: Mutex<Vec<i64>>,
+    fetched: Mutex<Vec<u64>>,
+    complete: Mutex<bool>,
+    progress_events: AtomicU64,
+  }
+  impl SyncPersistence for MemPersistence {
+    fn now(&self) -> i64 {
+      self.now
+    }
+    fn load_quota(&self) -> QuotaWindow {
+      QuotaWindow::new(self.quota_hits.lock().unwrap().clone(), LIMIT, WINDOW)
+    }
+    fn save_quota(&self, quota: &QuotaWindow) {
+      *self.quota_hits.lock().unwrap() = quota.snapshot();
+    }
+    fn load_fetched(&self) -> Vec<u64> {
+      self.fetched.lock().unwrap().clone()
+    }
+    fn persist_fetched(&self, ids: &[u64]) {
+      *self.fetched.lock().unwrap() = ids.to_vec();
+    }
+    fn set_full_sync_complete(&self, complete: bool) {
+      *self.complete.lock().unwrap() = complete;
+    }
+    fn emit_progress(&self, _progress: &SyncProgress) {
+      self.progress_events.fetch_add(1, Ordering::Relaxed);
+    }
+  }
+
+  fn engine(
+    gc: SpyGc,
+    backfill: SpyBackfill,
+  ) -> SyncEngine<SpyAuth, SpyGc, SpySink, SpyBackfill, MemPersistence> {
+    SyncEngine::new(
+      SpyAuth::default(),
+      gc,
+      SpySink::default(),
+      backfill,
+      MemPersistence {
+        now: 1_000_000,
+        ..Default::default()
+      },
+      Arc::new(Throttle::new(Duration::ZERO)),
+      Arc::new(AtomicU64::new(0)),
+    )
+  }
+
+  fn active_config() -> MatchSyncConfig {
+    MatchSyncConfig {
+      enabled: true,
+      consent_accepted: true,
+      full_sync_complete: false,
+    }
+  }
+
+  #[tokio::test]
+  async fn off_by_default_does_nothing() {
+    let eng = engine(
+      SpyGc::default(),
+      SpyBackfill {
+        account: vec![1, 2, 3],
+        global: vec![9, 8, 7],
+        calls: AtomicU64::new(0),
+      },
+    );
+    let config = MatchSyncConfig::default();
+
+    // Monitoring: no-op, and no dependency is touched.
+    let out = eng.run_background_pass(&config).await.unwrap();
+    assert!(out.is_none());
+    // Full sync: refuses.
+    assert!(eng.run_full_sync_if_enabled(&config, &AtomicBool::new(false)).await.is_err());
+
+    assert_eq!(eng.auth.calls.load(Ordering::Relaxed), 0);
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+    assert_eq!(eng.backfill.calls.load(Ordering::Relaxed), 0);
+    assert_eq!(eng.counter.load(Ordering::Relaxed), 0);
+    assert!(eng.sink.posted.lock().unwrap().is_empty());
+  }
+
+  #[tokio::test]
+  async fn full_sync_fetches_posts_and_is_idempotent() {
+    let backfill = SpyBackfill {
+      account: vec![10, 11, 12],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(SpyGc::default(), backfill);
+    let cancel = AtomicBool::new(false);
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &cancel)
+      .await
+      .unwrap();
+    assert_eq!(p.fetched, 3);
+    assert_eq!(eng.counter.load(Ordering::Relaxed), 3);
+    assert_eq!(*eng.sink.posted.lock().unwrap(), vec![12, 11, 10]);
+
+    // Re-run: the same ids are already fetched -> nothing new is fetched/posted.
+    let p2 = eng
+      .run_full_sync_if_enabled(&active_config(), &cancel)
+      .await
+      .unwrap();
+    assert_eq!(p2.fetched, 0);
+    assert_eq!(eng.counter.load(Ordering::Relaxed), 3);
+    assert_eq!(eng.sink.posted.lock().unwrap().len(), 3);
+  }
+
+  #[tokio::test]
+  async fn hard_quota_caps_total_fetches_at_limit() {
+    // 200 distinct ids available, but the 24h cap must stop us at LIMIT.
+    let ids: Vec<u64> = (1..=200).collect();
+    let backfill = SpyBackfill {
+      account: ids,
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(SpyGc::default(), backfill);
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+      .await
+      .unwrap();
+    assert_eq!(p.fetched, LIMIT as u32);
+    assert!(p.quota_reached);
+    assert_eq!(eng.counter.load(Ordering::Relaxed), LIMIT as u64);
+    // Persisted quota is full, proving it survives to the next process.
+    assert_eq!(eng.persistence.quota_hits.lock().unwrap().len(), LIMIT);
+  }
+
+  #[tokio::test]
+  async fn monitoring_unions_history_and_to_fetch_then_backfills_within_quota() {
+    let backfill = SpyBackfill {
+      account: vec![100, 101],
+      global: vec![200, 201, 202, 203, 204, 205, 206],
+      calls: AtomicU64::new(0),
+    };
+    // GC history contributes 102 and a duplicate of 100.
+    let eng = engine(
+      SpyGc {
+        history: vec![102, 100],
+        ..Default::default()
+      },
+      backfill,
+    );
+
+    let p = eng
+      .run_background_pass(&active_config())
+      .await
+      .unwrap()
+      .unwrap();
+    // own = {102, 101, 100} after union + dedup, fetched newest first.
+    assert_eq!(p.fetched, 3);
+    // Backfill takes the rest of the global list (quota has plenty left).
+    assert_eq!(p.backfilled, 7);
+    let posted = eng.sink.posted.lock().unwrap();
+    assert_eq!(&posted[..3], &[102, 101, 100], "own matches, newest first, deduped");
+    assert_eq!(posted.len(), 10);
+  }
+
+  #[tokio::test]
+  async fn gc_failure_posts_nothing_and_spares_quota() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(
+      SpyGc {
+        fail: true,
+        ..Default::default()
+      },
+      backfill,
+    );
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &AtomicBool::new(false))
+      .await
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert!(eng.sink.posted.lock().unwrap().is_empty());
+    // A failed fetch got no data, so it must not spend quota.
+    assert!(eng.persistence.quota_hits.lock().unwrap().is_empty());
+  }
+
+  #[tokio::test]
+  async fn rate_limit_stops_the_pass_and_exhausts_quota_for_24h() {
+    let backfill = SpyBackfill {
+      account: vec![1, 2, 3],
+      global: vec![9],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(
+      SpyGc {
+        rate_limited: true,
+        ..Default::default()
+      },
+      backfill,
+    );
+
+    let p = eng
+      .run_background_pass(&active_config())
+      .await
+      .unwrap()
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert_eq!(p.backfilled, 0, "backed off before backfill");
+    assert!(p.rate_limited);
+    assert!(p.quota_reached);
+    assert_eq!(p.quota_remaining, 0);
+    // One history call + exactly one salts attempt, then stop.
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 2);
+    // The very first rate-limit hit burns the whole 24h bucket, not just this attempt.
+    assert_eq!(eng.persistence.quota_hits.lock().unwrap().len(), LIMIT);
+  }
+
+  #[tokio::test]
+  async fn cancel_stops_full_sync() {
+    let ids: Vec<u64> = (1..=50).collect();
+    let backfill = SpyBackfill {
+      account: ids,
+      global: vec![],
+      calls: AtomicU64::new(0),
+    };
+    let eng = engine(SpyGc::default(), backfill);
+    let cancel = Arc::new(AtomicBool::new(true));
+
+    let p = eng
+      .run_full_sync_if_enabled(&active_config(), &cancel)
+      .await
+      .unwrap();
+    assert_eq!(p.fetched, 0);
+    assert_eq!(eng.gc.calls.load(Ordering::Relaxed), 0);
+  }
+}

--- a/apps/desktop/src-tauri/src/match_sync/throttle.rs
+++ b/apps/desktop/src-tauri/src/match_sync/throttle.rs
@@ -1,0 +1,47 @@
+//! Async min-interval throttle: smooths GC requests into a steady trickle (no
+//! bursts), independent of the hard [`super::quota`] cap.
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+pub struct Throttle {
+  min_interval: Duration,
+  last: Mutex<Option<Instant>>,
+}
+
+impl Throttle {
+  pub fn new(min_interval: Duration) -> Self {
+    Self {
+      min_interval,
+      last: Mutex::new(None),
+    }
+  }
+
+  pub async fn acquire(&self) {
+    let mut last = self.last.lock().await;
+    if let Some(prev) = *last {
+      let elapsed = prev.elapsed();
+      if elapsed < self.min_interval {
+        tokio::time::sleep(self.min_interval - elapsed).await;
+      }
+    }
+    *last = Some(Instant::now());
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn spaces_calls_by_min_interval() {
+    let throttle = Throttle::new(Duration::from_millis(30));
+    let start = Instant::now();
+    // First is immediate; each subsequent one waits the interval (3 gaps of 30ms).
+    for _ in 0..4 {
+      throttle.acquire().await;
+    }
+    assert!(start.elapsed() >= Duration::from_millis(85));
+  }
+}

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -10,6 +10,7 @@ import { Outlet } from "react-router";
 import { FontInstallDialog } from "./components/downloads/font-install-dialog";
 import { ProgressProvider } from "./components/downloads/progress-indicator";
 import { GamePresenceRenderer } from "./components/game-presence-renderer";
+import { MatchSyncRenderer } from "./components/match-sync-renderer";
 import GlobalPluginRenderer from "./components/global-plugin-renderer";
 import { UpdateDialog } from "./components/layout/update-dialog";
 import { TauriAppWindowProvider } from "./components/layout/window-controls/window-context";
@@ -143,6 +144,7 @@ const App = () => {
                     </ThemeOverridesProvider>
                     <GlobalPluginRenderer />
                     <GamePresenceRenderer />
+                    <MatchSyncRenderer />
                     <UpdateDialog
                       downloadProgress={downloadProgress}
                       isDownloading={isDownloading}

--- a/apps/desktop/src/components/match-sync-renderer.tsx
+++ b/apps/desktop/src/components/match-sync-renderer.tsx
@@ -1,0 +1,15 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect } from "react";
+import logger from "@/lib/logger";
+
+// Re-applies the persisted monitoring flag on startup. A no-op unless the user
+// previously opted in, so the feature stays off by default.
+export const MatchSyncRenderer = () => {
+  useEffect(() => {
+    invoke("resume_match_sync_monitoring").catch((error) => {
+      logger.withError(error).warn("Failed to resume match-sync monitoring");
+    });
+  }, []);
+
+  return null;
+};

--- a/apps/desktop/src/components/match-sync-renderer.tsx
+++ b/apps/desktop/src/components/match-sync-renderer.tsx
@@ -2,8 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useEffect } from "react";
 import logger from "@/lib/logger";
 
-// Re-applies the persisted monitoring flag on startup. A no-op unless the user
-// previously opted in, so the feature stays off by default.
+// A no-op unless the user previously opted in.
 export const MatchSyncRenderer = () => {
   useEffect(() => {
     invoke("resume_match_sync_monitoring").catch((error) => {

--- a/apps/desktop/src/components/settings/match-sync-settings.tsx
+++ b/apps/desktop/src/components/settings/match-sync-settings.tsx
@@ -64,23 +64,26 @@ export const MatchSyncSettings = () => {
     if (!progress) {
       return;
     }
-    const justFinished = wasRunning.current && !progress.running;
-    wasRunning.current = progress.running;
+    const justFinished = wasRunning.current && !progress.progress.running;
+    wasRunning.current = progress.progress.running;
     if (!justFinished) {
       return;
     }
-    if (progress.rateLimited && progress.fetched === 0) {
+    const limit =
+      status?.accounts.find((a) => a.accountName === progress.accountName)
+        ?.quotaLimit ?? 40;
+    if (progress.progress.rateLimited && progress.progress.fetched === 0) {
       toast.warning(t("matchSync.fullSync.rateLimited"));
-    } else if (progress.quotaReached) {
+    } else if (progress.progress.quotaReached) {
       toast.info(
         t("matchSync.fullSync.doneQuota", {
-          fetched: progress.fetched,
-          limit: status?.quotaLimit ?? 40,
+          fetched: progress.progress.fetched,
+          limit,
         }),
       );
-    } else if (progress.fetched > 0) {
+    } else if (progress.progress.fetched > 0) {
       toast.success(
-        t("matchSync.fullSync.done", { fetched: progress.fetched }),
+        t("matchSync.fullSync.done", { fetched: progress.progress.fetched }),
       );
     }
   }, [progress, status, t]);
@@ -112,12 +115,18 @@ export const MatchSyncSettings = () => {
     );
   }
 
-  const running = Boolean(status.fullSyncRunning || progress?.running);
-  const quotaRemaining = progress?.quotaRemaining ?? status.quotaRemaining;
+  const running = Boolean(status.fullSyncRunning || progress?.progress.running);
+  const aboutLimit = status.accounts[0]?.quotaLimit ?? 40;
+  const allQuotaExhausted =
+    status.accounts.length === 0 ||
+    status.accounts.every((a) => a.quotaRemaining === 0);
+  const activeAccount = status.accounts.find(
+    (a) => a.accountName === progress?.accountName,
+  );
+  const activeLimit = activeAccount?.quotaLimit ?? 40;
+  const activeRemaining = progress?.progress.quotaRemaining ?? 0;
   const quotaUsedPct =
-    status.quotaLimit > 0
-      ? ((status.quotaLimit - quotaRemaining) / status.quotaLimit) * 100
-      : 0;
+    activeLimit > 0 ? ((activeLimit - activeRemaining) / activeLimit) * 100 : 0;
 
   const handleEnableChange = async (next: boolean) => {
     try {
@@ -157,7 +166,7 @@ export const MatchSyncSettings = () => {
       <div className='space-y-1 rounded-md border border-border/50 bg-muted/30 p-3 text-muted-foreground text-sm'>
         <p>{t("matchSync.about.reads")}</p>
         <p>{t("matchSync.about.sends")}</p>
-        <p>{t("matchSync.about.limit", { limit: status.quotaLimit })}</p>
+        <p>{t("matchSync.about.limit", { limit: aboutLimit })}</p>
         <p className='text-amber-500/90'>{t("matchSync.about.risk")}</p>
       </div>
 
@@ -184,11 +193,33 @@ export const MatchSyncSettings = () => {
 
       {status.enabled && (
         <>
-          <div className='text-muted-foreground text-sm'>
-            {t("matchSync.quota.remaining", {
-              remaining: quotaRemaining,
-              limit: status.quotaLimit,
-            })}
+          <div className='flex flex-col gap-1 text-muted-foreground text-sm'>
+            {status.accounts.length === 0 ? (
+              <p>{t("matchSync.noAccounts")}</p>
+            ) : (
+              status.accounts.map((account) => (
+                <p
+                  className={
+                    account.gcUnavailable
+                      ? "text-amber-500/90"
+                      : account.available
+                        ? undefined
+                        : "opacity-50"
+                  }
+                  key={account.steamId64}>
+                  {t("matchSync.quota.accountRemaining", {
+                    name: account.accountName,
+                    remaining: account.quotaRemaining,
+                    limit: account.quotaLimit,
+                  })}
+                  {account.gcUnavailable
+                    ? ` (${t("matchSync.quota.gcUnavailable")})`
+                    : account.available
+                      ? ""
+                      : ` (${t("matchSync.quota.unavailable")})`}
+                </p>
+              ))
+            )}
           </div>
 
           <div className='flex flex-col gap-2 border-border/30 border-t pt-4'>
@@ -210,7 +241,7 @@ export const MatchSyncSettings = () => {
                 </Button>
               ) : (
                 <Button
-                  disabled={quotaRemaining === 0}
+                  disabled={allQuotaExhausted}
                   onClick={handleStartFullSync}
                   size='sm'>
                   {t("matchSync.fullSync.button")}
@@ -220,16 +251,25 @@ export const MatchSyncSettings = () => {
             {running && (
               <div className='space-y-1'>
                 <Progress value={quotaUsedPct} />
+                {progress && (
+                  <p className='text-muted-foreground text-xs'>
+                    {t("matchSync.fullSync.accountProgress", {
+                      index: progress.accountIndex,
+                      total: progress.accountTotal,
+                      name: progress.accountName,
+                    })}
+                  </p>
+                )}
                 <p className='text-muted-foreground text-xs'>
                   {t("matchSync.fullSync.running", {
-                    fetched: progress?.fetched ?? 0,
-                    remaining: quotaRemaining,
-                    limit: status.quotaLimit,
+                    fetched: progress?.progress.fetched ?? 0,
+                    remaining: activeRemaining,
+                    limit: activeLimit,
                   })}
                 </p>
               </div>
             )}
-            {!running && quotaRemaining === 0 && (
+            {!running && allQuotaExhausted && status.accounts.length > 0 && (
               <p className='text-amber-500/90 text-xs'>
                 {t("matchSync.quota.reachedToday")}
               </p>

--- a/apps/desktop/src/components/settings/match-sync-settings.tsx
+++ b/apps/desktop/src/components/settings/match-sync-settings.tsx
@@ -1,0 +1,198 @@
+import { Button } from "@deadlock-mods/ui/components/button";
+import { Label } from "@deadlock-mods/ui/components/label";
+import { Progress } from "@deadlock-mods/ui/components/progress";
+import { Skeleton } from "@deadlock-mods/ui/components/skeleton";
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { Switch } from "@deadlock-mods/ui/components/switch";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useConfirm } from "@/components/providers/alert-dialog";
+import { useMatchSync } from "@/hooks/use-match-sync";
+
+const errorMessage = (error: unknown): string => {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+};
+
+export const MatchSyncSettings = () => {
+  const { t } = useTranslation();
+  const confirm = useConfirm();
+  const {
+    status,
+    isLoading,
+    progress,
+    setConsent,
+    setEnabled,
+    startFullSync,
+    cancelFullSync,
+  } = useMatchSync();
+
+  // Announce the outcome once a full sync finishes (esp. hitting the daily limit).
+  const wasRunning = useRef(false);
+  useEffect(() => {
+    if (!progress) {
+      return;
+    }
+    const justFinished = wasRunning.current && !progress.running;
+    wasRunning.current = progress.running;
+    if (!justFinished) {
+      return;
+    }
+    if (progress.rateLimited && progress.fetched === 0) {
+      toast.warning(t("matchSync.fullSync.rateLimited"));
+    } else if (progress.quotaReached) {
+      toast.info(
+        t("matchSync.fullSync.doneQuota", {
+          fetched: progress.fetched,
+          limit: status?.quotaLimit ?? 40,
+        }),
+      );
+    } else if (progress.fetched > 0) {
+      toast.success(
+        t("matchSync.fullSync.done", { fetched: progress.fetched }),
+      );
+    }
+  }, [progress, status, t]);
+
+  if (isLoading || !status) {
+    return (
+      <div className='flex flex-col gap-3'>
+        <Skeleton className='h-4 w-full' />
+        <Skeleton className='h-10 w-full' />
+      </div>
+    );
+  }
+
+  const running = Boolean(status.fullSyncRunning || progress?.running);
+  const quotaRemaining = progress?.quotaRemaining ?? status.quotaRemaining;
+  const quotaUsedPct =
+    status.quotaLimit > 0
+      ? ((status.quotaLimit - quotaRemaining) / status.quotaLimit) * 100
+      : 0;
+
+  const handleEnableChange = async (next: boolean) => {
+    try {
+      if (!next) {
+        await setEnabled.mutateAsync(false);
+        return;
+      }
+      if (!status.consentAccepted) {
+        const accepted = await confirm({
+          title: t("matchSync.consent.title"),
+          body: t("matchSync.consent.body"),
+          actionButton: t("matchSync.consent.accept"),
+          cancelButton: t("matchSync.consent.decline"),
+        });
+        if (!accepted) {
+          return;
+        }
+        await setConsent.mutateAsync(true);
+      }
+      await setEnabled.mutateAsync(true);
+    } catch (error) {
+      toast.error(errorMessage(error));
+    }
+  };
+
+  const handleStartFullSync = async () => {
+    try {
+      await startFullSync.mutateAsync();
+      toast.success(t("matchSync.fullSync.started"));
+    } catch (error) {
+      toast.error(errorMessage(error));
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='space-y-1 rounded-md border border-border/50 bg-muted/30 p-3 text-muted-foreground text-sm'>
+        <p>{t("matchSync.about.reads")}</p>
+        <p>{t("matchSync.about.sends")}</p>
+        <p>{t("matchSync.about.limit", { limit: status.quotaLimit })}</p>
+        <p className='text-amber-500/90'>{t("matchSync.about.risk")}</p>
+      </div>
+
+      <div className='flex items-center justify-between'>
+        <div className='space-y-1'>
+          <Label className='font-bold text-sm'>
+            {t("matchSync.enable.title")}
+          </Label>
+          <p className='text-muted-foreground text-sm'>
+            {t("matchSync.enable.description")}
+          </p>
+        </div>
+        <div className='flex items-center gap-2'>
+          <Switch
+            checked={status.enabled}
+            id='toggle-match-sync'
+            onCheckedChange={handleEnableChange}
+          />
+          <Label htmlFor='toggle-match-sync'>
+            {status.enabled ? t("status.enabled") : t("status.disabled")}
+          </Label>
+        </div>
+      </div>
+
+      {status.enabled && (
+        <>
+          <div className='text-muted-foreground text-sm'>
+            {t("matchSync.quota.remaining", {
+              remaining: quotaRemaining,
+              limit: status.quotaLimit,
+            })}
+          </div>
+
+          <div className='flex flex-col gap-2 border-border/30 border-t pt-4'>
+            <div className='flex items-center justify-between gap-4'>
+              <div className='space-y-1'>
+                <Label className='font-bold text-sm'>
+                  {t("matchSync.fullSync.title")}
+                </Label>
+                <p className='text-muted-foreground text-sm'>
+                  {t("matchSync.fullSync.description")}
+                </p>
+              </div>
+              {running ? (
+                <Button
+                  onClick={() => cancelFullSync.mutate()}
+                  size='sm'
+                  variant='outline'>
+                  {t("matchSync.fullSync.cancel")}
+                </Button>
+              ) : (
+                <Button
+                  disabled={quotaRemaining === 0}
+                  onClick={handleStartFullSync}
+                  size='sm'>
+                  {t("matchSync.fullSync.button")}
+                </Button>
+              )}
+            </div>
+            {running && (
+              <div className='space-y-1'>
+                <Progress value={quotaUsedPct} />
+                <p className='text-muted-foreground text-xs'>
+                  {t("matchSync.fullSync.running", {
+                    fetched: progress?.fetched ?? 0,
+                    remaining: quotaRemaining,
+                    limit: status.quotaLimit,
+                  })}
+                </p>
+              </div>
+            )}
+            {!running && quotaRemaining === 0 && (
+              <p className='text-amber-500/90 text-xs'>
+                {t("matchSync.quota.reachedToday")}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/settings/match-sync-settings.tsx
+++ b/apps/desktop/src/components/settings/match-sync-settings.tsx
@@ -10,6 +10,9 @@ import { useTranslation } from "react-i18next";
 import { useConfirm } from "@/components/providers/alert-dialog";
 import { useMatchSync } from "@/hooks/use-match-sync";
 
+// Mirrors the backend's FETCH_QUOTA_LIMIT; used only until `status.accounts` loads.
+const DEFAULT_QUOTA_LIMIT = 40;
+
 // Subcodes with a stable, localizable message. Anything else (network/store
 // errors) falls back to the raw backend message, since those wrap arbitrary
 // underlying error text that can't be meaningfully translated.
@@ -71,7 +74,7 @@ export const MatchSyncSettings = () => {
     }
     const limit =
       status?.accounts.find((a) => a.accountName === progress.accountName)
-        ?.quotaLimit ?? 40;
+        ?.quotaLimit ?? DEFAULT_QUOTA_LIMIT;
     if (progress.progress.rateLimited && progress.progress.fetched === 0) {
       toast.warning(t("matchSync.fullSync.rateLimited"));
     } else if (progress.progress.quotaReached) {
@@ -116,14 +119,14 @@ export const MatchSyncSettings = () => {
   }
 
   const running = Boolean(status.fullSyncRunning || progress?.progress.running);
-  const aboutLimit = status.accounts[0]?.quotaLimit ?? 40;
+  const aboutLimit = status.accounts[0]?.quotaLimit ?? DEFAULT_QUOTA_LIMIT;
   const allQuotaExhausted =
     status.accounts.length === 0 ||
     status.accounts.every((a) => a.quotaRemaining === 0);
   const activeAccount = status.accounts.find(
     (a) => a.accountName === progress?.accountName,
   );
-  const activeLimit = activeAccount?.quotaLimit ?? 40;
+  const activeLimit = activeAccount?.quotaLimit ?? DEFAULT_QUOTA_LIMIT;
   const activeRemaining = progress?.progress.quotaRemaining ?? 0;
   const quotaUsedPct =
     activeLimit > 0 ? ((activeLimit - activeRemaining) / activeLimit) * 100 : 0;
@@ -200,11 +203,7 @@ export const MatchSyncSettings = () => {
               status.accounts.map((account) => (
                 <p
                   className={
-                    account.gcUnavailable
-                      ? "text-amber-500/90"
-                      : account.available
-                        ? undefined
-                        : "opacity-50"
+                    account.gcUnavailable ? "text-amber-500/90" : undefined
                   }
                   key={account.steamId64}>
                   {t("matchSync.quota.accountRemaining", {
@@ -214,9 +213,7 @@ export const MatchSyncSettings = () => {
                   })}
                   {account.gcUnavailable
                     ? ` (${t("matchSync.quota.gcUnavailable")})`
-                    : account.available
-                      ? ""
-                      : ` (${t("matchSync.quota.unavailable")})`}
+                    : ""}
                 </p>
               ))
             )}

--- a/apps/desktop/src/components/settings/match-sync-settings.tsx
+++ b/apps/desktop/src/components/settings/match-sync-settings.tsx
@@ -4,12 +4,25 @@ import { Progress } from "@deadlock-mods/ui/components/progress";
 import { Skeleton } from "@deadlock-mods/ui/components/skeleton";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { Switch } from "@deadlock-mods/ui/components/switch";
+import type { TFunction } from "i18next";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useConfirm } from "@/components/providers/alert-dialog";
 import { useMatchSync } from "@/hooks/use-match-sync";
 
-const errorMessage = (error: unknown): string => {
+// Subcodes with a stable, localizable message. Anything else (network/store
+// errors) falls back to the raw backend message, since those wrap arbitrary
+// underlying error text that can't be meaningfully translated.
+const MATCH_SYNC_ERROR_KEYS: Record<string, string> = {
+  consentRequired: "matchSync.errors.consentRequired",
+  disabled: "matchSync.errors.disabled",
+  alreadyRunning: "matchSync.errors.alreadyRunning",
+  gcRateLimited: "matchSync.fullSync.rateLimited",
+  gameRunning: "matchSync.errors.gameRunning",
+  quotaReached: "matchSync.errors.quotaReached",
+};
+
+const rawErrorMessage = (error: unknown): string => {
   if (typeof error === "string") {
     return error;
   }
@@ -19,12 +32,25 @@ const errorMessage = (error: unknown): string => {
   return String(error);
 };
 
+const errorMessage = (error: unknown, t: TFunction): string => {
+  if (error && typeof error === "object" && "matchSyncKind" in error) {
+    const kind = (error as { matchSyncKind?: string }).matchSyncKind;
+    if (kind && kind in MATCH_SYNC_ERROR_KEYS) {
+      return t(MATCH_SYNC_ERROR_KEYS[kind] as string);
+    }
+  }
+  return rawErrorMessage(error);
+};
+
 export const MatchSyncSettings = () => {
   const { t } = useTranslation();
   const confirm = useConfirm();
   const {
     status,
     isLoading,
+    isError,
+    error,
+    refetch,
     progress,
     setConsent,
     setEnabled,
@@ -58,6 +84,24 @@ export const MatchSyncSettings = () => {
       );
     }
   }, [progress, status, t]);
+
+  if (isError) {
+    return (
+      <div className='flex flex-col gap-2'>
+        <p className='text-destructive text-sm'>
+          {t("matchSync.loadError.title")}
+          {error ? `: ${rawErrorMessage(error)}` : ""}
+        </p>
+        <Button
+          className='w-fit'
+          onClick={() => refetch()}
+          size='sm'
+          variant='outline'>
+          {t("matchSync.loadError.retry")}
+        </Button>
+      </div>
+    );
+  }
 
   if (isLoading || !status) {
     return (
@@ -95,7 +139,7 @@ export const MatchSyncSettings = () => {
       }
       await setEnabled.mutateAsync(true);
     } catch (error) {
-      toast.error(errorMessage(error));
+      toast.error(errorMessage(error, t));
     }
   };
 
@@ -104,7 +148,7 @@ export const MatchSyncSettings = () => {
       await startFullSync.mutateAsync();
       toast.success(t("matchSync.fullSync.started"));
     } catch (error) {
-      toast.error(errorMessage(error));
+      toast.error(errorMessage(error, t));
     }
   };
 

--- a/apps/desktop/src/hooks/use-match-sync.ts
+++ b/apps/desktop/src/hooks/use-match-sync.ts
@@ -1,0 +1,97 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useState } from "react";
+
+export type MatchSyncStatus = {
+  enabled: boolean;
+  consentAccepted: boolean;
+  fullSyncRunning: boolean;
+  fullSyncComplete: boolean;
+  quotaLimit: number;
+  quotaRemaining: number;
+  quotaResetAt: number | null;
+  sessionFetches: number;
+};
+
+export type MatchSyncProgress = {
+  fetched: number;
+  skipped: number;
+  backfilled: number;
+  running: boolean;
+  quotaReached: boolean;
+  rateLimited: boolean;
+  quotaRemaining: number;
+};
+
+const STATUS_KEY = ["match-sync-status"] as const;
+
+export const useMatchSync = () => {
+  const queryClient = useQueryClient();
+  const [progress, setProgress] = useState<MatchSyncProgress | null>(null);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: STATUS_KEY });
+
+  const status = useQuery({
+    queryKey: STATUS_KEY,
+    queryFn: (): Promise<MatchSyncStatus> =>
+      invoke<MatchSyncStatus>("get_match_sync_status"),
+    // Poll while a full sync is running so the quota/progress stay current.
+    refetchInterval: (query) =>
+      query.state.data?.fullSyncRunning ? 2000 : false,
+  });
+
+  useEffect(() => {
+    const unlistenProgress = listen<MatchSyncProgress>(
+      "match-sync-progress",
+      (event) => {
+        setProgress(event.payload);
+        if (!event.payload.running) {
+          invalidate();
+        }
+      },
+    );
+    const unlistenError = listen<{ message: string }>(
+      "match-sync-error",
+      (event) => {
+        toast.error(event.payload.message);
+        invalidate();
+      },
+    );
+    return () => {
+      unlistenProgress.then((fn) => fn());
+      unlistenError.then((fn) => fn());
+    };
+  }, []);
+
+  const setConsent = useMutation({
+    mutationFn: (accepted: boolean) =>
+      invoke("set_match_sync_consent", { accepted }),
+    onSuccess: invalidate,
+  });
+  const setEnabled = useMutation({
+    mutationFn: (enabled: boolean) =>
+      invoke("set_match_sync_enabled", { enabled }),
+    onSuccess: invalidate,
+  });
+  const startFullSync = useMutation({
+    mutationFn: () => invoke("start_full_match_sync"),
+    onSuccess: invalidate,
+  });
+  const cancelFullSync = useMutation({
+    mutationFn: () => invoke("cancel_full_match_sync"),
+    onSuccess: invalidate,
+  });
+
+  return {
+    status: status.data,
+    isLoading: status.isLoading,
+    progress,
+    setConsent,
+    setEnabled,
+    startFullSync,
+    cancelFullSync,
+  };
+};

--- a/apps/desktop/src/hooks/use-match-sync.ts
+++ b/apps/desktop/src/hooks/use-match-sync.ts
@@ -11,7 +11,6 @@ export type AccountStatus = {
   quotaRemaining: number;
   quotaResetAt: number | null;
   fullSyncComplete: boolean;
-  available: boolean;
   gcUnavailable: boolean;
 };
 

--- a/apps/desktop/src/hooks/use-match-sync.ts
+++ b/apps/desktop/src/hooks/use-match-sync.ts
@@ -88,6 +88,9 @@ export const useMatchSync = () => {
   return {
     status: status.data,
     isLoading: status.isLoading,
+    isError: status.isError,
+    error: status.error,
+    refetch: status.refetch,
     progress,
     setConsent,
     setEnabled,

--- a/apps/desktop/src/hooks/use-match-sync.ts
+++ b/apps/desktop/src/hooks/use-match-sync.ts
@@ -4,25 +4,38 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useState } from "react";
 
+export type AccountStatus = {
+  steamId64: number;
+  accountName: string;
+  quotaLimit: number;
+  quotaRemaining: number;
+  quotaResetAt: number | null;
+  fullSyncComplete: boolean;
+  available: boolean;
+  gcUnavailable: boolean;
+};
+
 export type MatchSyncStatus = {
   enabled: boolean;
   consentAccepted: boolean;
   fullSyncRunning: boolean;
-  fullSyncComplete: boolean;
-  quotaLimit: number;
-  quotaRemaining: number;
-  quotaResetAt: number | null;
   sessionFetches: number;
+  accounts: AccountStatus[];
 };
 
 export type MatchSyncProgress = {
-  fetched: number;
-  skipped: number;
-  backfilled: number;
-  running: boolean;
-  quotaReached: boolean;
-  rateLimited: boolean;
-  quotaRemaining: number;
+  accountName: string;
+  accountIndex: number;
+  accountTotal: number;
+  progress: {
+    fetched: number;
+    skipped: number;
+    backfilled: number;
+    running: boolean;
+    quotaReached: boolean;
+    rateLimited: boolean;
+    quotaRemaining: number;
+  };
 };
 
 const STATUS_KEY = ["match-sync-status"] as const;
@@ -48,7 +61,7 @@ export const useMatchSync = () => {
       "match-sync-progress",
       (event) => {
         setProgress(event.payload);
-        if (!event.payload.running) {
+        if (!event.payload.progress.running) {
           invalidate();
         }
       },

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1015,7 +1015,6 @@
     "quota": {
       "remaining": "{{remaining}} of {{limit}} match fetches left in the next 24 hours.",
       "accountRemaining": "{{name}}: {{remaining}}/{{limit}} today",
-      "unavailable": "currently unavailable",
       "gcUnavailable": "Can't connect to Deadlock, retrying in 24h",
       "reachedToday": "Daily limit reached. Come back tomorrow to fetch more."
     },

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1014,7 +1014,7 @@
     },
     "quota": {
       "remaining": "{{remaining}} of {{limit}} match fetches left in the next 24 hours.",
-      "accountRemaining": "{{name}}: {{remaining}}/{{limit}} today",
+      "accountRemaining": "{{name}}: {{remaining}}/{{limit}} left today",
       "gcUnavailable": "Can't connect to Deadlock, retrying in 24h",
       "reachedToday": "Daily limit reached. Come back tomorrow to fetch more."
     },

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1014,8 +1014,12 @@
     },
     "quota": {
       "remaining": "{{remaining}} of {{limit}} match fetches left in the next 24 hours.",
+      "accountRemaining": "{{name}}: {{remaining}}/{{limit}} today",
+      "unavailable": "currently unavailable",
+      "gcUnavailable": "Can't connect to Deadlock, retrying in 24h",
       "reachedToday": "Daily limit reached. Come back tomorrow to fetch more."
     },
+    "noAccounts": "No Steam accounts detected. Log into Steam to sync matches.",
     "loadError": {
       "title": "Could not load match data sharing status",
       "retry": "Retry"
@@ -1033,6 +1037,7 @@
       "button": "Fetch all my matches",
       "started": "Fetching your matches in the background.",
       "cancel": "Cancel",
+      "accountProgress": "Syncing account {{index}} of {{total}}: {{name}}",
       "running": "Fetched {{fetched}} so far. {{remaining}} of {{limit}} fetches left today.",
       "done": "Fetched {{fetched}} matches. You are all caught up.",
       "doneQuota": "Fetched {{fetched}} matches. You have reached today's limit of {{limit}}. Come back tomorrow to fetch the rest.",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -993,6 +993,41 @@
     "confirmRestore": "Are you sure you want to restore gameinfo.gi from backup? This will overwrite the current file.",
     "confirmReset": "Are you sure you want to reset gameinfo.gi to vanilla state? This will remove all mod configurations and restore the original game settings."
   },
+  "matchSync": {
+    "title": "Match Data Sharing",
+    "description": "Optionally fetch your own Deadlock match data from your machine and contribute it to deadlock-api trackers.",
+    "about": {
+      "reads": "Reads your local Steam login (the auto-login token already stored on this machine) to talk to Steam on your behalf.",
+      "sends": "Sends only match IDs and match salts to deadlock-api, never your token, password, or personal data.",
+      "limit": "Strictly rate-limited to {{limit}} match fetches per 24 hours, shared across everything below.",
+      "risk": "This acts through your real Steam account, so the risk is low but not zero. Enable it only if you accept that."
+    },
+    "enable": {
+      "title": "Enable match data sharing",
+      "description": "Nothing is read from your machine or sent anywhere until you turn this on."
+    },
+    "consent": {
+      "title": "Enable match data sharing?",
+      "body": "When enabled, this app reads your local Steam login token from this machine to fetch your own Deadlock matches through your account, then sends the resulting match IDs and salts to deadlock-api. Your token, password, and personal data are never sent or stored. All fetching is throttled and capped at 40 requests per 24 hours. Because it acts through your real Steam account, the risk is low but not zero. Do you want to continue?",
+      "accept": "I understand, enable it",
+      "decline": "Cancel"
+    },
+    "quota": {
+      "remaining": "{{remaining}} of {{limit}} match fetches left in the next 24 hours.",
+      "reachedToday": "Daily limit reached. Come back tomorrow to fetch more."
+    },
+    "fullSync": {
+      "title": "Fetch all my matches",
+      "description": "Walk your match history once and send everything that trackers are missing. Throttled, resumable, and safe to re-run.",
+      "button": "Fetch all my matches",
+      "started": "Fetching your matches in the background.",
+      "cancel": "Cancel",
+      "running": "Fetched {{fetched}} so far. {{remaining}} of {{limit}} fetches left today.",
+      "done": "Fetched {{fetched}} matches. You are all caught up.",
+      "doneQuota": "Fetched {{fetched}} matches. You have reached today's limit of {{limit}}. Come back tomorrow to fetch the rest.",
+      "rateLimited": "Steam is rate-limiting your account right now. Try again later."
+    }
+  },
   "privacy": {
     "title": "Privacy & Content",
     "description": "Control how NSFW (Not Safe For Work) content is displayed and filtered.",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1016,6 +1016,17 @@
       "remaining": "{{remaining}} of {{limit}} match fetches left in the next 24 hours.",
       "reachedToday": "Daily limit reached. Come back tomorrow to fetch more."
     },
+    "loadError": {
+      "title": "Could not load match data sharing status",
+      "retry": "Retry"
+    },
+    "errors": {
+      "consentRequired": "You need to accept the consent screen first.",
+      "disabled": "Match data sharing is turned off.",
+      "alreadyRunning": "A sync is already in progress.",
+      "gameRunning": "Close Deadlock first, then try again.",
+      "quotaReached": "You've reached today's fetch limit. Come back tomorrow."
+    },
     "fullSync": {
       "title": "Fetch all my matches",
       "description": "Walk your match history once and send everything that trackers are missing. Throttled, resumable, and safe to re-run.",

--- a/apps/desktop/src/pages/settings.tsx
+++ b/apps/desktop/src/pages/settings.tsx
@@ -65,6 +65,7 @@ import { LinuxGpuToggle } from "@/components/settings/linux-gpu-toggle";
 import { LoggingSettings } from "@/components/settings/logging-settings";
 import OccultGeometrySettings from "@/components/settings/occult-geometry-settings";
 import { PluginList } from "@/components/settings/plugin-list";
+import { MatchSyncSettings } from "@/components/settings/match-sync-settings";
 import PrivacySettings from "@/components/settings/privacy-settings";
 import { ProxySettings } from "@/components/settings/proxy-settings";
 import Section, { SectionSkeleton } from "@/components/settings/section";
@@ -893,6 +894,12 @@ const CustomSettings = ({ value }: { value?: string }) => {
               <div className='grid grid-cols-1 gap-4'>
                 <PrivacySettings />
               </div>
+            </Section>
+
+            <Section
+              description={t("matchSync.description")}
+              title={t("matchSync.title")}>
+              <MatchSyncSettings />
             </Section>
           </TabsContent>
 

--- a/packages/deadlock-discord-presence/src-rs/lib.rs
+++ b/packages/deadlock-discord-presence/src-rs/lib.rs
@@ -14,4 +14,7 @@ pub use hero_data::{HeroDataStore, HeroInfo};
 pub use log_parser::LogParser;
 pub use presence_builder::build_presence;
 pub use state::{GamePhase, GameState, MatchMode};
-pub use watcher::{GameExitCallback, GamePresenceWatcher, PresencePhase, PresenceStatusCallback};
+pub use watcher::{
+    GameExitCallback, GamePresenceWatcher, PresencePhase, PresenceStatusCallback,
+    console_log_path, is_game_running,
+};

--- a/packages/deadlock-discord-presence/src-rs/lib.rs
+++ b/packages/deadlock-discord-presence/src-rs/lib.rs
@@ -14,4 +14,4 @@ pub use hero_data::{HeroDataStore, HeroInfo};
 pub use log_parser::LogParser;
 pub use presence_builder::build_presence;
 pub use state::{GamePhase, GameState, MatchMode};
-pub use watcher::{GamePresenceWatcher, PresencePhase, PresenceStatusCallback};
+pub use watcher::{GameExitCallback, GamePresenceWatcher, PresencePhase, PresenceStatusCallback};

--- a/packages/deadlock-discord-presence/src-rs/watcher.rs
+++ b/packages/deadlock-discord-presence/src-rs/watcher.rs
@@ -27,6 +27,7 @@ pub enum PresencePhase {
 }
 
 pub type PresenceStatusCallback = Arc<dyn Fn(PresencePhase) + Send + Sync>;
+pub type GameExitCallback = Arc<dyn Fn() + Send + Sync>;
 
 pub struct GamePresenceWatcher {
     game_path: PathBuf,
@@ -35,6 +36,10 @@ pub struct GamePresenceWatcher {
     discord_presence: DiscordPresenceState,
     status_callback: Option<PresenceStatusCallback>,
     presence_config: PresenceBuildConfig,
+    // When false, poll game state only (no Discord activity) — lets match-sync reuse
+    // this watcher for game-exit detection without turning on Rich Presence.
+    presence_enabled: bool,
+    on_game_exit: Option<GameExitCallback>,
 }
 
 impl GamePresenceWatcher {
@@ -53,7 +58,19 @@ impl GamePresenceWatcher {
             discord_presence,
             status_callback,
             presence_config,
+            presence_enabled: true,
+            on_game_exit: None,
         }
+    }
+
+    pub fn with_presence_enabled(mut self, enabled: bool) -> Self {
+        self.presence_enabled = enabled;
+        self
+    }
+
+    pub fn with_game_exit_callback(mut self, callback: GameExitCallback) -> Self {
+        self.on_game_exit = Some(callback);
+        self
     }
 
     pub async fn run(&self) {
@@ -92,27 +109,33 @@ impl GamePresenceWatcher {
                 );
                 last_offset = file_size(&self.console_log_path);
 
-                update_presence(
-                    &self.discord_presence,
-                    self.status_callback.as_ref(),
-                    &state,
-                    &hero_store,
-                    &self.presence_config,
-                    &mut last_presence_hash,
-                )
-                .await;
-                last_presence_update = std::time::Instant::now();
+                if self.presence_enabled {
+                    update_presence(
+                        &self.discord_presence,
+                        self.status_callback.as_ref(),
+                        &state,
+                        &hero_store,
+                        &self.presence_config,
+                        &mut last_presence_hash,
+                    )
+                    .await;
+                    last_presence_update = std::time::Instant::now();
+                }
             } else if !game_running {
                 if game_was_running {
                     log::info!("[GamePresence] Deadlock closed");
                     game_was_running = false;
                     parser.reset_tracking();
                     state.reset();
-                    if let Err(error) = self.discord_presence.disconnect().await
+                    if self.presence_enabled
+                        && let Err(error) = self.discord_presence.disconnect().await
                     {
                         log::debug!("[GamePresence] Discord disconnect skipped: {error}");
                     }
                     self.emit_phase(PresencePhase::Waiting);
+                    if let Some(callback) = &self.on_game_exit {
+                        callback();
+                    }
                     last_presence_hash = None;
                     last_offset = 0;
                 }
@@ -142,8 +165,10 @@ impl GamePresenceWatcher {
                 }
             }
 
-            if changed
-                || last_presence_update.elapsed().as_millis() > PRESENCE_UPDATE_INTERVAL_MS as u128
+            if self.presence_enabled
+                && (changed
+                    || last_presence_update.elapsed().as_millis()
+                        > PRESENCE_UPDATE_INTERVAL_MS as u128)
             {
                 update_presence(
                     &self.discord_presence,
@@ -160,7 +185,8 @@ impl GamePresenceWatcher {
             tokio::time::sleep(tokio::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
         }
 
-        if let Err(error) = self.discord_presence.disconnect().await
+        if self.presence_enabled
+            && let Err(error) = self.discord_presence.disconnect().await
         {
             log::debug!("[GamePresence] Discord disconnect skipped: {error}");
         }

--- a/packages/deadlock-discord-presence/src-rs/watcher.rs
+++ b/packages/deadlock-discord-presence/src-rs/watcher.rs
@@ -254,7 +254,13 @@ fn emit_phase(status_callback: Option<&PresenceStatusCallback>, phase: PresenceP
     }
 }
 
-fn is_game_running(sys: &mut sysinfo::System, console_log_path: &Path) -> bool {
+/// The `console.log` path this watcher itself checks, derived from the install dir.
+pub fn console_log_path(game_path: &Path) -> PathBuf {
+    game_path.join("game").join("citadel").join("console.log")
+}
+
+/// Exposed so other consumers can check without duplicating the process-name list.
+pub fn is_game_running(sys: &mut sysinfo::System, console_log_path: &Path) -> bool {
     sys.refresh_processes_specifics(
         sysinfo::ProcessesToUpdate::All,
         true,


### PR DESCRIPTION
## Summary

Lets users opt in to fetching their own Deadlock match history from their own machine, through their own Steam login, and contribute the results (and a small amount of globally-missing matches) to deadlock-api trackers. **Off by default** — no local file is read, no Steam connection is made, and no request leaves the machine until the user explicitly opts in through a consent screen.

- **Local Steam session recovery**: reads the `local.vdf` ConnectCache blob and decrypts the refresh-token JWT (AES on Linux/macOS, DPAPI on Windows), matching Steam's own recipe. No password prompt, no process-memory access.
- **Steam GC client** (`steam-vent` + `valveprotos`): fetches match history (`GetMatchHistory`) and per-match salts (`GetMatchMetaData`) through the user's own account — never through deadlock-api's own server-side salt/metadata endpoints.
- **Persisted rolling 24h fetch quota**: a hard cap on GC salt fetches, shared across full sync, background fetching, and backfill, and it survives app restarts. On a Steam GC rate-limit response, the quota is treated as fully spent so the client backs off for the rest of the window instead of retrying against an active limit.
- **One-time "fetch all my matches"**: paginated, resumable, idempotent, cancellable, with live progress.
- **Background worker**: while enabled, periodically fetches the user's new matches and opportunistically backfills globally-missing matches (from `/v1/matches/to-fetch`) within the same daily quota. Closing Deadlock also triggers an immediate check, reusing the existing `GamePresenceWatcher` (extended with an optional detect-only mode + a game-exit callback, rather than a second watcher).
- Every fetched salt is POSTed to the same `POST /v1/matches/salts` endpoint the existing httpcache scraper already uses.
- **Settings UI**: consent dialog explaining exactly what's read/sent, an enable toggle, and a full-sync button with progress + completion/rate-limit toasts. All reversible — disabling immediately halts monitoring.

## Test plan

- [x] `cargo test` — 15 unit tests covering: off-by-default (no auth/GC/network touched), the persisted 24h quota (caps at the limit, survives restarts, frees up as entries age out), rate-limit handling (backs off and marks quota spent), idempotent re-runs, GC-history + to-fetch union/dedup, backfill capped by remaining quota, and cancellation.
- [x] `cargo check` clean, no warnings in the new module.
- [x] `pnpm check-types` / `oxlint` / `oxfmt` clean on all changed frontend files.
- [x] Manually verified end-to-end against a real account on Linux: local token recovery, CM login, GC handshake, match-history + salt fetches, and posting to `deadlock-api` all confirmed working; also verified the rate-limit backoff path against a live Steam GC rate-limit response.
- [x] Windows DPAPI path is implemented per Steam's documented recipe but not yet manually verified on Windows (no Windows machine available in this environment).

## Notes for reviewers

- The Steam GC message shapes were cross-checked against `deadlock-api/tools` (`history-fetcher`, `salt-scraper`) and `sv-proxy` for the exact protobuf field names/message kinds.
- The daily fetch limit is currently `40` (see `apps/desktop/src-tauri/src/match_sync/model.rs`) — happy to adjust based on what the team is comfortable with.

AI Assistance: Implemented with Claude Code end-to-end (design, Rust/TS implementation, tests, and live manual testing of the Steam GC integration against a real account on Linux).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Desktop (apps/desktop)**
  - Added an **opt-in, consent-gated “Match Sync”** feature to the Tauri desktop app (default **off**). Until consent is accepted and syncing is enabled, the app performs **no local Steam session reads, no Steam/GC connections, and no network requests**.
  - Implemented Tauri IPC command handlers for match-sync lifecycle: **status**, **set consent**, **enable/disable**, **start full sync**, **cancel full sync**, and **resume background monitoring** after restart.
  - Added UI and state plumbing:
    - `MatchSyncSettings` settings panel (enable/consent dialog, full-sync start/cancel, progress, quota/rate-limit feedback, error-to-UI mapping via `matchSyncKind`).
    - `MatchSyncRenderer` bootstraps monitoring resumption.
    - `useMatchSync` hook polls status and listens for `match-sync-progress` / `match-sync-error` events.
  - Added match-sync backend logic (new `apps/desktop/src-tauri/src/match_sync/*` module):
    - **One-time “fetch all my matches”** flow with progress, cancellation, and **resumability**.
    - **Background worker** that periodically fetches new matches and **backfills missing matches**.
    - A persisted **rolling 24-hour fetch quota** shared across full sync, background passes, and backfill.
    - Disabling the feature **cancels monitoring immediately** and prevents further scheduling.
  - Steam integration:
    - Local Steam session recovery from Steam VDF files (`loginusers.vdf` and `local.vdf`) to decrypt remembered `ConnectCache` entries into refresh-token JWTs (AES on non-Windows, DPAPI on Windows).
    - Added a Steam **Game Coordinator (GC) match client** to fetch match history and per-match metadata (“salts”), including GC unavailability/rate-limit handling and corresponding persisted backoff.
  - Cross-cutting refactor/security-by-design:
    - Centralized sync orchestration via a generic `SyncEngine`, refactoring shared quota/request/idempotency logic across full-sync and background paths.
    - Updated the Discord presence integration control in `game_presence.rs` to use a **restart-safe watcher controller** that supports detect-only/monitoring modes and supports immediate match-sync triggering on game exit (see shared package below).
    - Expanded `crate::errors::Error` serialization so match-sync failures expose a stable, machine-readable **`matchSyncKind`** to the UI.

  - Dependency changes (`apps/desktop/src-tauri/Cargo.toml`):
    - Added production deps for crypto/parsing and Steam GC/session recovery support (e.g., AES/crypto helpers, `keyvalues-parser`, `valveprotos` + `steam-vent` with GC-related features).
    - Added Windows-only dependency on the `windows` crate for DPAPI access.

- **Shared/FFI boundary (packages/deadlock-discord-presence)**
  - Extended `GamePresenceWatcher` with:
    - ability to **disable Rich Presence activity** while still monitoring game state (used for match-sync “monitoring/detect-only” behavior),
    - optional **game-exit callback** (`GameExitCallback`) so the desktop app can kick off an immediate match-sync background pass when the game exits,
    - public helper exports (`console_log_path`, `is_game_running`).

- **Security / documentation**
  - Updated `SECURITY.md` to add **`deadlock-api.com`** to the trusted network access list.

- **Datastore / migrations**
  - No database migrations are indicated; persistence is handled via a dedicated Tauri store (`match-sync.json`) for per-account settings, quota hits, fetched-id history, full-sync completion, and GC backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->