### PR TITLE
fix(flatpak): run CEF unsandboxed to fix "Aw, Snap!" on launch

### DIFF
--- a/.changeset/brave-pandas-launch.md
+++ b/.changeset/brave-pandas-launch.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix the Linux Flatpak crashing to Chromium's "Aw, Snap!" page on launch by running CEF without its own sandbox; zypak's sandbox emulation is incompatible with CEF's Chromium 147 and killed every renderer at spawn.

--- a/.changeset/brave-pandas-launch.md
+++ b/.changeset/brave-pandas-launch.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": patch
 ---
 
-Fix the Linux Flatpak crashing to Chromium's "Aw, Snap!" page on launch by running CEF without its own sandbox; zypak's sandbox emulation is incompatible with CEF's Chromium 147 and killed every renderer at spawn.
+Fix the Linux Flatpak crashing to "Aw, Snap!" on launch

--- a/.changeset/tidy-labels-return.md
+++ b/.changeset/tidy-labels-return.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Show the correct app version in software stores by adding the missing 1.0.0 release entry to the Flatpak metainfo.

--- a/.changeset/tidy-labels-return.md
+++ b/.changeset/tidy-labels-return.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": patch
 ---
 
-Show the correct app version in software stores by adding the missing 1.0.0 release entry to the Flatpak metainfo.
+Show the correct app version in software stores on Flatpak

--- a/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.cef.yml
+++ b/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.cef.yml
@@ -22,15 +22,11 @@ finish-args:
   - --filesystem=home/.steam
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # CEF-only permissions (zypak, audio, portals)
+  # CEF-only permissions (audio, portals, updater's flatpak-spawn)
   - --socket=session-bus
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.portal.OpenURI
-  # zypak uses the spawn-strategy zygote by default which fails on some
-  # hosts ("Failed to send spawn request to supervisor: Bad file descriptor").
-  # The legacy fork strategy is more compatible with custom CEF apps.
-  - --env=ZYPAK_ZYGOTE_STRATEGY_SPAWN=0
 
 modules:
   - name: deadlock-mod-manager
@@ -43,7 +39,7 @@ modules:
       - type: file
         path: dev.stormix.deadlock-mod-manager.desktop
       - type: file
-        path: zypak-wrapper.sh
+        path: launcher.sh
     build-commands:
       - set -e
       - mkdir -p deb-extract
@@ -51,7 +47,8 @@ modules:
       - tar -C deb-extract -xf deb-extract/data.tar.gz
 
       # The binary has RUNPATH=$ORIGIN so it must stay next to libcef.so.
-      # chrome-sandbox is removed because zypak handles sandboxing.
+      # chrome-sandbox is removed because the Chromium sandbox is disabled
+      # under Flatpak (see launcher.sh).
       # The install path must not contain spaces (CEF's zygote re-execs
       # using argv[0] without quoting), so we relocate from the deb's
       # "/usr/share/Deadlock Mod Manager/" to a no-spaces path.
@@ -60,7 +57,7 @@ modules:
         mkdir -p /app/share
         cp -a "deb-extract/usr/share/Deadlock Mod Manager" /app/share/deadlock-mod-manager
         rm -f /app/share/deadlock-mod-manager/chrome-sandbox
-        install -Dm755 zypak-wrapper.sh /app/bin/deadlock-mod-manager
+        install -Dm755 launcher.sh /app/bin/deadlock-mod-manager
 
       - install -Dm644 dev.stormix.deadlock-mod-manager.desktop /app/share/applications/dev.stormix.deadlock-mod-manager.desktop
 

--- a/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.yml
+++ b/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.yml
@@ -38,7 +38,7 @@ modules:
 
       # WebKit (wry) builds ship the binary directly in /usr/bin. The CEF
       # manifest (dev.stormix.deadlock-mod-manager.cef.yml) handles the
-      # symlink/libcef layout and zypak wrapping.
+      # libcef layout and launcher wrapping.
       - install -Dm755 deb-extract/usr/bin/deadlock-mod-manager /app/bin/deadlock-mod-manager
 
       - install -Dm644 dev.stormix.deadlock-mod-manager.desktop /app/share/applications/dev.stormix.deadlock-mod-manager.desktop

--- a/apps/desktop/flatpak/launcher.sh
+++ b/apps/desktop/flatpak/launcher.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Chromium's own sandbox cannot run inside the Flatpak container, and zypak's
+# sandbox emulation is incompatible with CEF's Chromium 147 (renderer fd setup
+# fails at spawn, leaving an endless "Aw, Snap!" crash loop). Run unsandboxed
+# and rely on the Flatpak container instead, like other CEF Flatpaks do.
+exec /app/share/deadlock-mod-manager/deadlock-mod-manager --no-sandbox "$@"

--- a/apps/desktop/flatpak/zypak-wrapper.sh
+++ b/apps/desktop/flatpak/zypak-wrapper.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec zypak-wrapper /app/share/deadlock-mod-manager/deadlock-mod-manager "$@"

--- a/apps/desktop/src-tauri/dev.stormix.deadlock-mod-manager.metainfo.xml
+++ b/apps/desktop/src-tauri/dev.stormix.deadlock-mod-manager.metainfo.xml
@@ -55,6 +55,12 @@
   </provides>
 
   <releases>
+    <release version="1.0.0" date="2026-05-28">
+      <url type="details">https://github.com/deadlock-mod-manager/deadlock-mod-manager/releases/tag/v1.0.0</url>
+      <description>
+        <p>See the full release notes at https://github.com/deadlock-mod-manager/deadlock-mod-manager/releases</p>
+      </description>
+    </release>
     <release version="0.15.0" date="2026-02-26">
       <url type="details">https://github.com/deadlock-mod-manager/deadlock-mod-manager/releases/tag/v0.15.0</url>
       <description>


### PR DESCRIPTION
## Description

The v1.0.0 Flatpak (CEF runtime) shows Chromium's "Aw, Snap!" page on every launch. The renderers die at spawn because zypak — which mediates Chromium's sandbox inside Flatpak — is incompatible with CEF's Chromium 147 in **both** of its strategies:

- **Spawn strategy** (zypak's default): `zypak-sandbox: Failed to send spawn request to supervisor: Bad file descriptor`, followed by `FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc` — the app aborts before showing a window. This is why the manifest pinned strategy 0 in the first place.
- **Legacy strategy** (`ZYPAK_ZYGOTE_STRATEGY_SPAWN=0`, currently shipped): the browser process survives, but every renderer launch fails fd remapping (`zypak-helper: Failed to assign fd 14 to 4: Bad file descriptor (errno 9)`), so each renderer dies instantly and CEF respawn-loops behind the "Aw, Snap!" page.

This PR replaces the zypak wrapper with a launcher that execs the binary directly with `--no-sandbox`, relying on the Flatpak container (bubblewrap) for sandboxing — the same approach other CEF Flatpaks use (Spotify's official Flatpak, also CEF, runs all of its subprocesses with `--no-sandbox` and no zypak). Native `.deb`/AUR builds are unaffected and keep the full Chromium sandbox.

It also adds the missing 1.0.0 `<release>` entry to the metainfo: software stores read the app version from the newest entry, which is why Bazaar displayed and offered the 1.0.0 bundle as "0.15.0" (the version confusion in #557).

Trade-off, stated explicitly: Chromium's internal renderer isolation is disabled inside the Flatpak; the container remains the sandbox boundary. Upstream zypak tracks Electron rather than CEF, and with it broken under CEF 147 the practical alternative is an app that does not start.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Fixes #545
- Fixes #557

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code, Used for: root-cause investigation (reproducing the released 1.0.0 CEF bundle locally and testing both zypak strategies) and drafting this packaging fix

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works — *N/A: packaging-only change; no automated harness exercises a Flatpak launch*
- [ ] New and existing unit tests pass locally with my changes — *no JS/TS/Rust code changed, so the suites are untouched by this diff; CI runs them on this PR*
- [ ] I have tested the changes in both development and production-like environments — *verified against the released v1.0.0 production bundle (details below); could not rebuild the bundle from this branch locally (no flatpak-builder/SDK on this machine), so the build itself is covered by the flatpak CI job*

Verified on Fedora 44 (Wayland, NVIDIA RTX 4080 SUPER) against the released v1.0.0 CEF Flatpak bundle:

- Default launch (zypak, strategy 0): endless `Failed to assign fd 14 to 4` renderer crash loop — reproduces #545 exactly.
- `flatpak run --env=ZYPAK_ZYGOTE_STRATEGY_SPAWN=1 …`: `Failed to send spawn request to supervisor` + FATAL abort at startup.
- The exact process topology this launcher produces (`flatpak run --command=/app/share/deadlock-mod-manager/deadlock-mod-manager dev.stormix.deadlock-mod-manager --no-sandbox`): zero sandbox/fd errors, renderer and zygote processes stay alive, and the frontend boots fully (webview console logs, API traffic, Steam cache scan, compositor rendering frames). Same result when passing `--no-sandbox` through the existing zypak wrapper, matching the workaround reported in #545.

Manifest YAML and launcher shell syntax validated; `appstreamcli validate` reports only pre-existing warning classes (see notes).

## Screenshots (if applicable)

N/A — log evidence above.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [ ] My code follows the style guidelines of this project (`pnpm lint` passes) — *oxlint only covers JS/TS, none of which this PR touches; shell/YAML/XML were syntax-validated instead (see Testing)*
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — *N/A: no docs reference the Flatpak launcher or zypak (verified by grep)*
- [ ] My changes generate no new warnings or errors — *one more instance of the pre-existing appstream `description-has-plaintext-url` warning, because the new release entry matches the existing entries' format; see Additional Notes*
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable) — *N/A: Linux-Flatpak-only change; the #545 reporter independently confirmed the same approach on Arch*
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

- `--socket=session-bus` is kept: the in-app updater's `flatpak-spawn --host` needs it, so it was never zypak-only.
- The `org.electronjs.Electron2.BaseApp` base is kept for now (it still provides `gvfs-trash` and friends); dropping it could be a follow-up once confirmed nothing else from it is used.
- The new metainfo entry follows the existing entries' style, so `appstreamcli` flags it with the same pre-existing `description-has-plaintext-url` warning the 0.15.0 entry already has. It also reports the screenshot URL (`docs/assets/screenshot-library.png` on `main`) as 404 — pre-existing and worth fixing separately, since stores render it.
- The metainfo `<releases>` list is maintained by hand, which is how 1.0.0 got missed; a CI check (or generating the entry from the tag at release time) would prevent a repeat.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed the Linux Flatpak desktop launcher to execute the CEF binary directly with `--no-sandbox`, avoiding zypak-related renderer crashes and “Aw, Snap!” launch failures.
- Updated Flatpak permissions and build configuration, replacing the zypak wrapper while preserving native `.deb` and AUR behavior.
- Added the missing AppStream `1.0.0` release entry so software stores report the correct Flatpak version.
- Added patch-release changesets for the desktop package.

Only the desktop Flatpak is affected; no API, bot, web, shared-package, database, Tauri plugin, or Rust FFI changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->