### PR TITLE
fix(desktop): show download progress on mod buttons

### DIFF
--- a/.changeset/green-stars-rise.md
+++ b/.changeset/green-stars-rise.md
@@ -2,5 +2,4 @@
 "@deadlock-mods/desktop": patch
 ---
 
-Show download progress on mod download button
-
+Show download progress on mod action buttons

--- a/.changeset/green-stars-rise.md
+++ b/.changeset/green-stars-rise.md
@@ -1,0 +1,6 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Show download progress on mod download button
+

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -128,7 +128,9 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     currentMod,
   } = useInstallWithCollection();
   const { uninstall } = useUninstall();
-  const getModProgress = usePersistedStore((state) => state.getModProgress);
+  const modProgress = usePersistedStore((state) =>
+    remoteMod?.remoteId ? state.modProgress[remoteMod.remoteId] : undefined,
+  );
   const setInstalledVpks = usePersistedStore((state) => state.setInstalledVpks);
   const removeMod = usePersistedStore((state) => state.removeMod);
   const setModStatus = usePersistedStore((state) => state.setModStatus);
@@ -341,12 +343,16 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           return t("modButton.enableMod");
         }
         return t("modButton.downloaded");
+      case ModStatus.Downloading:
+        return t("downloads.downloadingPercent", {
+          percent: Math.round(modProgress?.percentage ?? 0),
+        });
       case undefined:
         return t("modButton.add");
       default:
         return t(`modButton.${localMod?.status}`);
     }
-  }, [localMod?.status, t, hovering]);
+  }, [localMod?.status, t, hovering, modProgress?.percentage]);
 
   const tooltip = useMemo(() => {
     switch (localMod?.status) {
@@ -451,9 +457,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
       />
 
       <MultiFileDownloadDialog
-        downloadPercentage={
-          getModProgress(remoteMod?.remoteId ?? "")?.percentage ?? 0
-        }
+        downloadPercentage={modProgress?.percentage ?? 0}
         files={availableFiles}
         isDownloading={
           localMod?.status === ModStatus.Downloading ||

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -347,6 +347,10 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         return t("downloads.downloadingPercent", {
           percent: Math.round(modProgress?.percentage ?? 0),
         });
+      case ModStatus.Paused:
+        return `${t("downloads.paused")} ${t("downloads.percentage", {
+          percentage: Math.round(modProgress?.percentage ?? 0),
+        })}`;
       case undefined:
         return t("modButton.add");
       default:
@@ -360,6 +364,8 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         return t("modButton.installedTooltip");
       case ModStatus.Downloaded:
         return t("modButton.downloadedTooltip");
+      case ModStatus.Paused:
+        return t("downloads.paused");
       case undefined:
         return t("modButton.add");
       default:


### PR DESCRIPTION
## Description

The mutli-file dialog already displayed the stored download percentage, but did not update the mod download button to also display the download percentage. 

This change makes the mod download button subscribe to the same percentage/progress entry directly, allowing the mod download button to continue to display the progress even after the mutli-file dialog is closed.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #540 
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: codex, Used for: tracing download state and reviewing work

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)
before:
<img width="1059" height="659" alt="before-progress" src="https://github.com/user-attachments/assets/fd0e200b-d553-49e7-b05c-c939dcb982cf" />

after:
<img width="1052" height="648" alt="after-progress" src="https://github.com/user-attachments/assets/85633eca-eb56-4207-9219-581ba1b551d7" />

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the desktop mod action/download button to display the stored download percentage while downloading (and show correct paused/paused-with-percent messaging), instead of relying on the transient progress helper.
- Wired `ModButton` and `MultiFileDownloadDialog` to the same persisted `state.modProgress` entry so progress remains visible even after closing the multi-file download dialog.
- Added a patch changeset for `@deadlock-mods/desktop`.

Only the desktop app (`apps/desktop`) and the `@deadlock-mods/desktop` changeset were changed; no API/bot/web/docs/shared-package, database migrations, Tauri plugin, or Rust/FFI changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->