### PR TITLE
feat(api,desktop,database,shared): parse and display GameBanana mod requirements

### DIFF
--- a/.changeset/twelve-towns-attack.md
+++ b/.changeset/twelve-towns-attack.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-Show a mod's GameBanana requirements on its detail page, linking to the required mods where we have them
+Show GameBanana requirements and local mod links on detail pages

--- a/.changeset/twelve-towns-attack.md
+++ b/.changeset/twelve-towns-attack.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Show a mod's GameBanana requirements on its detail page, linking to the required mods where we have them

--- a/apps/api/src/providers/game-banana/index.ts
+++ b/apps/api/src/providers/game-banana/index.ts
@@ -26,6 +26,7 @@ import {
   classifyNSFW,
   heroFromGameBananaProfile,
   mapGameBananaFileserverState,
+  parseRequirements,
   parseTags,
   submitterDisplayName,
 } from "./utils";
@@ -332,6 +333,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
     }
 
     const description = profile._sText || profile._sDescription || "";
+    const dependencies = parseRequirements(profile._aRequirements);
 
     return {
       remoteId: profile._idRow.toString(),
@@ -354,6 +356,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       isMap: false,
       isAudio: true,
       audioUrl: profile._aPreviewMedia._aMetadata._sAudioUrl,
+      dependencies,
       metadata: buildMetadata({
         description,
         isMap: false,
@@ -376,6 +379,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
     const description = profile._sText || profile._sDescription || "";
     const category = categoryFromGameBananaProfile(profile);
     const isMap = category === MAPS_CATEGORY_NAME;
+    const dependencies = parseRequirements(profile._aRequirements);
 
     return {
       remoteId: profile._idRow.toString(),
@@ -400,6 +404,7 @@ export class GameBananaProvider extends Provider<GameBananaSubmission> {
       isTrashed: false,
       isMap,
       isAudio: false,
+      dependencies,
       metadata: buildMetadata({
         description,
         isMap,

--- a/apps/api/src/providers/game-banana/utils.test.ts
+++ b/apps/api/src/providers/game-banana/utils.test.ts
@@ -629,11 +629,7 @@ describe("parseRequirements", () => {
   it("returns [] for null/undefined/non-array input", () => {
     expect(parseRequirements(null)).toEqual([]);
     expect(parseRequirements(undefined)).toEqual([]);
-    expect(
-      parseRequirements(
-        "nope" as unknown as GameBanana.GameBananaRequirement[],
-      ),
-    ).toEqual([]);
+    expect(parseRequirements("nope" as unknown as string[][])).toEqual([]);
   });
 
   it("parses the real Sinners-and-Statues sample (Recommended + enabled)", () => {
@@ -691,6 +687,23 @@ describe("parseRequirements", () => {
 
   it("drops rows with neither label nor url", () => {
     expect(parseRequirements([["", "", "1", "1"], []])).toEqual([]);
+  });
+
+  it("only reads a mod id when the url is actually a GameBanana mod page", () => {
+    const [embedded] = parseRequirements([
+      [
+        "Elsewhere",
+        "https://example.com/?ref=gamebanana.com/mods/123",
+        "1",
+        "1",
+      ],
+    ]);
+    expect(embedded.remoteId).toBeNull();
+
+    const [subdomain] = parseRequirements([
+      ["Real", "https://www.gamebanana.com/mods/123", "1", "1"],
+    ]);
+    expect(subdomain.remoteId).toBe("123");
   });
 
   it("parses the real ProfilePage label shape (Enabled + Recommended)", () => {

--- a/apps/api/src/providers/game-banana/utils.test.ts
+++ b/apps/api/src/providers/game-banana/utils.test.ts
@@ -8,6 +8,7 @@ import {
   extractDonationLinksFromDescription,
   extractMapName,
   heroFromGameBananaProfile,
+  parseRequirements,
 } from "./utils";
 
 type GameBananaCategory = GameBanana.GameBananaModProfile["_aCategory"];
@@ -621,5 +622,133 @@ describe("buildMetadata", () => {
     });
     expect(result?.mapName).toBe("my_arena");
     expect(result?.donationLinks).toHaveLength(1);
+  });
+});
+
+describe("parseRequirements", () => {
+  it("returns [] for null/undefined/non-array input", () => {
+    expect(parseRequirements(null)).toEqual([]);
+    expect(parseRequirements(undefined)).toEqual([]);
+    expect(
+      parseRequirements(
+        "nope" as unknown as GameBanana.GameBananaRequirement[],
+      ),
+    ).toEqual([]);
+  });
+
+  it("parses the real Sinners-and-Statues sample (Recommended + enabled)", () => {
+    const result = parseRequirements([
+      ["Universal Mod Manager", "https://gamebanana.com/mods/693642", "2", "5"],
+    ]);
+    expect(result).toEqual([
+      {
+        label: "Universal Mod Manager",
+        url: "https://gamebanana.com/mods/693642",
+        remoteId: "693642",
+        level: "recommended",
+      },
+    ]);
+  });
+
+  it("maps modality code 1 to required", () => {
+    const [dep] = parseRequirements([
+      ["Base Mod", "https://gamebanana.com/mods/111", "1", "1"],
+    ]);
+    expect(dep.level).toBe("required");
+    expect(dep.remoteId).toBe("111");
+  });
+
+  it("skips incompatibilities (negative state codes)", () => {
+    // 2 is uninstalled and 6 is disabled, so these are conflicts, not dependencies
+    expect(
+      parseRequirements([
+        ["Conflicting Mod", "https://gamebanana.com/mods/222", "1", "2"],
+        ["Other Conflict", "https://gamebanana.com/mods/333", "1", "6"],
+      ]),
+    ).toEqual([]);
+  });
+
+  it("handles URL-less free-text requirements", () => {
+    const [dep] = parseRequirements([
+      ["Add enable_mods 1 to autoexec.cfg", "", "1", "5"],
+    ]);
+    expect(dep).toEqual({
+      label: "Add enable_mods 1 to autoexec.cfg",
+      url: null,
+      remoteId: null,
+      level: "required",
+    });
+  });
+
+  it("leaves remoteId null for non-mod / external URLs and unknown modality", () => {
+    const [dep] = parseRequirements([
+      ["Deadlock Mod Loader", "https://gamebanana.com/tools/20525", "", "3"],
+    ]);
+    expect(dep.remoteId).toBeNull();
+    expect(dep.url).toBe("https://gamebanana.com/tools/20525");
+    expect(dep.level).toBeNull();
+  });
+
+  it("drops rows with neither label nor url", () => {
+    expect(parseRequirements([["", "", "1", "1"], []])).toEqual([]);
+  });
+
+  it("parses the real ProfilePage label shape (Enabled + Recommended)", () => {
+    const result = parseRequirements([
+      [
+        "Universal Mod Manager",
+        "https://gamebanana.com/mods/693642",
+        "Enabled",
+        "BlueColor",
+        "Recommended",
+        "GreyColor",
+      ],
+    ]);
+    expect(result).toEqual([
+      {
+        label: "Universal Mod Manager",
+        url: "https://gamebanana.com/mods/693642",
+        remoteId: "693642",
+        level: "recommended",
+      },
+    ]);
+  });
+
+  it("maps the Required label shape and ignores color tokens", () => {
+    const [dep] = parseRequirements([
+      [
+        "Base Mod",
+        "https://gamebanana.com/mods/111",
+        "Installed",
+        "GreenColor",
+        "Required",
+        "RedColor",
+      ],
+    ]);
+    expect(dep.level).toBe("required");
+    expect(dep.remoteId).toBe("111");
+  });
+
+  it("skips incompatibilities in the label shape (negative state label)", () => {
+    expect(
+      parseRequirements([
+        [
+          "Conflicting Mod",
+          "https://gamebanana.com/mods/222",
+          "Disabled",
+          "RedColor",
+          "Required",
+          "GreyColor",
+        ],
+        [
+          "Other Conflict",
+          "https://gamebanana.com/mods/333",
+          "Uninstalled",
+          "RedColor",
+          "Recommended",
+          "GreyColor",
+        ],
+      ]),
+    ).toEqual([]);
   });
 });

--- a/apps/api/src/providers/game-banana/utils.ts
+++ b/apps/api/src/providers/game-banana/utils.ts
@@ -1,4 +1,4 @@
-import type { ModDownload } from "@deadlock-mods/database";
+import type { ModDependency, ModDownload } from "@deadlock-mods/database";
 import type {
   DonationLink,
   FileserverDto,
@@ -15,6 +15,108 @@ export {
   parseTags,
   submitterDisplayName,
 } from "./profile";
+
+const GB_MOD_URL_RE = /gamebanana\.com\/mods\/(\d+)/i;
+
+// GameBanana's Required/Recommended dropdown. The profile endpoint spells it out,
+// the base endpoint sends a number
+const MODALITY_BY_CODE: Record<string, ModDependency["level"]> = {
+  "1": "required",
+  "2": "recommended",
+};
+const MODALITY_BY_LABEL: Record<string, ModDependency["level"]> = {
+  required: "required",
+  recommended: "recommended",
+};
+
+// The state dropdown is 1-indexed with ten options, and its five negative ones
+// ("uninstalled", "absent" ...) mean the mods clash, which is why these are the evens
+const NEGATIVE_STATE_CODES = new Set(["2", "4", "6", "8", "10"]);
+const NEGATIVE_STATE_LABELS = new Set([
+  "uninstalled",
+  "absent",
+  "disabled",
+  "off",
+  "false",
+]);
+const POSITIVE_STATE_LABELS = new Set([
+  "installed",
+  "present",
+  "enabled",
+  "on",
+  "true",
+]);
+
+/**
+ * Turns a mod's GameBanana requirements into the dependencies we store. Anything
+ * that flags a conflict is dropped, the rest are kept. The link can be empty, and
+ * when it points at another mod we pull out that mod's id.
+ *
+ * Rows arrive in two layouts, words from the profile page and numbers from the base
+ * endpoint, so the columns after label and url are read by what they say, not where
+ * they sit.
+ */
+export const parseRequirements = (
+  raw: GameBanana.GameBananaRequirement[] | null | undefined,
+): ModDependency[] => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const dependencies: ModDependency[] = [];
+  for (const row of raw) {
+    if (!Array.isArray(row) || row.length === 0) {
+      continue;
+    }
+    const label = typeof row[0] === "string" ? row[0].trim() : "";
+    const url = typeof row[1] === "string" ? row[1].trim() : "";
+    if (!label && !url) {
+      continue;
+    }
+
+    const meta = row
+      .slice(2)
+      .map((value) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "",
+      );
+
+    // Nothing in the response tells us which layout we got, so work it out from
+    // whether any of the trailing columns are words we recognise
+    const isLabelShape = meta.some(
+      (token) =>
+        token in MODALITY_BY_LABEL ||
+        NEGATIVE_STATE_LABELS.has(token) ||
+        POSITIVE_STATE_LABELS.has(token),
+    );
+
+    let level: ModDependency["level"];
+    let isIncompatibility: boolean;
+    if (isLabelShape) {
+      const modalityLabel = meta.find((token) => token in MODALITY_BY_LABEL);
+      level = modalityLabel ? MODALITY_BY_LABEL[modalityLabel] : null;
+      isIncompatibility = meta.some((token) =>
+        NEGATIVE_STATE_LABELS.has(token),
+      );
+    } else {
+      // In the number layout modality comes first and state second
+      level = MODALITY_BY_CODE[meta[0] ?? ""] ?? null;
+      isIncompatibility = NEGATIVE_STATE_CODES.has(meta[1] ?? "");
+    }
+
+    // The author wants the other mod gone, so there is nothing to offer installing
+    if (isIncompatibility) {
+      continue;
+    }
+
+    dependencies.push({
+      label,
+      url: url || null,
+      remoteId: url ? (url.match(GB_MOD_URL_RE)?.[1] ?? null) : null,
+      level,
+    });
+  }
+  return dependencies;
+};
 
 /**
  * Classify if a GameBanana mod contains NSFW content

--- a/apps/api/src/providers/game-banana/utils.ts
+++ b/apps/api/src/providers/game-banana/utils.ts
@@ -16,7 +16,7 @@ export {
   submitterDisplayName,
 } from "./profile";
 
-const GB_MOD_URL_RE = /gamebanana\.com\/mods\/(\d+)/i;
+const GB_MOD_URL_RE = /^https?:\/\/(?:www\.)?gamebanana\.com\/mods\/(\d+)/i;
 
 // GameBanana's Required/Recommended dropdown. The profile endpoint spells it out,
 // the base endpoint sends a number
@@ -57,7 +57,7 @@ const POSITIVE_STATE_LABELS = new Set([
  * they sit.
  */
 export const parseRequirements = (
-  raw: GameBanana.GameBananaRequirement[] | null | undefined,
+  raw: string[][] | null | undefined,
 ): ModDependency[] => {
   if (!Array.isArray(raw)) {
     return [];

--- a/apps/desktop/src/components/mod-detail/mod-dependencies.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-dependencies.tsx
@@ -1,0 +1,185 @@
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@deadlock-mods/ui/components/avatar";
+import { Badge } from "@deadlock-mods/ui/components/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@deadlock-mods/ui/components/card";
+import { ExternalLink, Info, Package } from "@deadlock-mods/ui/icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import ModButton from "@/components/mod-browsing/mod-button";
+import { prefetchModDetail } from "@/lib/mods/mod-detail-prefetch";
+import type { ModDependency, ResolvedDependency } from "@/types/dependencies";
+
+interface ModDependenciesProps {
+  dependencies: ResolvedDependency[];
+}
+
+export const ModDependencies = ({ dependencies }: ModDependenciesProps) => {
+  const { t } = useTranslation();
+
+  if (!dependencies || dependencies.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card className='shadow-none [contain:layout_style_paint]'>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <Package className='h-5 w-5' />
+          {t("modDependencies.title")}
+        </CardTitle>
+        <CardDescription>{t("modDependencies.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className='space-y-2'>
+          {dependencies.map((dependency) =>
+            dependency.kind === "internal" ? (
+              <InternalDependencyRow
+                dependency={dependency}
+                key={dependency.mod.remoteId}
+              />
+            ) : (
+              <ExternalDependencyRow
+                dependency={dependency}
+                key={dependency.dependency.url || dependency.dependency.label}
+              />
+            ),
+          )}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};
+
+const LevelBadge = ({ level }: { level: ModDependency["level"] }) => {
+  const { t } = useTranslation();
+  if (level === "required") {
+    return (
+      <Badge
+        className='shrink-0 border-amber-500/50 bg-amber-500/10 text-amber-600 dark:text-amber-400'
+        variant='outline'>
+        {t("modDependencies.required")}
+      </Badge>
+    );
+  }
+  if (level === "recommended") {
+    return (
+      <Badge className='shrink-0 text-muted-foreground' variant='outline'>
+        {t("modDependencies.recommended")}
+      </Badge>
+    );
+  }
+  return null;
+};
+
+const InternalDependencyRow = ({
+  dependency,
+}: {
+  dependency: Extract<ResolvedDependency, { kind: "internal" }>;
+}) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { mod } = dependency;
+  const level = dependency.dependency.level;
+  const image = mod.images?.[0];
+
+  const goToMod = () => {
+    prefetchModDetail(queryClient, mod.remoteId);
+    navigate(`/mods/${mod.remoteId}`);
+  };
+
+  return (
+    <li className='flex items-center gap-2 rounded-lg border p-2 transition-colors hover:bg-muted/50'>
+      <button
+        className='flex min-w-0 flex-1 items-center gap-3 rounded-md p-1.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        onClick={goToMod}
+        type='button'>
+        <Avatar className='h-11 w-11 rounded-md'>
+          <AvatarImage alt={mod.name} className='object-cover' src={image} />
+          <AvatarFallback className='rounded-md'>
+            <Package className='h-5 w-5 text-muted-foreground' />
+          </AvatarFallback>
+        </Avatar>
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-2'>
+            {level === "required" && <LevelBadge level='required' />}
+            <span className='truncate font-medium' title={mod.name}>
+              {mod.name}
+            </span>
+            {level === "recommended" && <LevelBadge level='recommended' />}
+          </div>
+          <p className='truncate text-muted-foreground text-sm'>
+            {t("mods.by")} {mod.author}
+          </p>
+        </div>
+      </button>
+
+      <div className='flex shrink-0 items-center pr-1'>
+        <ModButton remoteMod={mod} variant='default' />
+      </div>
+    </li>
+  );
+};
+
+const ExternalDependencyRow = ({
+  dependency,
+}: {
+  dependency: Extract<ResolvedDependency, { kind: "external" }>;
+}) => {
+  const { t } = useTranslation();
+  const { label } = dependency.dependency;
+  const url = dependency.dependency.url;
+  const level = dependency.dependency.level;
+
+  // No link, so it's just a note
+  if (!url) {
+    return (
+      <li className='flex items-center gap-3 rounded-lg border p-3'>
+        <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-secondary'>
+          <Info className='h-5 w-5 text-muted-foreground' />
+        </div>
+        <div className='flex min-w-0 flex-1 items-center gap-2'>
+          {level === "required" && <LevelBadge level='required' />}
+          <span className='font-medium'>{label}</span>
+          {level === "recommended" && <LevelBadge level='recommended' />}
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li>
+      <button
+        className='flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-muted/50'
+        onClick={() => openUrl(url)}
+        title={url}
+        type='button'>
+        <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-secondary'>
+          <ExternalLink className='h-5 w-5 text-muted-foreground' />
+        </div>
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-2'>
+            {level === "required" && <LevelBadge level='required' />}
+            <span className='truncate font-medium'>
+              {label || t("modDependencies.openExternal")}
+            </span>
+            {level === "recommended" && <LevelBadge level='recommended' />}
+          </div>
+          <p className='truncate text-muted-foreground text-sm'>{url}</p>
+        </div>
+        <ExternalLink className='h-4 w-4 shrink-0 text-muted-foreground' />
+      </button>
+    </li>
+  );
+};

--- a/apps/desktop/src/components/mod-detail/mod-dependencies.tsx
+++ b/apps/desktop/src/components/mod-detail/mod-dependencies.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import ModButton from "@/components/mod-browsing/mod-button";
 import { prefetchModDetail } from "@/lib/mods/mod-detail-prefetch";
+import { isTrustedExternalUrl } from "@/lib/trusted-external-url";
 import type { ModDependency, ResolvedDependency } from "@/types/dependencies";
 
 interface ModDependenciesProps {
@@ -142,17 +143,27 @@ const ExternalDependencyRow = ({
   const url = dependency.dependency.url;
   const level = dependency.dependency.level;
 
-  // No link, so it's just a note
-  if (!url) {
+  // These urls come from whatever the mod author typed on GameBanana, so we
+  // only open the ones we trust. Anything else stays a plain note with the link shown as text
+  if (!isTrustedExternalUrl(url)) {
     return (
       <li className='flex items-center gap-3 rounded-lg border p-3'>
         <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-md bg-secondary'>
           <Info className='h-5 w-5 text-muted-foreground' />
         </div>
-        <div className='flex min-w-0 flex-1 items-center gap-2'>
-          {level === "required" && <LevelBadge level='required' />}
-          <span className='font-medium'>{label}</span>
-          {level === "recommended" && <LevelBadge level='recommended' />}
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-2'>
+            {level === "required" && <LevelBadge level='required' />}
+            <span className='truncate font-medium'>
+              {label || t("modDependencies.openExternal")}
+            </span>
+            {level === "recommended" && <LevelBadge level='recommended' />}
+          </div>
+          {url && (
+            <p className='truncate text-muted-foreground text-sm' title={url}>
+              {url}
+            </p>
+          )}
         </div>
       </li>
     );

--- a/apps/desktop/src/hooks/use-mod-dependencies.ts
+++ b/apps/desktop/src/hooks/use-mod-dependencies.ts
@@ -1,0 +1,65 @@
+import type { ModDto } from "@deadlock-mods/shared";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { getMod } from "@/lib/api-client";
+import { modDetailQueryKey } from "@/lib/mods/mod-query-cache";
+import { STALE_TIME_API } from "@/lib/query-constants";
+import type { ModDependency, ResolvedDependency } from "@/types/dependencies";
+
+type DependencyWithRemoteId = ModDependency & { remoteId: string };
+
+/**
+ * Looks each dependency up in our mod catalogue. If we have the mod it's
+ * internal and gets a proper card, otherwise it's external and just links out
+ */
+export const useResolvedDependencies = (
+  dependencies: ModDependency[] | undefined,
+): ResolvedDependency[] => {
+  const deps = useMemo(() => dependencies ?? [], [dependencies]);
+  const idDeps = useMemo(
+    () => deps.filter((d): d is DependencyWithRemoteId => Boolean(d.remoteId)),
+    [deps],
+  );
+
+  const results = useQueries({
+    queries: idDeps.map((dependency) => ({
+      queryKey: modDetailQueryKey(dependency.remoteId),
+      queryFn: () => getMod(dependency.remoteId),
+      staleTime: STALE_TIME_API,
+      retry: false,
+    })),
+  });
+
+  return useMemo(() => {
+    // While we're still fetching a mod, leave its row out instead of briefly
+    // showing it as a plain link. Only drop to a link once the fetch has finished
+    // and found nothing
+    const stateByRemoteId = new Map<
+      string,
+      { mod?: ModDto; pending: boolean }
+    >();
+    idDeps.forEach((dependency, index) => {
+      const result = results[index];
+      stateByRemoteId.set(dependency.remoteId, {
+        mod: result?.data,
+        pending: result?.status === "pending",
+      });
+    });
+
+    const resolved: ResolvedDependency[] = [];
+    for (const dependency of deps) {
+      if (!dependency.remoteId) {
+        // No id, so it's just a note or a link elsewhere
+        resolved.push({ kind: "external", dependency });
+        continue;
+      }
+      const state = stateByRemoteId.get(dependency.remoteId);
+      if (state?.mod) {
+        resolved.push({ kind: "internal", dependency, mod: state.mod });
+      } else if (!state?.pending) {
+        resolved.push({ kind: "external", dependency });
+      }
+    }
+    return resolved;
+  }, [deps, idDeps, results]);
+};

--- a/apps/desktop/src/hooks/use-mod-processor.ts
+++ b/apps/desktop/src/hooks/use-mod-processor.ts
@@ -304,6 +304,7 @@ export const useModProcessor = () => {
       filesUpdatedAt: null,
       metadata: null,
       overrides: null,
+      dependencies: null,
     };
 
     addMod(modDto, {
@@ -399,6 +400,7 @@ export const useModProcessor = () => {
       filesUpdatedAt: null,
       metadata: null,
       overrides: null,
+      dependencies: null,
     };
 
     const vpkFileName = existingPath.split(/[\\/]/).pop() || existingPath;

--- a/apps/desktop/src/lib/trusted-external-url.test.ts
+++ b/apps/desktop/src/lib/trusted-external-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { isTrustedExternalUrl } from "./trusted-external-url";
+
+describe("isTrustedExternalUrl", () => {
+  it("accepts https urls on the trusted hosts and their subdomains", () => {
+    expect(isTrustedExternalUrl("https://gamebanana.com/mods/693642")).toBe(
+      true,
+    );
+    expect(isTrustedExternalUrl("https://www.gamebanana.com/tools/20525")).toBe(
+      true,
+    );
+    expect(isTrustedExternalUrl("https://docs.deadlockmods.app/")).toBe(true);
+    expect(isTrustedExternalUrl("https://deadlock-api.com/")).toBe(true);
+  });
+
+  it("rejects untrusted hosts", () => {
+    expect(isTrustedExternalUrl("https://example.com/mods/1")).toBe(false);
+    // Suffix without a dot boundary, e.g. someone registering evilgamebanana.com
+    expect(isTrustedExternalUrl("https://evilgamebanana.com/mods/1")).toBe(
+      false,
+    );
+    // Trusted host in the path or query only
+    expect(
+      isTrustedExternalUrl("https://example.com/?ref=gamebanana.com/mods/1"),
+    ).toBe(false);
+  });
+
+  it("rejects non-https protocols", () => {
+    expect(isTrustedExternalUrl("http://gamebanana.com/mods/1")).toBe(false);
+    expect(isTrustedExternalUrl("file:///etc/passwd")).toBe(false);
+    expect(isTrustedExternalUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects empty and unparseable values", () => {
+    expect(isTrustedExternalUrl(null)).toBe(false);
+    expect(isTrustedExternalUrl(undefined)).toBe(false);
+    expect(isTrustedExternalUrl("")).toBe(false);
+    expect(isTrustedExternalUrl("not a url")).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/trusted-external-url.ts
+++ b/apps/desktop/src/lib/trusted-external-url.ts
@@ -1,0 +1,35 @@
+/**
+ * Hosts we're willing to hand over
+ */
+const TRUSTED_HOSTS = [
+  "gamebanana.com",
+  "deadlockmods.app",
+  "deadlock-api.com",
+] as const;
+
+/**
+ * Whether a url that came from remote data is safe to open.
+ */
+export const isTrustedExternalUrl = (
+  url: string | null | undefined,
+): url is string => {
+  if (!url) {
+    return false;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  return TRUSTED_HOSTS.some(
+    (trusted) => host === trusted || host.endsWith(`.${trusted}`),
+  );
+};

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -2293,6 +2293,13 @@
       "countMismatch": "Expected {{expected}} file(s), got {{actual}}"
     }
   },
+  "modDependencies": {
+    "title": "Requirements",
+    "description": "This mod is built to work with the following.",
+    "openExternal": "Open link",
+    "required": "Required",
+    "recommended": "Recommended"
+  },
   "reports": {
     "reportSubmitted": "Report submitted successfully",
     "reportFailed": "Failed to submit report",

--- a/apps/desktop/src/pages/mod.tsx
+++ b/apps/desktop/src/pages/mod.tsx
@@ -13,6 +13,7 @@ import ModButton from "@/components/mod-browsing/mod-button";
 import { InstalledFilesDisplay } from "@/components/mod-detail/installed-files-display";
 import { InstalledVpksSection } from "@/components/mod-detail/installed-vpks-section";
 import { ModAudioPreview } from "@/components/mod-detail/mod-audio-preview";
+import { ModDependencies } from "@/components/mod-detail/mod-dependencies";
 import { ModDescription } from "@/components/mod-detail/mod-description";
 import { ModFiles } from "@/components/mod-detail/mod-files";
 import { ModGallery } from "@/components/mod-detail/mod-gallery";
@@ -31,6 +32,7 @@ import { BrokenModButton } from "@/components/reports/report-button";
 import ErrorBoundary from "@/components/shared/error-boundary";
 import { useFeatureFlag } from "@/hooks/use-feature-flags";
 import { useMod } from "@/hooks/use-mod";
+import { useResolvedDependencies } from "@/hooks/use-mod-dependencies";
 import { useModOptions } from "@/hooks/use-mod-options";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
 import { useReportCounts } from "@/hooks/use-report-counts";
@@ -84,6 +86,9 @@ const Mod = () => {
   const developerMode = usePersistedStore((state) => state.developerMode);
   const setModDownloads = usePersistedStore((state) => state.setModDownloads);
   const localMod = localMods.find((m) => m.remoteId === mod?.remoteId);
+  const resolvedDependencies = useResolvedDependencies(
+    mod?.dependencies ?? undefined,
+  );
 
   useEffect(() => {
     if (
@@ -326,6 +331,7 @@ const Mod = () => {
               </div>
             </CardFooter>
           </Card>
+          <ModDependencies dependencies={resolvedDependencies} />
           {isInstalled &&
             localMod?.installedVpks &&
             localMod.installedVpks.length > 0 && (

--- a/apps/desktop/src/types/dependencies.ts
+++ b/apps/desktop/src/types/dependencies.ts
@@ -1,0 +1,19 @@
+import type { ModDependency, ModDto } from "@deadlock-mods/shared";
+
+export type { ModDependency } from "@deadlock-mods/shared";
+
+/**
+ * A dependency once we've looked it up. Internal means we have the mod and can
+ * show a card for it. External means we can'tt: a tool, a mod we don't have, a
+ * note, or a link somewhere else
+ */
+export type ResolvedDependency =
+  | {
+      kind: "internal";
+      dependency: ModDependency;
+      mod: ModDto;
+    }
+  | {
+      kind: "external";
+      dependency: ModDependency;
+    };

--- a/packages/database/drizzle/0053_legal_beast.sql
+++ b/packages/database/drizzle/0053_legal_beast.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mod" ADD COLUMN "dependencies" jsonb;

--- a/packages/database/drizzle/meta/0053_snapshot.json
+++ b/packages/database/drizzle/meta/0053_snapshot.json
@@ -1,0 +1,3400 @@
+{
+  "id": "aeb806a3-4252-41f5-9518-6be8e4a981b7",
+  "prevId": "8b36bfc4-6815-4b1b-9287-897ecd416ead",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "announcement_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "status": {
+          "name": "status",
+          "type": "announcement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_author_id_user_id_fk": {
+          "name": "announcement_author_id_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "user",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_account_id": {
+          "name": "idx_account_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_access_token_on_access_token": {
+          "name": "idx_oauth_access_token_on_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_token_on_refresh_token": {
+          "name": "idx_oauth_access_token_on_refresh_token",
+          "columns": [
+            {
+              "expression": "refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_application_user_id_user_id_fk": {
+          "name": "oauth_application_user_id_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_created_at": {
+          "name": "idx_user_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_message_session_created": {
+          "name": "idx_chat_message_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_message_session_id_chat_session_id_fk": {
+          "name": "chat_message_session_id_chat_session_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session": {
+      "name": "chat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_session_discord_channel_id": {
+          "name": "idx_chat_session_discord_channel_id",
+          "columns": [
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_chat_session_user_channel": {
+          "name": "unique_chat_session_user_channel",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair_like": {
+      "name": "crosshair_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crosshair_id": {
+          "name": "crosshair_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crosshair_like_crosshair_id_user_id_idx": {
+          "name": "crosshair_like_crosshair_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "crosshair_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_like_user_id": {
+          "name": "idx_crosshair_like_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_like_crosshair_id_crosshair_id_fk": {
+          "name": "crosshair_like_crosshair_id_crosshair_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "crosshair",
+          "columnsFrom": ["crosshair_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crosshair_like_user_id_user_id_fk": {
+          "name": "crosshair_like_user_id_user_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair": {
+      "name": "crosshair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "heroes": {
+          "name": "heroes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crosshair_created_at": {
+          "name": "idx_crosshair_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_likes": {
+          "name": "idx_crosshair_likes",
+          "columns": [
+            {
+              "expression": "likes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_downloads": {
+          "name": "idx_crosshair_downloads",
+          "columns": [
+            {
+              "expression": "downloads",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_user_id": {
+          "name": "idx_crosshair_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_user_id_user_id_fk": {
+          "name": "crosshair_user_id_user_id_fk",
+          "tableFrom": "crosshair",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_setting": {
+      "name": "custom_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_chunks": {
+      "name": "documentation_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documentation_chunks_embedding_idx": {
+          "name": "documentation_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_sync": {
+      "name": "documentation_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::json"
+        },
+        "exposed": {
+          "name": "exposed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_name_unique": {
+          "name": "feature_flags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_flag_overrides": {
+      "name": "user_feature_flag_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feature_flag_overrides_user_id_user_id_fk": {
+          "name": "user_feature_flag_overrides_user_id_user_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk": {
+          "name": "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feature_flag_overrides_user_id_feature_flag_id_unique": {
+          "name": "user_feature_flag_overrides_user_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_lock": {
+      "name": "job_lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_lock_job_name_unique": {
+          "name": "job_lock_job_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_patterns": {
+      "name": "message_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern_type": {
+          "name": "pattern_type",
+          "type": "pattern_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_text": {
+          "name": "pattern_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_patterns_embedding_idx": {
+          "name": "message_patterns_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "message_patterns_pattern_type_idx": {
+          "name": "message_patterns_pattern_type_idx",
+          "columns": [
+            {
+              "expression": "pattern_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_keywords": {
+      "name": "triage_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "triage_keywords_keyword_unique": {
+          "name": "triage_keywords_keyword_unique",
+          "nullsNotDistinct": false,
+          "columns": ["keyword"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mirrored_files": {
+      "name": "mirrored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mirrored_at": {
+          "name": "mirrored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_downloaded_at": {
+          "name": "last_downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated": {
+          "name": "last_validated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stale": {
+          "name": "is_stale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mirrored_files_last_downloaded_at": {
+          "name": "idx_mirrored_files_last_downloaded_at",
+          "columns": [
+            {
+              "expression": "last_downloaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mirrored_files_is_stale": {
+          "name": "idx_mirrored_files_is_stale",
+          "columns": [
+            {
+              "expression": "is_stale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_mod_download_id_and_mod_id": {
+          "name": "unique_mod_download_id_and_mod_id",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mirrored_files_mod_download_id_mod_download_id_fk": {
+          "name": "mirrored_files_mod_download_id_mod_download_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mirrored_files_mod_id_mod_id_fk": {
+          "name": "mirrored_files_mod_id_mod_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mirrored_files_file_hash_unique": {
+          "name": "mirrored_files_file_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_download": {
+      "name": "mod_download",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "md5_checksum": {
+          "name": "md5_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_download_mod_id_remote_id_idx": {
+          "name": "mod_download_mod_id_remote_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_download_created_at": {
+          "name": "idx_mod_download_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mod_download_mod_id_mod_id_fk": {
+          "name": "mod_download_mod_id_mod_id_fk",
+          "tableFrom": "mod_download",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod": {
+      "name": "mod",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloadable": {
+          "name": "downloadable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_added_at": {
+          "name": "remote_added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_updated_at": {
+          "name": "remote_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hero": {
+          "name": "hero",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_audio": {
+          "name": "is_audio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_map": {
+          "name": "is_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_nsfw": {
+          "name": "is_nsfw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_obsolete": {
+          "name": "is_obsolete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_trashed": {
+          "name": "is_trashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_blacklisted": {
+          "name": "is_blacklisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blacklist_reason": {
+          "name": "blacklist_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_at": {
+          "name": "blacklisted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_by": {
+          "name": "blacklisted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_updated_at": {
+          "name": "files_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mod_created_at": {
+          "name": "idx_mod_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_updated_at": {
+          "name": "idx_mod_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_blacklisted_remote_updated": {
+          "name": "idx_mod_blacklisted_remote_updated",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_active_listing": {
+          "name": "idx_mod_active_listing",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_trashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mod_remote_id_unique": {
+          "name": "mod_remote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["remote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hardware_id": {
+          "name": "hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_content_hash_idx": {
+          "name": "profiles_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_answer_assets": {
+      "name": "quick_answer_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "quick_answer_asset_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_answer_assets_template_sort_idx": {
+          "name": "quick_answer_assets_template_sort_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_answer_assets_attachment_idx": {
+          "name": "quick_answer_assets_attachment_idx",
+          "columns": [
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quick_answer_assets_template_id_quick_answer_templates_id_fk": {
+          "name": "quick_answer_assets_template_id_quick_answer_templates_id_fk",
+          "tableFrom": "quick_answer_assets",
+          "tableTo": "quick_answer_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_answer_templates": {
+      "name": "quick_answer_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_discord_id": {
+          "name": "created_by_discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_discord_id": {
+          "name": "updated_by_discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_answer_templates_guild_slug_idx": {
+          "name": "quick_answer_templates_guild_slug_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_answer_templates_guild_active_idx": {
+          "name": "quick_answer_templates_guild_active_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_hardware_id": {
+          "name": "reporter_hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_mod_id_reporter_hardware_id_idx": {
+          "name": "report_mod_id_reporter_hardware_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_hardware_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_mod_id": {
+          "name": "idx_report_mod_id",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_mod_id_mod_id_fk": {
+          "name": "report_mod_id_mod_id_fk",
+          "tableFrom": "report",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rss_item": {
+      "name": "rss_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gamebanana'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rss_item_link_source_idx": {
+          "name": "rss_item_link_source_idx",
+          "columns": [
+            {
+              "expression": "link",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rss_item_pub_date_idx": {
+          "name": "rss_item_pub_date_idx",
+          "columns": [
+            {
+              "expression": "pub_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_feature_flags": {
+      "name": "segment_feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_feature_flags_segment_id_segments_id_fk": {
+          "name": "segment_feature_flags_segment_id_segments_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_feature_flags_feature_flag_id_feature_flags_id_fk": {
+          "name": "segment_feature_flags_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_feature_flags_segment_id_feature_flag_id_unique": {
+          "name": "segment_feature_flags_segment_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_members": {
+      "name": "segment_members",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_members_segment_id_segments_id_fk": {
+          "name": "segment_members_segment_id_segments_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_members_user_id_user_id_fk": {
+          "name": "segment_members_user_id_user_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_members_segment_id_user_id_unique": {
+          "name": "segment_members_segment_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segments_name_unique": {
+          "name": "segments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vpk": {
+      "name": "vpk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fast_hash": {
+          "name": "fast_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sig": {
+          "name": "content_sig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vpk_version": {
+          "name": "vpk_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_multiparts": {
+          "name": "has_multiparts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_inline_data": {
+          "name": "has_inline_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merkle_root": {
+          "name": "merkle_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "vpk_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_mtime": {
+          "name": "file_mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vpk_sha256_uk": {
+          "name": "vpk_sha256_uk",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_content_sig_idx": {
+          "name": "vpk_content_sig_idx",
+          "columns": [
+            {
+              "expression": "content_sig",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_src_uk": {
+          "name": "vpk_src_uk",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_fast_size_idx": {
+          "name": "vpk_fast_size_idx",
+          "columns": [
+            {
+              "expression": "fast_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_bytes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vpk_mod_id_mod_id_fk": {
+          "name": "vpk_mod_id_mod_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vpk_mod_download_id_mod_download_id_fk": {
+          "name": "vpk_mod_download_id_mod_download_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.announcement_category": {
+      "name": "announcement_category",
+      "schema": "public",
+      "values": ["maintenance", "downtime", "info"]
+    },
+    "public.announcement_status": {
+      "name": "announcement_status",
+      "schema": "public",
+      "values": ["draft", "published", "archived"]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": ["human", "ai", "system"]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["idle", "syncing", "error"]
+    },
+    "public.pattern_type": {
+      "name": "pattern_type",
+      "schema": "public",
+      "values": ["bug_report", "help_request"]
+    },
+    "public.quick_answer_asset_kind": {
+      "name": "quick_answer_asset_kind",
+      "schema": "public",
+      "values": ["image", "video"]
+    },
+    "public.vpk_state": {
+      "name": "vpk_state",
+      "schema": "public",
+      "values": ["ok", "duplicate", "corrupt"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1784228932248,
       "tag": "0052_cultured_menace",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1784644302365,
+      "tag": "0053_legal_beast",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/mods.ts
+++ b/packages/database/src/schema/mods.ts
@@ -28,6 +28,17 @@ export interface ModOverrides {
   downloads?: Array<{ url: string; file: string }>;
 }
 
+export interface ModDependency {
+  /** The text GameBanana shows */
+  label: string;
+  /** The link, if there is one */
+  url: string | null;
+  /** The other mod's id, if the link points at a GameBanana mod */
+  remoteId: string | null;
+  /** Required or recommended, if GameBanana says which */
+  level: "required" | "recommended" | null;
+}
+
 export const mods = pgTable(
   "mod",
   {
@@ -64,6 +75,7 @@ export const mods = pgTable(
       donationLinks?: Array<{ url: string; platform: string }>;
     }>(),
     overrides: jsonb("overrides").$type<ModOverrides>(),
+    dependencies: jsonb("dependencies").$type<ModDependency[]>(),
     ...timestamps,
   },
   (table) => [

--- a/packages/shared/src/dto/mod.dto.ts
+++ b/packages/shared/src/dto/mod.dto.ts
@@ -1,5 +1,7 @@
 import type { Mod, ModDownload } from "@deadlock-mods/database";
 
+export type { ModDependency } from "@deadlock-mods/database";
+
 export const toModDto = (mod: Mod) => {
   if (!mod.overrides) return mod;
 

--- a/packages/shared/src/providers/game-banana.ts
+++ b/packages/shared/src/providers/game-banana.ts
@@ -146,7 +146,15 @@ export type GameBananaModFile = {
   _sAvastAvResult: string;
 };
 
+/**
+ * One row from a mod's GameBanana requirements
+ */
+export type GameBananaRequirement = string[];
+
 export type GameBananaModProfile = BaseSubmission & {
+  _aRequirements?: GameBananaRequirement[] | null;
+  /** True when the mod has any requirements */
+  _bAdvancedRequirementsExist?: boolean;
   _nStatus: string;
   _bIsPrivate: boolean;
   _tsDateModified: number;
@@ -275,6 +283,9 @@ export type GameBananaModProfile = BaseSubmission & {
 };
 
 export type GameBananaSoundProfile = BaseSubmission & {
+  _aRequirements?: GameBananaRequirement[] | null;
+  /** True when the mod has any requirements */
+  _bAdvancedRequirementsExist?: boolean;
   _nStatus: string;
   _bIsPrivate: boolean;
   _tsDateModified: number;

--- a/packages/shared/src/providers/game-banana.ts
+++ b/packages/shared/src/providers/game-banana.ts
@@ -146,13 +146,9 @@ export type GameBananaModFile = {
   _sAvastAvResult: string;
 };
 
-/**
- * One row from a mod's GameBanana requirements
- */
-export type GameBananaRequirement = string[];
-
 export type GameBananaModProfile = BaseSubmission & {
-  _aRequirements?: GameBananaRequirement[] | null;
+  /** Each row is one requirement */
+  _aRequirements?: string[][] | null;
   /** True when the mod has any requirements */
   _bAdvancedRequirementsExist?: boolean;
   _nStatus: string;
@@ -283,7 +279,8 @@ export type GameBananaModProfile = BaseSubmission & {
 };
 
 export type GameBananaSoundProfile = BaseSubmission & {
-  _aRequirements?: GameBananaRequirement[] | null;
+  /** Each row is one requirement */
+  _aRequirements?: string[][] | null;
   /** True when the mod has any requirements */
   _bAdvancedRequirementsExist?: boolean;
   _nStatus: string;

--- a/packages/shared/src/schemas/mod.schemas.ts
+++ b/packages/shared/src/schemas/mod.schemas.ts
@@ -4,6 +4,13 @@ import { z } from "zod";
 const coercedDate = z.coerce.date();
 const coercedDateNullable = z.coerce.date().nullable();
 
+export const ModDependencySchema = z.object({
+  label: z.string(),
+  url: z.string().nullable(),
+  remoteId: z.string().nullable(),
+  level: z.enum(["required", "recommended"]).nullable(),
+});
+
 // ModDto schema (matches the raw Mod type from database)
 export const ModDtoSchema = z.object({
   id: z.string(),
@@ -40,6 +47,7 @@ export const ModDtoSchema = z.object({
     })
     .nullable()
     .optional(),
+  dependencies: z.array(ModDependencySchema).nullable().optional(),
   createdAt: coercedDateNullable,
   updatedAt: coercedDateNullable,
 });


### PR DESCRIPTION
## Description

Mod authors on GameBanana can list requirements on a submission, usually "install X first" or a link to a loader. We were dropping all of it, so unless the author repeated it in their description text, you'd never see it

This pulls `_aRequirements` off the mod and sound profile responses, stores it on the mod row, and puts a Requirements card on the detail page. Requirements pointing at a mod we already have link straight there, everything else links out. It's display only for now, nothing blocks or warns at install time

The parsing is a bit annoying: rows come back as words on the profile endpoint and as numbers on the base one, so `parseRequirements` matches whatever tokens it recognises rather than trusting positions.

## Future Work

- Prompt from the install button when a requirement is missing. That means touching `mod-button.tsx`, which is shared app dwide and is quite sensitive, so I want it in its own PR . It should only fire when an internal requirement is genuinely missing.
- Surface conflicts. The "uninstall X" rows dropped on ingest would get stored under a separate level and shown as a "conflicts with" section. I think this would be a cool addition aswell, but again- warrants its own PR

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude, Used for: used for researching the scope of the project and to help me setup a roadmap, also used it to generate the test(s) which later verified manually.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<img width="1529" height="1113" alt="image" src="https://github.com/user-attachments/assets/f52c1a9a-a9f7-4f5c-aaaf-c70707f1b638" />


## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [ ] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Adds a nullable `dependencies` jsonb column to `mod` (migration `0053`). This migration needs to be run

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds end-to-end support for parsing and displaying GameBanana mod requirements.

- **API (`apps/api`):** Parses `_aRequirements` from GameBanana mod and sound profiles via a new `parseRequirements` helper, normalizing required/recommended states, extracting external requirement URLs + GameBanana mod IDs (`remoteId`), and dropping incompatibility/disabled/uninstall rows. Parsed requirements are included in sync payloads as `dependencies`.
- **Database (`packages/database`):** Introduces `ModDependency` and extends the `mod` table with a nullable `dependencies` **JSONB** column via migration **`0053`**.
- **Shared (`packages/shared`):** Extends GameBanana profile DTO typings to include `_aRequirements` and re-exports `ModDependency`; updates mod DTO validation schema to include `dependencies`.
- **Desktop (`apps/desktop`):**
  - Adds `useResolvedDependencies` to resolve internal dependencies (via `getMod`) and represent unresolved/no-URL items as external requirements.
  - Adds a `ModDependencies` Requirements card on the mod detail page (with internal links for locally available mods and external links otherwise), including required/recommended severity badges and author/mod metadata.
  - Adds `isTrustedExternalUrl` with an HTTPS + hostname allowlist to safely gate external URL opening (Tauri `openUrl`) and includes unit tests for the trust logic.
  - Ensures locally processed mods persist `dependencies: null`.
- **Testing (`apps/api`):** Adds focused `parseRequirements` tests covering multiple GameBanana requirement row shapes, label-only vs URL-based rows, URL/mod-ID extraction rules, and incompatibility filtering.

**Behavior:** Display-only—requirements do not block or warn during installation. Run database migration **`0053`**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->