### PR TITLE
fix/mod-loadorder: validate VPK reorder mappings

### DIFF
--- a/.changeset/calm-owls-repair.md
+++ b/.changeset/calm-owls-repair.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix unreliable mod load order saves

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -10,7 +10,7 @@ use crate::mod_manager::{
   mod_repository::{Mod, ModRepository},
   steam_manager::SteamManager,
   vpk_manager::{MissingVpkPolicy, VpkManager},
-  vpk_manifest::ProfileVpkManifest,
+  vpk_manifest::{ProfileVpkManifest, ProfileVpkManifestEntry},
 };
 use log;
 use std::{
@@ -134,6 +134,75 @@ impl ModManager {
           .unwrap_or_else(|| vpk.clone())
       })
       .collect()
+  }
+
+  fn existing_vpk_filenames(addons_path: &Path, vpks: &[String]) -> Vec<String> {
+    Self::vpk_filenames(vpks)
+      .into_iter()
+      .filter(|vpk| addons_path.join(vpk).exists())
+      .collect()
+  }
+
+  fn resolve_reorder_vpks(
+    addons_path: &Path,
+    manifest_vpks: &[String],
+    fallback_vpks: &[String],
+  ) -> Vec<String> {
+    let manifest_filenames = Self::vpk_filenames(manifest_vpks);
+    let existing_manifest_vpks = Self::existing_vpk_filenames(addons_path, &manifest_filenames);
+
+    if !manifest_filenames.is_empty() && existing_manifest_vpks.len() == manifest_filenames.len() {
+      return manifest_filenames;
+    }
+
+    let fallback_filenames = Self::vpk_filenames(fallback_vpks);
+    let existing_fallback_vpks = Self::existing_vpk_filenames(addons_path, &fallback_filenames);
+
+    if !existing_fallback_vpks.is_empty()
+      && existing_fallback_vpks.len() == fallback_filenames.len()
+    {
+      return fallback_filenames;
+    }
+
+    if !existing_manifest_vpks.is_empty() {
+      return existing_manifest_vpks;
+    }
+
+    existing_fallback_vpks
+  }
+
+  fn reconcile_manifest_entry_for_reorder(
+    addons_path: &Path,
+    entry: &mut ProfileVpkManifestEntry,
+    fallback_vpks: &[String],
+  ) -> bool {
+    let resolved_vpks = Self::resolve_reorder_vpks(addons_path, &entry.current_vpks, fallback_vpks);
+    let can_enable_from_fallback = !fallback_vpks.is_empty();
+    let mut changed = false;
+
+    if entry.current_vpks != resolved_vpks {
+      entry.current_vpks = resolved_vpks;
+      changed = true;
+    }
+
+    if entry.current_vpks.is_empty() {
+      if entry.enabled {
+        entry.enabled = false;
+        changed = true;
+      }
+    } else if entry.enabled || can_enable_from_fallback {
+      if !entry.enabled {
+        entry.enabled = true;
+        changed = true;
+      }
+
+      if !entry.disabled_vpks.is_empty() {
+        entry.disabled_vpks.clear();
+        changed = true;
+      }
+    }
+
+    changed
   }
 
   pub fn stop_game(&mut self) -> Result<(), Error> {
@@ -453,18 +522,19 @@ impl ModManager {
     log::info!("Reordering all mods based on install order for profile: {profile_folder:?}");
 
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-    let mut ordered_manifest_entries: Vec<(String, u32, Vec<String>)> = manifest
-      .mods
-      .iter()
-      .filter(|(_, entry)| entry.enabled && !entry.current_vpks.is_empty())
-      .map(|(mod_id, entry)| {
-        (
+    let mut manifest_changed = false;
+    let mut ordered_manifest_entries = Vec::new();
+    for (mod_id, entry) in &mut manifest.mods {
+      manifest_changed |= Self::reconcile_manifest_entry_for_reorder(&addons_path, entry, &[]);
+
+      if entry.enabled && !entry.current_vpks.is_empty() {
+        ordered_manifest_entries.push((
           mod_id.clone(),
           entry.order.unwrap_or(UNORDERED_FALLBACK_ORDER),
           entry.current_vpks.clone(),
-        )
-      })
-      .collect();
+        ));
+      }
+    }
     ordered_manifest_entries.sort_by_key(|(_, order, _)| *order);
 
     let mod_vpk_mapping: Vec<(String, Vec<String>)> = ordered_manifest_entries
@@ -473,6 +543,9 @@ impl ModManager {
       .collect();
 
     if mod_vpk_mapping.is_empty() {
+      if manifest_changed {
+        manifest.save(&addons_path)?;
+      }
       log::info!("No enabled manifest VPKs need reordering");
       return Ok(());
     }
@@ -535,18 +608,14 @@ impl ModManager {
     let mut manifest_changed = false;
     for (remote_id, vpk_files, order) in sorted_data {
       let vpk_files = Self::vpk_filenames(&vpk_files);
-      let was_known = manifest.mods.contains_key(&remote_id);
       let entry = manifest.mods.entry(remote_id.clone()).or_default();
       if entry.order != Some(order) {
         entry.order = Some(order);
         manifest_changed = true;
       }
 
-      if !was_known && !vpk_files.is_empty() {
-        entry.enabled = true;
-        entry.current_vpks = vpk_files;
-        manifest_changed = true;
-      }
+      manifest_changed |=
+        Self::reconcile_manifest_entry_for_reorder(&addons_path, entry, &vpk_files);
 
       if entry.enabled && !entry.current_vpks.is_empty() {
         mod_vpk_mapping.push((remote_id, entry.current_vpks.clone()));
@@ -613,6 +682,7 @@ impl ModManager {
           entry.order = Some(new_order);
           manifest_changed = true;
         }
+        manifest_changed |= Self::reconcile_manifest_entry_for_reorder(&addons_path, entry, &[]);
         if entry.enabled && !entry.current_vpks.is_empty() {
           mod_vpk_mapping.push((mod_id.clone(), entry.current_vpks.clone()));
         }
@@ -1028,7 +1098,14 @@ fn dir_size(path: &std::path::Path) -> u64 {
 
 #[cfg(test)]
 mod tests {
+  use crate::mod_manager::vpk_manifest::ProfileVpkManifestEntry;
+
   use super::ModManager;
+  use std::fs;
+
+  fn write_vpk(addons_path: &std::path::Path, name: &str) {
+    fs::write(addons_path.join(name), b"test vpk").unwrap();
+  }
 
   #[test]
   fn profile_folder_validation_rejects_path_escape_components() {
@@ -1043,5 +1120,67 @@ mod tests {
 
     #[cfg(windows)]
     assert!(!ModManager::is_safe_profile_folder("C:\\tmp\\profile_123"));
+  }
+
+  #[test]
+  fn reorder_vpk_resolution_prefers_valid_manifest_names() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "pak01_dir.vpk");
+    write_vpk(temp.path(), "pak02_dir.vpk");
+
+    let resolved = ModManager::resolve_reorder_vpks(
+      temp.path(),
+      &["pak01_dir.vpk".to_string()],
+      &["pak02_dir.vpk".to_string()],
+    );
+
+    assert_eq!(resolved, vec!["pak01_dir.vpk".to_string()]);
+  }
+
+  #[test]
+  fn reorder_vpk_resolution_uses_frontend_names_when_manifest_is_stale() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "pak02_dir.vpk");
+
+    let resolved = ModManager::resolve_reorder_vpks(
+      temp.path(),
+      &["pak01_dir.vpk".to_string()],
+      &["pak02_dir.vpk".to_string()],
+    );
+
+    assert_eq!(resolved, vec!["pak02_dir.vpk".to_string()]);
+  }
+
+  #[test]
+  fn reorder_manifest_reconciliation_disables_entries_without_existing_vpks() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut entry = ProfileVpkManifestEntry {
+      enabled: true,
+      current_vpks: vec!["pak01_dir.vpk".to_string()],
+      ..Default::default()
+    };
+
+    let changed = ModManager::reconcile_manifest_entry_for_reorder(temp.path(), &mut entry, &[]);
+
+    assert!(changed);
+    assert!(!entry.enabled);
+    assert!(entry.current_vpks.is_empty());
+  }
+
+  #[test]
+  fn reorder_manifest_reconciliation_does_not_enable_disabled_entries_without_fallback() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "pak01_dir.vpk");
+    let mut entry = ProfileVpkManifestEntry {
+      enabled: false,
+      current_vpks: vec!["pak01_dir.vpk".to_string()],
+      ..Default::default()
+    };
+
+    let changed = ModManager::reconcile_manifest_entry_for_reorder(temp.path(), &mut entry, &[]);
+
+    assert!(!changed);
+    assert!(!entry.enabled);
+    assert_eq!(entry.current_vpks, vec!["pak01_dir.vpk".to_string()]);
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -3,6 +3,7 @@ use crate::mod_manager::filesystem_helper::FileSystemHelper;
 use crate::mod_manager::fs_retry;
 use log;
 use regex::Regex;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::sync::LazyLock;
@@ -69,6 +70,14 @@ impl VpkManager {
     }
 
     log::info!("Starting VPK reordering for {} mods", mod_vpk_mapping.len());
+
+    let duplicate_assignments = Self::duplicate_reorder_vpk_assignments(mod_vpk_mapping);
+    if !duplicate_assignments.is_empty() {
+      return Err(Error::ModInvalid(format!(
+        "Cannot reorder mods because VPK files are assigned to multiple mods: {}",
+        duplicate_assignments.join("; ")
+      )));
+    }
 
     let mut missing_vpks = Vec::new();
     for (mod_id, old_vpk_names) in mod_vpk_mapping {
@@ -177,6 +186,30 @@ impl VpkManager {
 
     log::info!("VPK reordering completed successfully");
     Ok(updated_mappings)
+  }
+
+  fn duplicate_reorder_vpk_assignments(mod_vpk_mapping: &[(String, Vec<String>)]) -> Vec<String> {
+    let mut owners_by_vpk: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for (mod_id, vpk_names) in mod_vpk_mapping {
+      for vpk_name in vpk_names {
+        owners_by_vpk
+          .entry(Self::vpk_filename(vpk_name))
+          .or_default()
+          .push(mod_id.clone());
+      }
+    }
+
+    owners_by_vpk
+      .into_iter()
+      .filter_map(|(vpk_name, owners)| {
+        if owners.len() > 1 {
+          Some(format!("{vpk_name} -> {}", owners.join(", ")))
+        } else {
+          None
+        }
+      })
+      .collect()
   }
 
   /// Pre-check: verify existing VPK files can be opened for write before deleting any.
@@ -914,6 +947,30 @@ mod tests {
     );
     assert!(addons_path.join("local-abc-123_original.vpk").exists());
     assert!(!addons_path.join("pak02_dir.vpk").exists());
+  }
+
+  #[test]
+  fn reorder_errors_before_mutating_when_vpk_is_assigned_to_multiple_mods() {
+    let temp = tempfile::tempdir().unwrap();
+    let addons_path = temp.path();
+    write_vpk(addons_path, "pak01_dir.vpk");
+
+    let manager = VpkManager::new();
+    let err = manager
+      .reorder_vpks(
+        &[
+          ("first".to_string(), vec!["pak01_dir.vpk".to_string()]),
+          ("second".to_string(), vec!["pak01_dir.vpk".to_string()]),
+        ],
+        addons_path,
+      )
+      .unwrap_err();
+
+    assert!(err.to_string().contains(
+      "Cannot reorder mods because VPK files are assigned to multiple mods: pak01_dir.vpk -> first, second"
+    ));
+    assert!(addons_path.join("pak01_dir.vpk").exists());
+    assert!(!addons_path.join("temp_reorder").exists());
   }
 
   #[test]


### PR DESCRIPTION
- Reconcile manifest entries against on-disk VPKs before reordering
- Persist manifest changes even when no reorder is needed
- Reject duplicate VPK assignments across multiple mods

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #547

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: [codex], Used for: [bughunting and testing]

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions





Build: 
        Info File src-tauri\src\mod_manager\manager.rs changed. Rebuilding application...
     Running DevCommand (`cargo  run --no-default-features --features tauri-wry --color always --`)
   Compiling deadlock-mod-manager v1.0.0 (C:\Users\%username%\dev\deadlock-mod-manager\apps\desktop\src-tauri)

warning: `deadlock-mod-manager` (lib) generated 5 warnings
warning: unexpected `cfg` condition value: `cef`
   --> src-tauri\src\main.rs:121:12
    |
121 | #[cfg_attr(feature = "cef", tauri::cef_entry_point)]
    |            ^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `default` and `tauri-wry`
    = help: consider adding `cef` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

warning: `deadlock-mod-manager` (bin "deadlock-mod-manager") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 34.71s
     Running `C:\Users\%username%\dev\deadlock-mod-manager\apps\desktop\target\debug\deadlock-mod-manager.exe`
[MCP][ELEMENT_PICKER][INFO] Element picker event listeners registered
[MCP][PLUGIN][INFO] MCP Bridge plugin initialized for 'Deadlock Mod Manager' (dev.stormix.deadlock-mod-manager) on 127.0.0.1:9223
[MCP][WS_SERVER][INFO] WebSocket server listening on: 127.0.0.1:9223
[2026-07-04][20:43:04][desktop_lib::deep_link][INFO] [DeepLink] Registering deep link protocols...
[2026-07-04][20:43:05][desktop_lib::mod_manager::steam_manager][INFO] Steam path from steamlocate: "C:\\Program Files (x86)\\Steam"
[2026-07-04][20:43:05][desktop_lib::mod_manager::steam_manager][INFO] Game path found: "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Deadlock"
[2026-07-04][20:43:05][desktop_lib][INFO] [App] Setup completed, starting application...






Loadorder fix:
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Starting VPK reordering for 41 mods
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Created temporary directory: "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Deadlock\\game\\citadel\\addons\\temp_reorder"
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak02_dir.vpk -> pak01_dir.vpk for mod 626469
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak01_dir.vpk -> pak02_dir.vpk for mod 650634
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak03_dir.vpk -> pak03_dir.vpk for mod 655426
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak04_dir.vpk -> pak04_dir.vpk for mod 654172
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak05_dir.vpk -> pak05_dir.vpk for mod 619847
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak06_dir.vpk -> pak06_dir.vpk for mod 653836
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak07_dir.vpk -> pak07_dir.vpk for mod 664027
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak08_dir.vpk -> pak08_dir.vpk for mod 667319
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak09_dir.vpk -> pak09_dir.vpk for mod 625517
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak10_dir.vpk -> pak10_dir.vpk for mod 657755
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak11_dir.vpk -> pak11_dir.vpk for mod 623644
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak12_dir.vpk -> pak12_dir.vpk for mod 563116
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak13_dir.vpk -> pak13_dir.vpk for mod 655721
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak14_dir.vpk -> pak14_dir.vpk for mod 633177
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak15_dir.vpk -> pak15_dir.vpk for mod 659625
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak16_dir.vpk -> pak16_dir.vpk for mod 639529
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak17_dir.vpk -> pak17_dir.vpk for mod 654594
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak18_dir.vpk -> pak18_dir.vpk for mod 665094
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak19_dir.vpk -> pak19_dir.vpk for mod 661996
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak20_dir.vpk -> pak20_dir.vpk for mod 633091
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak21_dir.vpk -> pak21_dir.vpk for mod 678174
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak22_dir.vpk -> pak22_dir.vpk for mod 675316
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak23_dir.vpk -> pak23_dir.vpk for mod local-ea003e8f-425e-4e46-91f3-45c985b805cb
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak24_dir.vpk -> pak24_dir.vpk for mod 665609
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak25_dir.vpk -> pak25_dir.vpk for mod 671974
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak26_dir.vpk -> pak26_dir.vpk for mod 660144
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak27_dir.vpk -> pak27_dir.vpk for mod 673747
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak28_dir.vpk -> pak28_dir.vpk for mod 670286
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak29_dir.vpk -> pak29_dir.vpk for mod 677190
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak30_dir.vpk -> pak30_dir.vpk for mod 647280
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak31_dir.vpk -> pak31_dir.vpk for mod 674717
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak32_dir.vpk -> pak32_dir.vpk for mod 679626
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak33_dir.vpk -> pak33_dir.vpk for mod 677309
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak34_dir.vpk -> pak34_dir.vpk for mod 675879
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak35_dir.vpk -> pak35_dir.vpk for mod 677869
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak36_dir.vpk -> pak36_dir.vpk for mod 681048
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak37_dir.vpk -> pak37_dir.vpk for mod 685750
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak38_dir.vpk -> pak38_dir.vpk for mod 86860
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak39_dir.vpk -> pak39_dir.vpk for mod 87207
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak40_dir.vpk -> pak40_dir.vpk for mod 649268
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak41_dir.vpk -> pak41_dir.vpk for mod 623055
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Reordered pak42_dir.vpk -> pak42_dir.vpk for mod 623055
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak43_dir.vpk -> pak43_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak44_dir.vpk -> pak44_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak45_dir.vpk -> pak45_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak46_dir.vpk -> pak46_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak47_dir.vpk -> pak47_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak48_dir.vpk -> pak48_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak49_dir.vpk -> pak49_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] Restored orphaned VPK file: pak50_dir.vpk -> pak50_dir.vpk
[2026-07-04][20:41:32][desktop_lib::mod_manager::vpk_manager][INFO] VPK reordering completed successfully
[2026-07-04][20:41:32][desktop_lib::mod_manager::manager][INFO] Mod reordering by remote ID completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Desktop

- Tightened mod load order reconciliation for VPK-based mods by validating manifest entries against files that actually exist on disk before reordering.
- Persisted manifest updates even when no reorder action is needed, fixing cases where load order state could be lost.
- Added handling to reconcile stale or disabled entries more safely, including updating `current_vpks` and `enabled/disabled_vpks` based on what is present in the addons directory.
- Reworked reorder flows to use the new reconciliation logic when determining whether the manifest changed.
- Added validation to reject duplicate VPK assignments across multiple mods before any filesystem changes occur.
- Expanded test coverage for VPK resolution, manifest reconciliation, and duplicate assignment failures.

### Releases

- Added a patch changeset for `@deadlock-mods/desktop` to ship the load order persistence fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->