### PR TITLE
feat(desktop): retry failed downloads

### DIFF
--- a/.changeset/light-ants-view.md
+++ b/.changeset/light-ants-view.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-Add a retry action for failed downloads in the download queue and for failed downloads in the mod screen.
+Add retry actions for failed downloads in the queue and mod screen.

--- a/.changeset/light-ants-view.md
+++ b/.changeset/light-ants-view.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Add a retry action for failed downloads in the download queue.

--- a/.changeset/light-ants-view.md
+++ b/.changeset/light-ants-view.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-Add a retry action for failed downloads in the download queue.
+Add a retry action for failed downloads in the download queue and for failed downloads in the mod screen.

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -151,6 +151,9 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
       )}
       onClick={handleOpen}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) {
+          return;
+        }
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           handleOpen();

--- a/apps/desktop/src/components/downloads/download-card.tsx
+++ b/apps/desktop/src/components/downloads/download-card.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@deadlock-mods/ui/components/button";
 import { Card } from "@deadlock-mods/ui/components/card";
 import { toast } from "@deadlock-mods/ui/components/sonner";
-import { Pause, Play } from "@phosphor-icons/react";
+import { ArrowClockwiseIcon, Pause, Play } from "@phosphor-icons/react";
 import { type MouseEvent, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { downloadManager } from "@/lib/download/manager";
+import { useDownload } from "@/hooks/use-download";
 import { getErrorMessage } from "@/lib/errors";
 import { usePersistedStore } from "@/lib/store";
 import { cn, formatSize, formatSpeed } from "@/lib/utils";
@@ -102,6 +103,7 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
   const isPaused = download.status === ModStatus.Paused;
   const isExtracting = download.status === ModStatus.Extracting;
   const isInProgress = isDownloading || isPaused || isExtracting;
+  const isFailed = download.status === ModStatus.FailedToDownload;
   const percentage = isInProgress ? (modProgress?.percentage ?? 0) : 100;
   const speed = isDownloading ? (modProgress?.speed ?? 0) : 0;
   const totalSize = useMemo(() => {
@@ -110,6 +112,7 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
     }
     return download.downloads.reduce((acc, curr) => acc + (curr.size || 0), 0);
   }, [download.downloads]);
+  const { retryDownload } = useDownload(download, download.downloads ?? []);
 
   const handleOpen = () => navigate(`/mods/${download.remoteId}`);
 
@@ -129,6 +132,12 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
         t("downloads.resumeError", { message: getErrorMessage(err) }),
       );
     });
+  };
+
+  const handleRetry = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    retryDownload();
   };
 
   return (
@@ -198,12 +207,28 @@ const DownloadCard = ({ download }: DownloadCardProps) => {
         />
       </div>
 
-      {(isDownloading || isPaused) && (
+      {(isDownloading || isPaused || isFailed) && (
         <div
           className='mt-3 flex flex-wrap gap-2'
           onClick={(e) => {
             e.stopPropagation();
           }}>
+          {isFailed && (
+            <Button
+              className='h-8'
+              onClick={handleRetry}
+              size='sm'
+              type='button'
+              variant='outline'>
+              <ArrowClockwiseIcon
+                aria-hidden
+                className='mr-1 size-4'
+                weight='bold'
+              />
+              {t("downloads.retry")}
+            </Button>
+          )}
+
           {isDownloading && (
             <Button
               className='h-8'

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -14,6 +14,7 @@ import {
   X,
   XIcon,
 } from "@deadlock-mods/ui/icons";
+import { ArrowClockwiseIcon } from "@phosphor-icons/react";
 import { useHover } from "@uidotdev/usehooks";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -72,6 +73,7 @@ export const ModStatusIcon = ({
       case ModStatus.Installed:
         return hovering ? X : Check;
       case ModStatus.FailedToDownload:
+        return ArrowClockwiseIcon;
       case ModStatus.FailedToInstall:
       case ModStatus.FailedToRemove:
         return XIcon;
@@ -114,6 +116,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
   const {
     download,
     downloadSelectedFiles,
+    retryDownload,
     closeDialog,
     localMod,
     isDialogOpen,
@@ -285,6 +288,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
           analytics.trackModUninstalled(localMod.remoteId, "user_choice");
           break;
         case ModStatus.FailedToDownload:
+          retryDownload();
           break;
         case ModStatus.Error:
           removeMod(localMod.remoteId);
@@ -304,6 +308,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     heroConflictWarningEnabled,
     confirm,
     download,
+    retryDownload,
     uninstall,
     removeMod,
     askHeroConflict,
@@ -366,6 +371,8 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         return t("modButton.downloadedTooltip");
       case ModStatus.Paused:
         return t("downloads.paused");
+      case ModStatus.FailedToDownload:
+        return t("downloads.retry");
       case undefined:
         return t("modButton.add");
       default:
@@ -431,6 +438,7 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              aria-label={tooltip}
               disabled={isActionInProgress || isAnalyzing}
               icon={
                 <ModStatusIcon hovering={hovering} status={localMod?.status} />
@@ -438,7 +446,6 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
               onClick={onClick}
               ref={ref}
               size={variant === "iconOnly" ? "icon" : "default"}
-              title={text}
               variant={buttonVariant}>
               {variant === "iconOnly" ? null : text}
             </Button>

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -4,8 +4,10 @@ import type { z } from "zod";
 import { ModDownloadDtoSchema } from "@deadlock-mods/shared";
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { detectHeroForMod } from "@/hooks/use-hero-detection";
 import { downloadManager } from "@/lib/download/manager";
+import { getErrorMessage } from "@/lib/errors";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
 import { type ModDownloadItem, ModStatus } from "@/types/mods";
@@ -16,6 +18,7 @@ export const useDownload = (
   mod: Pick<ModDto, "remoteId" | "name"> | undefined,
   availableFiles: ModDownloadDto[],
 ) => {
+  const { t } = useTranslation();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const addLocalMod = usePersistedStore((state) => state.addLocalMod);
   const localMods = usePersistedStore((state) => state.localMods);
@@ -120,13 +123,13 @@ export const useDownload = (
   };
 
   const retryDownload = () => {
-    if (!mod || !localMod) {
-      toast.error("Failed to fetch mod download data. Try again later.");
+    if (!mod) {
+      toast.error(t("downloads.retryFetchError"));
       return;
     }
 
-    const selectedDownloads = localMod.selectedDownloads ?? [];
-    const persistedDownloads = localMod.downloads ?? [];
+    const selectedDownloads = localMod?.selectedDownloads ?? [];
+    const persistedDownloads = localMod?.downloads ?? [];
 
     const retryFiles =
       selectedDownloads.length > 0
@@ -136,12 +139,20 @@ export const useDownload = (
           : availableFiles;
 
     if (retryFiles.length === 0) {
-      toast.error("No downloadable files found.");
+      toast.error(t("downloads.retryNoFiles"));
       return;
     }
 
     setModStatus(mod.remoteId, ModStatus.Downloading);
-    void downloadSelectedFiles(retryFiles);
+    downloadSelectedFiles(retryFiles).catch((err: unknown) => {
+      const message = getErrorMessage(err);
+      logger
+        .withMetadata({ mod: mod.remoteId })
+        .withError(err instanceof Error ? err : new Error(message))
+        .error("Failed to retry download");
+      setModStatus(mod.remoteId, ModStatus.FailedToDownload);
+      toast.error(t("downloads.retryError", { message }));
+    });
   };
 
   return {

--- a/apps/desktop/src/hooks/use-download.ts
+++ b/apps/desktop/src/hooks/use-download.ts
@@ -119,8 +119,34 @@ export const useDownload = (
     }
   };
 
+  const retryDownload = () => {
+    if (!mod || !localMod) {
+      toast.error("Failed to fetch mod download data. Try again later.");
+      return;
+    }
+
+    const selectedDownloads = localMod.selectedDownloads ?? [];
+    const persistedDownloads = localMod.downloads ?? [];
+
+    const retryFiles =
+      selectedDownloads.length > 0
+        ? selectedDownloads
+        : persistedDownloads.length > 0
+          ? persistedDownloads
+          : availableFiles;
+
+    if (retryFiles.length === 0) {
+      toast.error("No downloadable files found.");
+      return;
+    }
+
+    setModStatus(mod.remoteId, ModStatus.Downloading);
+    void downloadSelectedFiles(retryFiles);
+  };
+
   return {
     download: initiateDownload,
+    retryDownload,
     downloadSelectedFiles,
     pauseDownload,
     resumeDownload,

--- a/apps/desktop/src/lib/state-machines/mod-status.ts
+++ b/apps/desktop/src/lib/state-machines/mod-status.ts
@@ -42,7 +42,7 @@ const VALID_TRANSITIONS: Record<ModStatus, ModStatus[]> = {
   [ModStatus.Removing]: [ModStatus.Removed, ModStatus.FailedToRemove],
   [ModStatus.Removed]: [ModStatus.Error],
   [ModStatus.FailedToInstall]: [ModStatus.Downloaded, ModStatus.Error],
-  [ModStatus.FailedToDownload]: [ModStatus.Error],
+  [ModStatus.FailedToDownload]: [ModStatus.Error, ModStatus.Downloading],
   [ModStatus.FailedToRemove]: [
     ModStatus.Installed,
     ModStatus.Downloaded,

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1212,6 +1212,7 @@
   "modStatus": {
     "added": "Added to my mods",
     "completed": "Completed",
+    "failed": "Failed",
     "downloading": "Downloading...",
     "extracting": "Extracting...",
     "downloaded": "Downloaded",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -353,6 +353,7 @@
     "pause": "Pause",
     "resume": "Resume",
     "paused": "Paused",
+    "retry": "Retry",
     "pauseError": "Could not pause download: {{message}}",
     "resumeError": "Could not resume download: {{message}}"
   },

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -355,7 +355,10 @@
     "paused": "Paused",
     "retry": "Retry",
     "pauseError": "Could not pause download: {{message}}",
-    "resumeError": "Could not resume download: {{message}}"
+    "resumeError": "Could not resume download: {{message}}",
+    "retryFetchError": "Failed to fetch mod download data. Try again later.",
+    "retryNoFiles": "No downloadable files found.",
+    "retryError": "Could not retry download: {{message}}"
   },
   "notifications": {
     "modInstalledSuccessfully": "Mod installed successfully",


### PR DESCRIPTION
## Description

Adds a retry action for failed mod downloads from both the download card queue and mod button.

Retry actions reuse the previously selected files and update the mod status accordingly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #556

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: codex / Cursor, Used for: logic brainstorming, code review, and addressing review feedback

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)
download card
- before
    <img width="1075" height="196" alt="image" src="https://github.com/user-attachments/assets/07f3e63e-686a-4e30-93fa-b60b38f93180" />
- after
    <img width="1075" height="250" alt="image" src="https://github.com/user-attachments/assets/b153a47f-d976-49d1-ab8a-062912330476" />

mod button
- before
    <img width="891" height="113" alt="image" src="https://github.com/user-attachments/assets/48a4ac27-7668-419d-8150-f373da0f910d" />

- after
   <img width="1041" height="128" alt="image" src="https://github.com/user-attachments/assets/84a2e430-1638-415f-b815-954525aa64f5" />

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Removed redundant mod button title, but added accessibility label.

The title was essentially a second tooltip cluttering the screen, view the image mod button before and after.

Addressed CodeRabbit review feedback:
- Guard download-card keyboard handler so nested Retry/Pause/Resume controls do not open the mod
- Catch retry queue-setup failures and restore `FailedToDownload` with a toast
- Localize retry error toasts
- Relax retry guard so `availableFiles` fallback is reachable
- Shorten changeset summary to under 80 characters

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added **retry** support for **failed mod downloads** in the **desktop app**:
  - **Download queue:** renders a **Retry** action for items in `ModStatus.FailedToDownload`.
  - **Mod screen (mod button):** updates `FailedToDownload` UI to show a retry icon/action and routes the action through the download retry flow.
- Retry attempts **reuse previously selected files**, falling back in priority order to persisted/known download candidates; if none are available, the user gets a translated toast error.
- Improved retry/error handling in `useDownload` by catching retry failures, setting status back to **`FailedToDownload`**, and showing **localized** retry-related messages/toasts.
- Updated the **mod status state machine** so transitions from `FailedToDownload` are allowed back to **`Downloading`** (and **`Error`**).
- Accessibility and UX polish:
  - Replaced a redundant mod button `title` with **`aria-label`**.
  - Refined keyboard activation on the download card to avoid triggering when key events originate from child elements.

## Affected packages / apps

- **`apps/desktop`** (`@deadlock-mods/desktop`)
  - `apps/desktop/src/components/downloads/download-card.tsx`
  - `apps/desktop/src/components/mod-browsing/mod-button.tsx`
  - `apps/desktop/src/hooks/use-download.ts`
  - `apps/desktop/src/lib/state-machines/mod-status.ts`
  - `apps/desktop/src/locales/en.json` (retry-related strings)
- **Changeset:** updated the `@deadlock-mods/desktop` minor changelog entry to document retry actions for failed downloads in the queue/mod screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->