### PR TITLE
feat(desktop): add per-hero skins page

### DIFF
--- a/.changeset/soft-hounds-swim.md
+++ b/.changeset/soft-hounds-swim.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-Add a per-hero Skins page for choosing exactly one skin per hero, applied through the existing install/uninstall pipeline
+Add a Skins page for choosing which single skin each hero wears

--- a/.changeset/soft-hounds-swim.md
+++ b/.changeset/soft-hounds-swim.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+Add a per-hero Skins page for choosing exactly one skin per hero, applied through the existing install/uninstall pipeline

--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -13,7 +13,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@deadlock-mods/ui/components/sidebar";
-import { ShirtIcon } from "@deadlock-mods/ui/icons";
 import {
   ArticleIcon,
   BugBeetleIcon,
@@ -29,6 +28,7 @@ import {
   MapTrifoldIcon,
   PackageIcon,
   QuestionIcon,
+  TShirtIcon,
 } from "@phosphor-icons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
@@ -164,7 +164,7 @@ const getSidebarItems = (
       title: () => <span>{t("navigation.skins")}</span>,
       tooltipLabel: t("navigation.skins"),
       url: "/skins",
-      icon: ShirtIcon,
+      icon: TShirtIcon,
       group: "customization",
     },
     {

--- a/apps/desktop/src/components/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/layout/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@deadlock-mods/ui/components/sidebar";
+import { ShirtIcon } from "@deadlock-mods/ui/icons";
 import {
   ArticleIcon,
   BugBeetleIcon,
@@ -156,6 +157,14 @@ const getSidebarItems = (
       tooltipLabel: t("navigation.crosshairs"),
       url: "/crosshairs",
       icon: CrosshairIcon,
+      group: "customization",
+    },
+    {
+      id: "skins",
+      title: () => <span>{t("navigation.skins")}</span>,
+      tooltipLabel: t("navigation.skins"),
+      url: "/skins",
+      icon: ShirtIcon,
       group: "customization",
     },
     {

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -26,7 +26,6 @@ import {
   HeroConflictDialog,
   type HeroConflictResolution,
 } from "@/components/mod-browsing/hero-conflict-dialog";
-import { useConfirm } from "@/components/providers/alert-dialog";
 import ErrorBoundary from "@/components/shared/error-boundary";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { useDownload } from "@/hooks/use-download";
@@ -103,7 +102,6 @@ export const ModStatusIcon = ({
 const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
   const { t } = useTranslation();
   const { analytics } = useAnalyticsContext();
-  const confirm = useConfirm();
   const localMods = usePersistedStore((state) => state.localMods);
   const heroConflictWarningEnabled = usePersistedStore(
     (state) => state.settings["hero-conflict-warning"]?.enabled ?? true,
@@ -209,16 +207,6 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
               }
             }
           }
-          if (localMod.usesCriticalPaths) {
-            const confirmed = await confirm({
-              title: t("criticalPaths.title"),
-              body: t("criticalPaths.body"),
-              tone: "destructive",
-              cancelButton: t("criticalPaths.cancel"),
-              actionButton: t("criticalPaths.confirm"),
-            });
-            if (!confirmed) break;
-          }
           await performInstall(localMod);
           break;
         }
@@ -245,7 +233,6 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     localMod,
     localMods,
     heroConflictWarningEnabled,
-    confirm,
     download,
     retryDownload,
     uninstall,

--- a/apps/desktop/src/components/mod-browsing/mod-button.tsx
+++ b/apps/desktop/src/components/mod-browsing/mod-button.tsx
@@ -30,7 +30,7 @@ import { useConfirm } from "@/components/providers/alert-dialog";
 import ErrorBoundary from "@/components/shared/error-boundary";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import { useDownload } from "@/hooks/use-download";
-import useInstallWithCollection from "@/hooks/use-install-with-collection";
+import { useInstallAction } from "@/hooks/use-install-action";
 import { useModDownloads } from "@/hooks/use-mod-downloads";
 import useUninstall from "@/hooks/use-uninstall";
 import logger from "@/lib/logger";
@@ -122,24 +122,19 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
     isDialogOpen,
   } = useDownload(remoteMod, availableFiles);
   const {
-    install,
+    performInstall,
     isAnalyzing,
     currentFileTree,
     showFileSelector,
     confirmInstallation,
     cancelInstallation,
     currentMod,
-  } = useInstallWithCollection();
+  } = useInstallAction();
   const { uninstall } = useUninstall();
   const modProgress = usePersistedStore((state) =>
     remoteMod?.remoteId ? state.modProgress[remoteMod.remoteId] : undefined,
   );
-  const setInstalledVpks = usePersistedStore((state) => state.setInstalledVpks);
   const removeMod = usePersistedStore((state) => state.removeMod);
-  const setModStatus = usePersistedStore((state) => state.setModStatus);
-  const setModEnabledInCurrentProfile = usePersistedStore(
-    (state) => state.setModEnabledInCurrentProfile,
-  );
   const [ref, hovering] = useHover();
   const [isActionInProgress, setIsActionInProgress] = useState(false);
   const [heroConflict, setHeroConflict] = useState<{
@@ -150,62 +145,6 @@ const ModButton = ({ remoteMod, variant = "default" }: ModButtonProps) => {
   const heroConflictResolverRef = useRef<
     ((resolution: HeroConflictResolution) => void) | null
   >(null);
-
-  const performInstall = useCallback(
-    async (mod: typeof localMod) => {
-      if (!mod) {
-        return;
-      }
-      await install(mod, {
-        onStart: (m) => {
-          setModStatus(m.remoteId, ModStatus.Installing);
-        },
-        onComplete: (m, result) => {
-          setModStatus(m.remoteId, ModStatus.Installed);
-          setInstalledVpks(m.remoteId, result.installed_vpks, result.file_tree);
-          setModEnabledInCurrentProfile(m.remoteId, true);
-          toast.success(t("notifications.modInstalledSuccessfully"));
-          analytics.trackModInstalled(m.remoteId, {
-            vpk_count: result.installed_vpks.length,
-            file_tree_complexity: result.file_tree?.has_multiple_files
-              ? "complex"
-              : "simple",
-          });
-        },
-        onError: (m, error) => {
-          setModStatus(m.remoteId, ModStatus.Downloaded);
-          toast.error(error.message || t("notifications.failedToInstallMod"));
-          analytics.trackError(
-            "mod_installation",
-            error.message || "Unknown installation error",
-            { mod_id: m.remoteId },
-          );
-        },
-        onCancel: (m) => {
-          setModStatus(m.remoteId, ModStatus.Downloaded);
-          toast.info(t("notifications.installationCanceled"));
-        },
-        onFileTreeAnalyzed: (m, fileTree) => {
-          if (fileTree.has_multiple_files) {
-            toast.info(
-              t("notifications.modContainsFiles", {
-                modName: m.name,
-                fileCount: fileTree.total_files,
-              }),
-            );
-          }
-        },
-      });
-    },
-    [
-      install,
-      setModStatus,
-      setInstalledVpks,
-      setModEnabledInCurrentProfile,
-      t,
-      analytics,
-    ],
-  );
 
   const askHeroConflict = useCallback(
     (heroName: string, currentMod: LocalMod, newMod: LocalMod) =>

--- a/apps/desktop/src/components/skins/hero-list.tsx
+++ b/apps/desktop/src/components/skins/hero-list.tsx
@@ -1,0 +1,103 @@
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@deadlock-mods/ui/components/avatar";
+import { Input } from "@deadlock-mods/ui/components/input";
+import { TriangleAlert } from "@deadlock-mods/ui/icons";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useHero } from "@/hooks/use-hero";
+import { cn } from "@/lib/utils";
+
+export interface HeroListEntry {
+  hero: string;
+  skinCount: number;
+  activeNames: string[];
+  conflicted: boolean;
+}
+
+interface HeroListRowProps {
+  entry: HeroListEntry;
+  isSelected: boolean;
+  onSelect: (hero: string) => void;
+}
+
+const HeroListRow = ({ entry, isSelected, onSelect }: HeroListRowProps) => {
+  const { t } = useTranslation();
+  const { data: hero } = useHero(entry.hero);
+  const heroImage =
+    hero?.images.icon_image_small_webp ?? hero?.images.icon_image_small;
+
+  const subtitle = entry.conflicted
+    ? t("skins.conflict")
+    : (entry.activeNames[0] ?? t("skins.default"));
+
+  return (
+    <button
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-accent",
+        isSelected && "bg-accent",
+        entry.skinCount === 0 && "opacity-50",
+      )}
+      onClick={() => onSelect(entry.hero)}
+      type='button'>
+      <Avatar className='h-9 w-9'>
+        {heroImage && <AvatarImage alt={entry.hero} src={heroImage} />}
+        <AvatarFallback>{entry.hero.charAt(0)}</AvatarFallback>
+      </Avatar>
+      <div className='min-w-0 flex-1'>
+        <div className='truncate font-medium text-sm'>{entry.hero}</div>
+        <div
+          className={cn(
+            "flex items-center gap-1 text-muted-foreground text-xs",
+            entry.conflicted && "text-destructive",
+          )}>
+          {entry.conflicted && <TriangleAlert className='h-3 w-3 shrink-0' />}
+          <span className='truncate'>
+            {entry.skinCount === 0 ? t("skins.noSkins") : subtitle}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+interface HeroListProps {
+  entries: HeroListEntry[];
+  selectedHero: string | null;
+  onSelect: (hero: string) => void;
+}
+
+export const HeroList = ({
+  entries,
+  selectedHero,
+  onSelect,
+}: HeroListProps) => {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+
+  const visible = entries.filter((entry) =>
+    entry.hero.toLowerCase().includes(query.trim().toLowerCase()),
+  );
+
+  return (
+    <div className='flex h-full w-64 shrink-0 flex-col gap-2'>
+      <Input
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder={t("skins.searchPlaceholder")}
+        value={query}
+      />
+      <div className='flex-1 overflow-y-auto'>
+        {visible.map((entry) => (
+          <HeroListRow
+            entry={entry}
+            isSelected={entry.hero === selectedHero}
+            key={entry.hero}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/components/skins/skin-card.tsx
+++ b/apps/desktop/src/components/skins/skin-card.tsx
@@ -23,18 +23,36 @@ export const SkinCard = ({
   const { t } = useTranslation();
   const { shouldBlur, handleNSFWToggle, nsfwSettings } = useNSFWBlur(mod);
 
+  const handleSelect = () => {
+    if (!disabled) {
+      onSelect();
+    }
+  };
+
   return (
     <Card
+      aria-disabled={disabled}
+      aria-pressed={isActive}
       className={cn(
         "cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         isActive && "ring-2 ring-primary",
         disabled && "pointer-events-none opacity-60",
       )}
-      onClick={() => {
-        if (!disabled) {
-          onSelect();
+      onClick={handleSelect}
+      onKeyDown={(e) => {
+        // Guard on the card itself so Enter on the nested NSFW or variant
+        // controls does not also trigger a swap.
+        if (
+          e.target === e.currentTarget &&
+          (e.key === "Enter" || e.key === " ")
+        ) {
+          e.preventDefault();
+          handleSelect();
         }
-      }}>
+      }}
+      role='button'
+      tabIndex={disabled ? -1 : 0}>
       {mod.images.length > 0 ? (
         <NSFWBlur
           blurStrength={nsfwSettings.blurStrength}
@@ -82,18 +100,31 @@ export const DefaultSkinCard = ({
 }: DefaultSkinCardProps) => {
   const { t } = useTranslation();
 
+  const handleSelect = () => {
+    if (!disabled) {
+      onSelect();
+    }
+  };
+
   return (
     <Card
+      aria-disabled={disabled}
+      aria-pressed={isActive}
       className={cn(
         "cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         isActive && "ring-2 ring-primary",
         disabled && "pointer-events-none opacity-60",
       )}
-      onClick={() => {
-        if (!disabled) {
-          onSelect();
+      onClick={handleSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleSelect();
         }
-      }}>
+      }}
+      role='button'
+      tabIndex={disabled ? -1 : 0}>
       <div className='flex h-32 w-full items-center justify-center bg-muted text-muted-foreground'>
         {t("skins.default")}
       </div>

--- a/apps/desktop/src/components/skins/skin-card.tsx
+++ b/apps/desktop/src/components/skins/skin-card.tsx
@@ -30,7 +30,7 @@ export const SkinCard = ({
         disabled && "pointer-events-none opacity-60",
       )}
       onClick={() => {
-        if (!(disabled || isActive)) {
+        if (!disabled) {
           onSelect();
         }
       }}>
@@ -88,7 +88,7 @@ export const DefaultSkinCard = ({
         disabled && "pointer-events-none opacity-60",
       )}
       onClick={() => {
-        if (!(disabled || isActive)) {
+        if (!disabled) {
           onSelect();
         }
       }}>

--- a/apps/desktop/src/components/skins/skin-card.tsx
+++ b/apps/desktop/src/components/skins/skin-card.tsx
@@ -1,0 +1,111 @@
+import { Card } from "@deadlock-mods/ui/components/card";
+import { Check } from "@deadlock-mods/ui/icons";
+import { useTranslation } from "react-i18next";
+import { NSFWBlur } from "@/components/mod-browsing/nsfw-blur";
+import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
+import { cn } from "@/lib/utils";
+import type { LocalMod } from "@/types/mods";
+
+interface SkinCardProps {
+  mod: LocalMod;
+  isActive: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}
+
+export const SkinCard = ({
+  mod,
+  isActive,
+  disabled,
+  onSelect,
+}: SkinCardProps) => {
+  const { t } = useTranslation();
+  const { shouldBlur, handleNSFWToggle, nsfwSettings } = useNSFWBlur(mod);
+
+  return (
+    <Card
+      className={cn(
+        "cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
+        isActive && "ring-2 ring-primary",
+        disabled && "pointer-events-none opacity-60",
+      )}
+      onClick={() => {
+        if (!(disabled || isActive)) {
+          onSelect();
+        }
+      }}>
+      {mod.images.length > 0 ? (
+        <NSFWBlur
+          blurStrength={nsfwSettings.blurStrength}
+          className='h-32 w-full overflow-hidden'
+          disableBlur={nsfwSettings.disableBlur}
+          isNSFW={shouldBlur}
+          onToggleVisibility={handleNSFWToggle}>
+          <img
+            alt={mod.name}
+            className='h-32 w-full object-cover'
+            decoding='async'
+            loading='lazy'
+            src={mod.images[0]}
+          />
+        </NSFWBlur>
+      ) : (
+        <div className='flex h-32 w-full items-center justify-center bg-muted text-muted-foreground text-sm'>
+          {t("mods.noPreviewAvailable")}
+        </div>
+      )}
+      <div className='flex items-start justify-between gap-2 p-3'>
+        <div className='min-w-0'>
+          <div className='truncate font-medium text-sm'>{mod.name}</div>
+          <div className='truncate text-muted-foreground text-xs'>
+            {mod.author}
+          </div>
+        </div>
+        {isActive && <Check className='h-4 w-4 shrink-0 text-primary' />}
+      </div>
+    </Card>
+  );
+};
+
+interface DefaultSkinCardProps {
+  isActive: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}
+
+export const DefaultSkinCard = ({
+  isActive,
+  disabled,
+  onSelect,
+}: DefaultSkinCardProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Card
+      className={cn(
+        "cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
+        isActive && "ring-2 ring-primary",
+        disabled && "pointer-events-none opacity-60",
+      )}
+      onClick={() => {
+        if (!(disabled || isActive)) {
+          onSelect();
+        }
+      }}>
+      <div className='flex h-32 w-full items-center justify-center bg-muted text-muted-foreground'>
+        {t("skins.default")}
+      </div>
+      <div className='flex items-start justify-between gap-2 p-3'>
+        <div className='min-w-0'>
+          <div className='truncate font-medium text-sm'>
+            {t("skins.default")}
+          </div>
+          <div className='truncate text-muted-foreground text-xs'>
+            {t("skins.defaultDescription")}
+          </div>
+        </div>
+        {isActive && <Check className='h-4 w-4 shrink-0 text-primary' />}
+      </div>
+    </Card>
+  );
+};

--- a/apps/desktop/src/components/skins/skin-card.tsx
+++ b/apps/desktop/src/components/skins/skin-card.tsx
@@ -2,6 +2,7 @@ import { Card } from "@deadlock-mods/ui/components/card";
 import { Check } from "@deadlock-mods/ui/icons";
 import { useTranslation } from "react-i18next";
 import { NSFWBlur } from "@/components/mod-browsing/nsfw-blur";
+import { SkinVariantControls } from "@/components/skins/skin-variant-controls";
 import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { cn } from "@/lib/utils";
 import type { LocalMod } from "@/types/mods";
@@ -63,6 +64,7 @@ export const SkinCard = ({
         </div>
         {isActive && <Check className='h-4 w-4 shrink-0 text-primary' />}
       </div>
+      <SkinVariantControls mod={mod} />
     </Card>
   );
 };

--- a/apps/desktop/src/components/skins/skin-grid.tsx
+++ b/apps/desktop/src/components/skins/skin-grid.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from "react-i18next";
+import { DefaultSkinCard, SkinCard } from "@/components/skins/skin-card";
+import type { LocalMod } from "@/types/mods";
+
+interface SkinGridProps {
+  hero: string;
+  skins: LocalMod[];
+  activeIds: Set<string>;
+  disabled: boolean;
+  onSelect: (mod: LocalMod | null) => void;
+}
+
+export const SkinGrid = ({
+  hero,
+  skins,
+  activeIds,
+  disabled,
+  onSelect,
+}: SkinGridProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className='flex-1 overflow-y-auto pr-2'>
+      <div className='mb-4'>
+        <h2 className='font-semibold text-xl'>{hero}</h2>
+        <p className='text-muted-foreground text-sm'>
+          {t("skins.skinsDownloaded", { count: skins.length })}
+        </p>
+      </div>
+      {skins.length === 0 ? (
+        <p className='max-w-md text-muted-foreground text-sm'>
+          {t("skins.noSkinsHint")}
+        </p>
+      ) : (
+        <div className='grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4'>
+          <DefaultSkinCard
+            disabled={disabled}
+            isActive={activeIds.size === 0}
+            onSelect={() => onSelect(null)}
+          />
+          {skins.map((mod) => (
+            <SkinCard
+              disabled={disabled}
+              isActive={activeIds.has(mod.remoteId)}
+              key={mod.remoteId}
+              mod={mod}
+              onSelect={() => onSelect(mod)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/skins/skin-variant-controls.tsx
+++ b/apps/desktop/src/components/skins/skin-variant-controls.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@deadlock-mods/ui/components/button";
+import { Settings } from "@deadlock-mods/ui/icons";
+import { useTranslation } from "react-i18next";
+import { ModOptionsDialog } from "@/components/mod-management/mod-options-dialog";
+import { useModOptions } from "@/hooks/use-mod-options";
+import type { LocalMod } from "@/types/mods";
+
+interface SkinVariantControlsProps {
+  mod: LocalMod;
+}
+
+export const SkinVariantControls = ({ mod }: SkinVariantControlsProps) => {
+  const { t } = useTranslation();
+  const modOptions = useModOptions(mod);
+
+  if (!modOptions.showButton) {
+    return null;
+  }
+
+  return (
+    // Stop propagation so the controls never bubble a click into the card's
+    // select handler.
+    <div
+      className='flex items-center justify-between gap-2 border-t px-3 py-2'
+      onClick={(e) => e.stopPropagation()}>
+      <span className='truncate text-muted-foreground text-xs'>
+        {[...modOptions.activeArchiveNames].join(", ")}
+      </span>
+      <Button
+        icon={<Settings className='h-3 w-3' />}
+        onClick={modOptions.open}
+        size='sm'
+        variant='outline'>
+        {t("skins.variants")}
+      </Button>
+      <ModOptionsDialog
+        activeArchiveNames={modOptions.activeArchiveNames}
+        downloads={modOptions.downloads}
+        isOpen={modOptions.isOpen}
+        isSaving={modOptions.isSaving}
+        modName={mod.name}
+        onApply={modOptions.apply}
+        onCancel={modOptions.close}
+        onDiskArchiveNames={modOptions.onDiskArchiveNames}
+        onOpenChange={(open) => (open ? modOptions.open() : modOptions.close())}
+      />
+    </div>
+  );
+};

--- a/apps/desktop/src/components/skins/skin-variant-controls.tsx
+++ b/apps/desktop/src/components/skins/skin-variant-controls.tsx
@@ -1,4 +1,9 @@
 import { Button } from "@deadlock-mods/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deadlock-mods/ui/components/tooltip";
 import { Settings } from "@deadlock-mods/ui/icons";
 import { useTranslation } from "react-i18next";
 import { ModOptionsDialog } from "@/components/mod-management/mod-options-dialog";
@@ -26,13 +31,19 @@ export const SkinVariantControls = ({ mod }: SkinVariantControlsProps) => {
       <span className='truncate text-muted-foreground text-xs'>
         {[...modOptions.activeArchiveNames].join(", ")}
       </span>
-      <Button
-        icon={<Settings className='h-3 w-3' />}
-        onClick={modOptions.open}
-        size='sm'
-        variant='outline'>
-        {t("skins.variants")}
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            aria-label={t("skins.variants")}
+            className='h-8 w-8 shrink-0'
+            icon={<Settings className='h-3 w-3' />}
+            onClick={modOptions.open}
+            size='icon'
+            variant='outline'
+          />
+        </TooltipTrigger>
+        <TooltipContent>{t("skins.variants")}</TooltipContent>
+      </Tooltip>
       <ModOptionsDialog
         activeArchiveNames={modOptions.activeArchiveNames}
         downloads={modOptions.downloads}

--- a/apps/desktop/src/hooks/use-install-action.ts
+++ b/apps/desktop/src/hooks/use-install-action.ts
@@ -1,6 +1,7 @@
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useConfirm } from "@/components/providers/alert-dialog";
 import { useAnalyticsContext } from "@/contexts/analytics-context";
 import useInstallWithCollection from "@/hooks/use-install-with-collection";
 import { usePersistedStore } from "@/lib/store";
@@ -19,6 +20,7 @@ export type UseInstallActionReturn = {
 export const useInstallAction = (): UseInstallActionReturn => {
   const { t } = useTranslation();
   const { analytics } = useAnalyticsContext();
+  const confirm = useConfirm();
   const setInstalledVpks = usePersistedStore((state) => state.setInstalledVpks);
   const setModStatus = usePersistedStore((state) => state.setModStatus);
   const setModEnabledInCurrentProfile = usePersistedStore(
@@ -36,6 +38,19 @@ export const useInstallAction = (): UseInstallActionReturn => {
 
   const performInstall = useCallback(
     async (mod: LocalMod) => {
+      if (mod.usesCriticalPaths) {
+        const confirmed = await confirm({
+          title: t("criticalPaths.title"),
+          body: t("criticalPaths.body"),
+          tone: "destructive",
+          cancelButton: t("criticalPaths.cancel"),
+          actionButton: t("criticalPaths.confirm"),
+        });
+        if (!confirmed) {
+          return;
+        }
+      }
+
       await install(mod, {
         onStart: (m) => {
           setModStatus(m.remoteId, ModStatus.Installing);
@@ -84,6 +99,7 @@ export const useInstallAction = (): UseInstallActionReturn => {
       setModEnabledInCurrentProfile,
       t,
       analytics,
+      confirm,
     ],
   );
 

--- a/apps/desktop/src/hooks/use-install-action.ts
+++ b/apps/desktop/src/hooks/use-install-action.ts
@@ -1,0 +1,99 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useAnalyticsContext } from "@/contexts/analytics-context";
+import useInstallWithCollection from "@/hooks/use-install-with-collection";
+import { usePersistedStore } from "@/lib/store";
+import { type LocalMod, type ModFileTree, ModStatus } from "@/types/mods";
+
+export type UseInstallActionReturn = {
+  performInstall: (mod: LocalMod) => Promise<void>;
+  isAnalyzing: boolean;
+  currentFileTree: ModFileTree | null;
+  showFileSelector: boolean;
+  confirmInstallation: (fileTree: ModFileTree) => Promise<void>;
+  cancelInstallation: () => void;
+  currentMod: LocalMod | null;
+};
+
+export const useInstallAction = (): UseInstallActionReturn => {
+  const { t } = useTranslation();
+  const { analytics } = useAnalyticsContext();
+  const setInstalledVpks = usePersistedStore((state) => state.setInstalledVpks);
+  const setModStatus = usePersistedStore((state) => state.setModStatus);
+  const setModEnabledInCurrentProfile = usePersistedStore(
+    (state) => state.setModEnabledInCurrentProfile,
+  );
+  const {
+    install,
+    isAnalyzing,
+    currentFileTree,
+    showFileSelector,
+    confirmInstallation,
+    cancelInstallation,
+    currentMod,
+  } = useInstallWithCollection();
+
+  const performInstall = useCallback(
+    async (mod: LocalMod) => {
+      await install(mod, {
+        onStart: (m) => {
+          setModStatus(m.remoteId, ModStatus.Installing);
+        },
+        onComplete: (m, result) => {
+          setModStatus(m.remoteId, ModStatus.Installed);
+          setInstalledVpks(m.remoteId, result.installed_vpks, result.file_tree);
+          setModEnabledInCurrentProfile(m.remoteId, true);
+          toast.success(t("notifications.modInstalledSuccessfully"));
+          analytics.trackModInstalled(m.remoteId, {
+            vpk_count: result.installed_vpks.length,
+            file_tree_complexity: result.file_tree?.has_multiple_files
+              ? "complex"
+              : "simple",
+          });
+        },
+        onError: (m, error) => {
+          setModStatus(m.remoteId, ModStatus.Downloaded);
+          toast.error(error.message || t("notifications.failedToInstallMod"));
+          analytics.trackError(
+            "mod_installation",
+            error.message || "Unknown installation error",
+            { mod_id: m.remoteId },
+          );
+        },
+        onCancel: (m) => {
+          setModStatus(m.remoteId, ModStatus.Downloaded);
+          toast.info(t("notifications.installationCanceled"));
+        },
+        onFileTreeAnalyzed: (m, fileTree) => {
+          if (fileTree.has_multiple_files) {
+            toast.info(
+              t("notifications.modContainsFiles", {
+                modName: m.name,
+                fileCount: fileTree.total_files,
+              }),
+            );
+          }
+        },
+      });
+    },
+    [
+      install,
+      setModStatus,
+      setInstalledVpks,
+      setModEnabledInCurrentProfile,
+      t,
+      analytics,
+    ],
+  );
+
+  return {
+    performInstall,
+    isAnalyzing,
+    currentFileTree,
+    showFileSelector,
+    confirmInstallation,
+    cancelInstallation,
+    currentMod,
+  };
+};

--- a/apps/desktop/src/hooks/use-install-with-collection.ts
+++ b/apps/desktop/src/hooks/use-install-with-collection.ts
@@ -14,6 +14,23 @@ import type { ErrorKind } from "@/types/tauri";
 
 const logger = createLogger("install-with-collection");
 
+// Every rejection has to reach onError or the mod stays stuck in Installing.
+// An empty message is deliberate: callers substitute their own localized copy.
+const toUnknownError = (error: unknown): ErrorKind => {
+  if (typeof error === "string") {
+    return { kind: "unknown", message: error };
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return { kind: "unknown", message: error.message };
+  }
+  return { kind: "unknown", message: "" };
+};
+
 export type InstallWithCollectionOptions = {
   onStart: (mod: LocalMod) => void;
   onComplete: (mod: LocalMod, result: InstallableMod) => void;
@@ -130,11 +147,7 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
       ) {
         options.onError(mod, error as ErrorKind);
       } else {
-        // A swallowed failure leaves the mod stuck in Installing forever.
-        options.onError(mod, {
-          kind: "unknown",
-          message: typeof error === "string" ? error : "",
-        });
+        options.onError(mod, toUnknownError(error));
       }
       return null;
     }
@@ -349,11 +362,7 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
       ) {
         options.onError(mod, error as ErrorKind);
       } else {
-        // A swallowed failure leaves the mod stuck in Installing forever.
-        options.onError(mod, {
-          kind: "unknown",
-          message: typeof error === "string" ? error : "",
-        });
+        options.onError(mod, toUnknownError(error));
       }
       return null;
     }

--- a/apps/desktop/src/hooks/use-install-with-collection.ts
+++ b/apps/desktop/src/hooks/use-install-with-collection.ts
@@ -129,6 +129,12 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
         "kind" in error
       ) {
         options.onError(mod, error as ErrorKind);
+      } else {
+        // A swallowed failure leaves the mod stuck in Installing forever.
+        options.onError(mod, {
+          kind: "unknown",
+          message: typeof error === "string" ? error : "",
+        });
       }
       return null;
     }
@@ -342,6 +348,12 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
         "kind" in error
       ) {
         options.onError(mod, error as ErrorKind);
+      } else {
+        // A swallowed failure leaves the mod stuck in Installing forever.
+        options.onError(mod, {
+          kind: "unknown",
+          message: typeof error === "string" ? error : "",
+        });
       }
       return null;
     }

--- a/apps/desktop/src/hooks/use-mod-options.ts
+++ b/apps/desktop/src/hooks/use-mod-options.ts
@@ -154,6 +154,28 @@ const deriveOriginalsForArchive = (
     .map((f) => f.name);
 };
 
+export const deriveActiveArchiveNames = (mod: LocalMod | null): Set<string> => {
+  const names = new Set<string>();
+  for (const f of mod?.installedFileTree?.files ?? []) {
+    if (f.is_selected && f.archive_name) names.add(f.archive_name);
+  }
+  if (names.size === 0 && mod?.activeVariantArchive) {
+    for (const part of mod.activeVariantArchive.split(",")) {
+      if (part) names.add(part);
+    }
+  }
+  if (
+    names.size === 0 &&
+    mod?.selectedDownloads &&
+    mod.selectedDownloads.length > 0
+  ) {
+    for (const d of mod.selectedDownloads) {
+      names.add(d.name);
+    }
+  }
+  return names;
+};
+
 export const useModOptions = (mod: LocalMod | null) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -176,31 +198,10 @@ export const useModOptions = (mod: LocalMod | null) => {
     [mod?.selectedDownloads],
   );
 
-  const activeArchiveNames = useMemo(() => {
-    const names = new Set<string>();
-    for (const f of mod?.installedFileTree?.files ?? []) {
-      if (f.is_selected && f.archive_name) names.add(f.archive_name);
-    }
-    if (names.size === 0 && mod?.activeVariantArchive) {
-      for (const part of mod.activeVariantArchive.split(",")) {
-        if (part) names.add(part);
-      }
-    }
-    if (
-      names.size === 0 &&
-      mod?.selectedDownloads &&
-      mod.selectedDownloads.length > 0
-    ) {
-      for (const d of mod.selectedDownloads) {
-        names.add(d.name);
-      }
-    }
-    return names;
-  }, [
-    mod?.installedFileTree,
-    mod?.activeVariantArchive,
-    mod?.selectedDownloads,
-  ]);
+  const activeArchiveNames = useMemo(
+    () => deriveActiveArchiveNames(mod),
+    [mod?.installedFileTree, mod?.activeVariantArchive, mod?.selectedDownloads],
+  );
 
   const showButton =
     mod?.status === ModStatus.Installed && downloads.length > 1;

--- a/apps/desktop/src/hooks/use-skin-swap.ts
+++ b/apps/desktop/src/hooks/use-skin-swap.ts
@@ -1,0 +1,74 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  type UseInstallActionReturn,
+  useInstallAction,
+} from "@/hooks/use-install-action";
+import useUninstall from "@/hooks/use-uninstall";
+import logger from "@/lib/logger";
+import { groupSkinsByHero } from "@/lib/mods/skin-selection";
+import { swapHeroSkin } from "@/lib/mods/skin-swap";
+import { usePersistedStore } from "@/lib/store";
+import { type LocalMod, ModStatus } from "@/types/mods";
+
+const isStillInstalled = (remoteId: string): boolean =>
+  usePersistedStore
+    .getState()
+    .localMods.find((mod) => mod.remoteId === remoteId)?.status ===
+  ModStatus.Installed;
+
+export const useSkinSwap = (): {
+  selectSkin: (hero: string, target: LocalMod | null) => Promise<void>;
+  swappingHero: string | null;
+  installAction: UseInstallActionReturn;
+} => {
+  const { t } = useTranslation();
+  const { uninstall } = useUninstall();
+  const installAction = useInstallAction();
+  const [swappingHero, setSwappingHero] = useState<string | null>(null);
+
+  const selectSkin = useCallback(
+    async (hero: string, target: LocalMod | null) => {
+      if (swappingHero !== null) {
+        return;
+      }
+      setSwappingHero(hero);
+      try {
+        // Read the store fresh so a conflicted state (two installed skins) is
+        // fully collapsed even if the rendered props were stale.
+        const active =
+          groupSkinsByHero(usePersistedStore.getState().localMods).get(hero)
+            ?.active ?? [];
+
+        const result = await swapHeroSkin(active, target, {
+          uninstall: async (mod) => {
+            await uninstall(mod, false);
+            return !isStillInstalled(mod.remoteId);
+          },
+          install: async (mod) => {
+            await installAction.performInstall(mod);
+          },
+        });
+
+        if (result === "swapped" || result === "reset") {
+          const gameRunning = await invoke<boolean>("is_game_running").catch(
+            () => false,
+          );
+          if (gameRunning) {
+            toast.info(t("skins.restartHint"));
+          }
+        }
+      } catch (error) {
+        logger.errorOnly(error);
+        toast.error(t("skins.swapFailed"));
+      } finally {
+        setSwappingHero(null);
+      }
+    },
+    [swappingHero, uninstall, installAction, t],
+  );
+
+  return { selectSkin, swappingHero, installAction };
+};

--- a/apps/desktop/src/hooks/use-skin-swap.ts
+++ b/apps/desktop/src/hooks/use-skin-swap.ts
@@ -1,5 +1,4 @@
 import { toast } from "@deadlock-mods/ui/components/sonner";
-import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -7,6 +6,7 @@ import {
   useInstallAction,
 } from "@/hooks/use-install-action";
 import useUninstall from "@/hooks/use-uninstall";
+import { isGameRunning } from "@/lib/tauri-commands";
 import logger from "@/lib/logger";
 import { groupSkinsByHero } from "@/lib/mods/skin-selection";
 import { swapHeroSkin } from "@/lib/mods/skin-swap";
@@ -49,13 +49,34 @@ export const useSkinSwap = (): {
           },
           install: async (mod) => {
             await installAction.performInstall(mod);
+
+            const statusBeforeInstall = usePersistedStore
+              .getState()
+              .localMods.find((m) => m.remoteId === mod.remoteId)?.status;
+
+            if (statusBeforeInstall !== ModStatus.Installing) {
+              const finalStatus = usePersistedStore
+                .getState()
+                .localMods.find((m) => m.remoteId === mod.remoteId)?.status;
+              return finalStatus === ModStatus.Installed;
+            }
+
+            return new Promise<boolean>((resolve) => {
+              const unsubscribe = usePersistedStore.subscribe((state) => {
+                const status = state.localMods.find(
+                  (m) => m.remoteId === mod.remoteId,
+                )?.status;
+                if (status !== ModStatus.Installing) {
+                  unsubscribe();
+                  resolve(status === ModStatus.Installed);
+                }
+              });
+            });
           },
         });
 
         if (result === "swapped" || result === "reset") {
-          const gameRunning = await invoke<boolean>("is_game_running").catch(
-            () => false,
-          );
+          const gameRunning = await isGameRunning().catch(() => false);
           if (gameRunning) {
             toast.info(t("skins.restartHint"));
           }

--- a/apps/desktop/src/hooks/use-skin-swap.ts
+++ b/apps/desktop/src/hooks/use-skin-swap.ts
@@ -77,6 +77,8 @@ export const useSkinSwap = (): {
           if (gameRunning) {
             toast.info(t("skins.restartHint"));
           }
+        } else if (result === "aborted") {
+          toast.error(t("skins.swapFailed"));
         }
       } catch (error) {
         logger.errorOnly(error);

--- a/apps/desktop/src/hooks/use-skin-swap.ts
+++ b/apps/desktop/src/hooks/use-skin-swap.ts
@@ -50,15 +50,12 @@ export const useSkinSwap = (): {
           install: async (mod) => {
             await installAction.performInstall(mod);
 
-            const statusBeforeInstall = usePersistedStore
+            const status = usePersistedStore
               .getState()
               .localMods.find((m) => m.remoteId === mod.remoteId)?.status;
 
-            if (statusBeforeInstall !== ModStatus.Installing) {
-              const finalStatus = usePersistedStore
-                .getState()
-                .localMods.find((m) => m.remoteId === mod.remoteId)?.status;
-              return finalStatus === ModStatus.Installed;
+            if (status !== ModStatus.Installing) {
+              return status === ModStatus.Installed;
             }
 
             return new Promise<boolean>((resolve) => {

--- a/apps/desktop/src/lib/mods/skin-selection.test.ts
+++ b/apps/desktop/src/lib/mods/skin-selection.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { ModCategory } from "@/lib/constants";
+import { ModStatus } from "@/types/mods";
+import { groupSkinsByHero, type SkinSelectableMod } from "./skin-selection";
+
+let nextId = 0;
+const makeMod = (
+  overrides: Partial<SkinSelectableMod> = {},
+): SkinSelectableMod => ({
+  remoteId: `mod-${++nextId}`,
+  name: "Some Cosmetic",
+  hero: null,
+  category: ModCategory.SKINS,
+  status: ModStatus.Downloaded,
+  detectedHero: null,
+  heroOverride: undefined,
+  ...overrides,
+});
+
+describe("groupSkinsByHero", () => {
+  it("groups selectable skins under their resolved hero", () => {
+    const haze = makeMod({ detectedHero: "Haze" });
+    const wraith = makeMod({ hero: "Wraith" });
+    const groups = groupSkinsByHero([haze, wraith]);
+    expect(groups.get("Haze")?.skins).toEqual([haze]);
+    expect(groups.get("Wraith")?.skins).toEqual([wraith]);
+  });
+
+  it("prefers the manual hero override over detection", () => {
+    const mod = makeMod({ detectedHero: "Haze", heroOverride: "Lash" });
+    const groups = groupSkinsByHero([mod]);
+    expect(groups.get("Lash")?.skins).toEqual([mod]);
+    expect(groups.has("Haze")).toBe(false);
+  });
+
+  it("includes model replacements and excludes audio categories", () => {
+    const model = makeMod({
+      category: ModCategory.MODEL_REPLACEMENT,
+      detectedHero: "Haze",
+    });
+    const voiceLines = makeMod({
+      category: ModCategory.VOICE_LINES,
+      detectedHero: "Haze",
+    });
+    const groups = groupSkinsByHero([model, voiceLines]);
+    expect(groups.get("Haze")?.skins).toEqual([model]);
+  });
+
+  it("excludes mods in transitional statuses", () => {
+    const installing = makeMod({
+      detectedHero: "Haze",
+      status: ModStatus.Installing,
+    });
+    expect(groupSkinsByHero([installing]).size).toBe(0);
+  });
+
+  it("excludes mods with no resolvable hero", () => {
+    expect(groupSkinsByHero([makeMod()]).size).toBe(0);
+  });
+
+  it("collects every installed skin as active", () => {
+    const a = makeMod({ detectedHero: "Haze", status: ModStatus.Installed });
+    const b = makeMod({ detectedHero: "Haze", status: ModStatus.Installed });
+    const c = makeMod({ detectedHero: "Haze" });
+    const group = groupSkinsByHero([a, b, c]).get("Haze");
+    expect(group?.skins).toEqual([a, b, c]);
+    expect(group?.active).toEqual([a, b]);
+  });
+});

--- a/apps/desktop/src/lib/mods/skin-selection.test.ts
+++ b/apps/desktop/src/lib/mods/skin-selection.test.ts
@@ -54,6 +54,16 @@ describe("groupSkinsByHero", () => {
     expect(groupSkinsByHero([installing]).size).toBe(0);
   });
 
+  it("keeps failed installs selectable so they can be retried", () => {
+    const failed = makeMod({
+      detectedHero: "Haze",
+      status: ModStatus.FailedToInstall,
+    });
+    const group = groupSkinsByHero([failed]).get("Haze");
+    expect(group?.skins).toEqual([failed]);
+    expect(group?.active).toEqual([]);
+  });
+
   it("excludes mods with no resolvable hero", () => {
     expect(groupSkinsByHero([makeMod()]).size).toBe(0);
   });

--- a/apps/desktop/src/lib/mods/skin-selection.ts
+++ b/apps/desktop/src/lib/mods/skin-selection.ts
@@ -1,0 +1,59 @@
+import { ModCategory } from "@/lib/constants";
+import { resolveLocalModHero } from "@/lib/mods/hero-resolution";
+import { type LocalMod, ModStatus } from "@/types/mods";
+
+export type SkinSelectableMod = Pick<
+  LocalMod,
+  | "remoteId"
+  | "name"
+  | "hero"
+  | "category"
+  | "status"
+  | "detectedHero"
+  | "heroOverride"
+>;
+
+const SKIN_CATEGORIES: ReadonlySet<string> = new Set([
+  ModCategory.SKINS,
+  ModCategory.MODEL_REPLACEMENT,
+]);
+
+const SELECTABLE_STATUSES: ReadonlySet<ModStatus> = new Set([
+  ModStatus.Downloaded,
+  ModStatus.Installed,
+  ModStatus.FailedToInstall,
+]);
+
+export type HeroSkinGroup<T> = {
+  skins: T[];
+  active: T[];
+};
+
+export function groupSkinsByHero<T extends SkinSelectableMod>(
+  mods: T[],
+): Map<string, HeroSkinGroup<T>> {
+  const groups = new Map<string, HeroSkinGroup<T>>();
+
+  for (const mod of mods) {
+    if (
+      !SKIN_CATEGORIES.has(mod.category) ||
+      !SELECTABLE_STATUSES.has(mod.status)
+    ) {
+      continue;
+    }
+
+    const hero = resolveLocalModHero(mod).hero;
+    if (!hero) {
+      continue;
+    }
+
+    const group = groups.get(hero) ?? { skins: [], active: [] };
+    group.skins.push(mod);
+    if (mod.status === ModStatus.Installed) {
+      group.active.push(mod);
+    }
+    groups.set(hero, group);
+  }
+
+  return groups;
+}

--- a/apps/desktop/src/lib/mods/skin-swap.test.ts
+++ b/apps/desktop/src/lib/mods/skin-swap.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { swapHeroSkin } from "./skin-swap";
+
+type TestMod = { remoteId: string };
+const mod = (id: string): TestMod => ({ remoteId: id });
+
+const recordingDeps = (uninstallResults: Record<string, boolean> = {}) => {
+  const calls: string[] = [];
+  return {
+    calls,
+    deps: {
+      uninstall: async (m: TestMod) => {
+        calls.push(`uninstall:${m.remoteId}`);
+        return uninstallResults[m.remoteId] ?? true;
+      },
+      install: async (m: TestMod) => {
+        calls.push(`install:${m.remoteId}`);
+      },
+    },
+  };
+};
+
+describe("swapHeroSkin", () => {
+  it("uninstalls the active skin before installing the target", async () => {
+    const { calls, deps } = recordingDeps();
+    const result = await swapHeroSkin([mod("old")], mod("new"), deps);
+    expect(result).toBe("swapped");
+    expect(calls).toEqual(["uninstall:old", "install:new"]);
+  });
+
+  it("aborts without installing when an uninstall fails", async () => {
+    const { calls, deps } = recordingDeps({ old: false });
+    const result = await swapHeroSkin([mod("old")], mod("new"), deps);
+    expect(result).toBe("aborted");
+    expect(calls).toEqual(["uninstall:old"]);
+  });
+
+  it("resets to default by uninstalling every active skin", async () => {
+    const { calls, deps } = recordingDeps();
+    const result = await swapHeroSkin([mod("a"), mod("b")], null, deps);
+    expect(result).toBe("reset");
+    expect(calls).toEqual(["uninstall:a", "uninstall:b"]);
+  });
+
+  it("does nothing when the target is already the only active skin", async () => {
+    const { calls, deps } = recordingDeps();
+    const result = await swapHeroSkin([mod("a")], mod("a"), deps);
+    expect(result).toBe("noop");
+    expect(calls).toEqual([]);
+  });
+
+  it("keeps the target and removes the rest when resolving a conflict", async () => {
+    const { calls, deps } = recordingDeps();
+    const result = await swapHeroSkin([mod("a"), mod("b")], mod("a"), deps);
+    expect(result).toBe("swapped");
+    expect(calls).toEqual(["uninstall:b"]);
+  });
+
+  it("installs the target when nothing is active", async () => {
+    const { calls, deps } = recordingDeps();
+    const result = await swapHeroSkin([], mod("new"), deps);
+    expect(result).toBe("swapped");
+    expect(calls).toEqual(["install:new"]);
+  });
+});

--- a/apps/desktop/src/lib/mods/skin-swap.test.ts
+++ b/apps/desktop/src/lib/mods/skin-swap.test.ts
@@ -4,7 +4,10 @@ import { swapHeroSkin } from "./skin-swap";
 type TestMod = { remoteId: string };
 const mod = (id: string): TestMod => ({ remoteId: id });
 
-const recordingDeps = (uninstallResults: Record<string, boolean> = {}) => {
+const recordingDeps = (
+  uninstallResults: Record<string, boolean> = {},
+  installResults: Record<string, boolean> = {},
+) => {
   const calls: string[] = [];
   return {
     calls,
@@ -15,6 +18,7 @@ const recordingDeps = (uninstallResults: Record<string, boolean> = {}) => {
       },
       install: async (m: TestMod) => {
         calls.push(`install:${m.remoteId}`);
+        return installResults[m.remoteId] ?? true;
       },
     },
   };
@@ -61,5 +65,12 @@ describe("swapHeroSkin", () => {
     const result = await swapHeroSkin([], mod("new"), deps);
     expect(result).toBe("swapped");
     expect(calls).toEqual(["install:new"]);
+  });
+
+  it("aborts when the install fails", async () => {
+    const { calls, deps } = recordingDeps({}, { new: false });
+    const result = await swapHeroSkin([mod("old")], mod("new"), deps);
+    expect(result).toBe("aborted");
+    expect(calls).toEqual(["uninstall:old", "install:new"]);
   });
 });

--- a/apps/desktop/src/lib/mods/skin-swap.test.ts
+++ b/apps/desktop/src/lib/mods/skin-swap.test.ts
@@ -53,6 +53,13 @@ describe("swapHeroSkin", () => {
     expect(calls).toEqual([]);
   });
 
+  it("does nothing when resetting to default with no active skins", async () => {
+    const { calls, deps } = recordingDeps();
+    const result = await swapHeroSkin([], null, deps);
+    expect(result).toBe("noop");
+    expect(calls).toEqual([]);
+  });
+
   it("keeps the target and removes the rest when resolving a conflict", async () => {
     const { calls, deps } = recordingDeps();
     const result = await swapHeroSkin([mod("a"), mod("b")], mod("a"), deps);

--- a/apps/desktop/src/lib/mods/skin-swap.ts
+++ b/apps/desktop/src/lib/mods/skin-swap.ts
@@ -1,0 +1,39 @@
+export type SkinSwapDeps<T> = {
+  /** Returns false when the uninstall did not take effect; the swap aborts. */
+  uninstall: (mod: T) => Promise<boolean>;
+  install: (mod: T) => Promise<void>;
+};
+
+export type SkinSwapResult = "swapped" | "reset" | "aborted" | "noop";
+
+export async function swapHeroSkin<T extends { remoteId: string }>(
+  activeSkins: T[],
+  target: T | null,
+  deps: SkinSwapDeps<T>,
+): Promise<SkinSwapResult> {
+  const targetIsActive =
+    target !== null &&
+    activeSkins.some((mod) => mod.remoteId === target.remoteId);
+
+  if (targetIsActive && activeSkins.length === 1) {
+    return "noop";
+  }
+
+  const toRemove = activeSkins.filter(
+    (mod) => mod.remoteId !== target?.remoteId,
+  );
+  for (const mod of toRemove) {
+    const uninstalled = await deps.uninstall(mod);
+    if (!uninstalled) {
+      return "aborted";
+    }
+  }
+
+  if (target === null) {
+    return "reset";
+  }
+  if (!targetIsActive) {
+    await deps.install(target);
+  }
+  return "swapped";
+}

--- a/apps/desktop/src/lib/mods/skin-swap.ts
+++ b/apps/desktop/src/lib/mods/skin-swap.ts
@@ -1,7 +1,8 @@
 export type SkinSwapDeps<T> = {
   /** Returns false when the uninstall did not take effect; the swap aborts. */
   uninstall: (mod: T) => Promise<boolean>;
-  install: (mod: T) => Promise<void>;
+  /** Returns false when the install did not succeed; the swap aborts. */
+  install: (mod: T) => Promise<boolean>;
 };
 
 export type SkinSwapResult = "swapped" | "reset" | "aborted" | "noop";
@@ -33,7 +34,10 @@ export async function swapHeroSkin<T extends { remoteId: string }>(
     return "reset";
   }
   if (!targetIsActive) {
-    await deps.install(target);
+    const installed = await deps.install(target);
+    if (!installed) {
+      return "aborted";
+    }
   }
   return "swapped";
 }

--- a/apps/desktop/src/lib/mods/skin-swap.ts
+++ b/apps/desktop/src/lib/mods/skin-swap.ts
@@ -19,6 +19,9 @@ export async function swapHeroSkin<T extends { remoteId: string }>(
   if (targetIsActive && activeSkins.length === 1) {
     return "noop";
   }
+  if (target === null && activeSkins.length === 0) {
+    return "noop";
+  }
 
   const toRemove = activeSkins.filter(
     (mod) => mod.remoteId !== target?.remoteId,

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -48,7 +48,8 @@
     "restartHint": "Deadlock is running — the new skin appears after you restart the game.",
     "swapFailed": "Failed to change skin",
     "overrideFooter": "Skin not showing under the right hero?",
-    "overrideFooterLink": "Set its hero override in your Mods Library."
+    "overrideFooterLink": "Set its hero override in your Mods Library.",
+    "variants": "Variants"
   },
   "servers": {
     "title": "Server Browser",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -24,6 +24,7 @@
     "expandMenu": "Expand menu",
     "about": "About",
     "crosshairs": "Crosshairs",
+    "skins": "Hero Skins",
     "customization": "Customization",
     "autoexec": "Autoexec Config",
     "maps": "Maps",
@@ -32,6 +33,22 @@
     "general": "General",
     "earlyAccess": "Early Access",
     "mods": "Mods"
+  },
+  "skins": {
+    "title": "Hero Skins",
+    "subtitle": "Choose which skin each hero wears — one at a time",
+    "searchPlaceholder": "Search heroes...",
+    "default": "Default",
+    "defaultDescription": "Vanilla appearance, no skin mod",
+    "skinsDownloaded_one": "{{count}} skin downloaded",
+    "skinsDownloaded_other": "{{count}} skins downloaded",
+    "noSkins": "No skins downloaded",
+    "noSkinsHint": "Download skins from the Mods Store. If a downloaded skin isn't listed here, set its hero override from your Mods Library.",
+    "conflict": "Multiple skins active",
+    "restartHint": "Deadlock is running — the new skin appears after you restart the game.",
+    "swapFailed": "Failed to change skin",
+    "overrideFooter": "Skin not showing under the right hero?",
+    "overrideFooterLink": "Set its hero override in your Mods Library."
   },
   "servers": {
     "title": "Server Browser",

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -19,6 +19,7 @@ import MyMods from "./pages/my-mods";
 import PluginEntry from "./pages/plugin";
 import Servers from "./pages/servers";
 import CustomSettings from "./pages/settings";
+import Skins from "./pages/skins";
 import Splash from "./pages/splash";
 import "flag-icons/css/flag-icons.min.css";
 import "./index.css";
@@ -61,6 +62,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
               <Route element={<PluginEntry />} path='/plugins/:id' />
               <Route element={<Debug />} path='/debug' />
               <Route element={<Crosshairs />} path='/crosshairs' />
+              <Route element={<Skins />} path='/skins' />
               <Route
                 element={<CustomSettings value='autoexec' />}
                 path='/settings/autoexec'

--- a/apps/desktop/src/pages/skins.tsx
+++ b/apps/desktop/src/pages/skins.tsx
@@ -1,0 +1,102 @@
+import { DeadlockHeroes } from "@deadlock-mods/shared";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { FileSelectorDialog } from "@/components/downloads/file-selector-dialog";
+import PageTitle from "@/components/shared/page-title";
+import { HeroList, type HeroListEntry } from "@/components/skins/hero-list";
+import { SkinGrid } from "@/components/skins/skin-grid";
+import { useSkinSwap } from "@/hooks/use-skin-swap";
+import { groupSkinsByHero } from "@/lib/mods/skin-selection";
+import { usePersistedStore } from "@/lib/store";
+import type { LocalMod } from "@/types/mods";
+
+const Skins = () => {
+  const { t } = useTranslation();
+  const localMods = usePersistedStore((state) => state.localMods);
+  const { selectSkin, swappingHero, installAction } = useSkinSwap();
+  const [selectedHero, setSelectedHero] = useState<string | null>(null);
+
+  const groups = useMemo(() => groupSkinsByHero(localMods), [localMods]);
+
+  const entries = useMemo<HeroListEntry[]>(() => {
+    const knownHeroes = Object.values(DeadlockHeroes) as string[];
+    // Manual overrides may name heroes outside the enum; keep them visible.
+    const extraHeroes = [...groups.keys()]
+      .filter((hero) => !knownHeroes.includes(hero))
+      .sort();
+    const all = [...knownHeroes, ...extraHeroes].map((hero) => {
+      const group = groups.get(hero);
+      return {
+        hero,
+        skinCount: group?.skins.length ?? 0,
+        activeNames: group?.active.map((mod) => mod.name) ?? [],
+        conflicted: (group?.active.length ?? 0) > 1,
+      };
+    });
+    return [
+      ...all.filter((entry) => entry.skinCount > 0),
+      ...all.filter((entry) => entry.skinCount === 0),
+    ];
+  }, [groups]);
+
+  const effectiveHero =
+    selectedHero ??
+    entries.find((entry) => entry.skinCount > 0)?.hero ??
+    entries[0]?.hero ??
+    null;
+  const selectedGroup = effectiveHero ? groups.get(effectiveHero) : undefined;
+
+  const handleSelect = (mod: LocalMod | null) => {
+    if (effectiveHero) {
+      void selectSkin(effectiveHero, mod);
+    }
+  };
+
+  return (
+    <div className='flex h-full w-full flex-col overflow-hidden pl-4 pr-2'>
+      <div className='mb-6'>
+        <PageTitle subtitle={t("skins.subtitle")} title={t("skins.title")} />
+      </div>
+      <div className='flex min-h-0 flex-1 gap-4'>
+        <HeroList
+          entries={entries}
+          onSelect={setSelectedHero}
+          selectedHero={effectiveHero}
+        />
+        {effectiveHero && (
+          <SkinGrid
+            activeIds={
+              new Set((selectedGroup?.active ?? []).map((mod) => mod.remoteId))
+            }
+            disabled={swappingHero !== null}
+            hero={effectiveHero}
+            onSelect={handleSelect}
+            skins={selectedGroup?.skins ?? []}
+          />
+        )}
+      </div>
+      <p className='shrink-0 py-3 text-muted-foreground text-xs'>
+        {t("skins.overrideFooter")}{" "}
+        <Link className='underline' to='/my-mods'>
+          {t("skins.overrideFooterLink")}
+        </Link>
+      </p>
+
+      <FileSelectorDialog
+        fileTree={installAction.currentFileTree}
+        isOpen={installAction.showFileSelector}
+        modName={installAction.currentMod?.name}
+        onCancel={installAction.cancelInstallation}
+        onConfirm={installAction.confirmInstallation}
+        onOpenChange={(open) => {
+          if (!open) {
+            installAction.cancelInstallation();
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+export default Skins;

--- a/apps/desktop/src/pages/skins.tsx
+++ b/apps/desktop/src/pages/skins.tsx
@@ -6,6 +6,7 @@ import { FileSelectorDialog } from "@/components/downloads/file-selector-dialog"
 import PageTitle from "@/components/shared/page-title";
 import { HeroList, type HeroListEntry } from "@/components/skins/hero-list";
 import { SkinGrid } from "@/components/skins/skin-grid";
+import { deriveActiveArchiveNames } from "@/hooks/use-mod-options";
 import { useSkinSwap } from "@/hooks/use-skin-swap";
 import { groupSkinsByHero } from "@/lib/mods/skin-selection";
 import { usePersistedStore } from "@/lib/store";
@@ -31,7 +32,12 @@ const Skins = () => {
         hero,
         skinCount: group?.skins.length ?? 0,
         activeNames: group?.active.map((mod) => mod.name) ?? [],
-        conflicted: (group?.active.length ?? 0) > 1,
+        conflicted:
+          (group?.active.length ?? 0) > 1 ||
+          (group?.active.some(
+            (mod) => deriveActiveArchiveNames(mod).size > 1,
+          ) ??
+            false),
       };
     });
     return [

--- a/apps/desktop/src/pages/skins.tsx
+++ b/apps/desktop/src/pages/skins.tsx
@@ -21,10 +21,12 @@ const Skins = () => {
   const groups = useMemo(() => groupSkinsByHero(localMods), [localMods]);
 
   const entries = useMemo<HeroListEntry[]>(() => {
-    const knownHeroes = Object.values(DeadlockHeroes) as string[];
+    const knownHeroes: ReadonlySet<string> = new Set(
+      Object.values(DeadlockHeroes),
+    );
     // Manual overrides may name heroes outside the enum; keep them visible.
     const extraHeroes = [...groups.keys()]
-      .filter((hero) => !knownHeroes.includes(hero))
+      .filter((hero) => !knownHeroes.has(hero))
       .sort();
     const all = [...knownHeroes, ...extraHeroes].map((hero) => {
       const group = groups.get(hero);


### PR DESCRIPTION
## Description

Adds a dedicated "Skins" page to the desktop app sidebar (Customization group, next to Crosshairs). It gives a single place to see and change which skin each hero is wearing:

- Left pane: searchable hero list with portraits, subtitle showing the active skin name (or "Default"), heroes with no downloaded skins grayed out at the bottom.
- Right pane: a "Default" card plus one card per downloaded skin (Skins + Model Replacement categories only) for the selected hero, with the usual NSFW blur behavior.
- Clicking a card swaps skins through the existing install/uninstall pipeline (uninstall the old one, install the new one), so exactly one skin stays active per hero, and the existing hero-conflict dialog / profile system keeps working as-is.
- A conflicted hero (two skins somehow both active) shows a warning badge; picking any card collapses it back to one.
- If Deadlock is running when a swap happens, a toast reminds the user the change needs a restart — swaps never touch the game while it's running.

Also, as part of extracting the shared install flow (`useInstallAction`) so both the Mods page and the new Skins page install through identical logic:
- The "this mod overwrites critical game files" confirmation, previously only shown on the Mods page, now also applies to installs triggered from the Skins page.
- The install-swap sequencing now gets a verified success/failure signal (mirroring uninstall), fixing a race where a multi-file skin needing manual file selection could let a second swap start before the first one's dialog was resolved.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Related to #571

**Scope note:** this implements the core of #571 (hero list, skin cards, Default card, swap-through-existing-pipeline, conflict badge, restart hint) but does **not** include the "Variants" button described there (opening the existing Mod Options dialog for skins that ship several variants as separate archives). Leaving this open rather than closing the issue — happy to follow up in a separate PR if that's still wanted.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code, Used for: implementation across all tasks (subagent-driven development with per-task and whole-branch review), following a pre-written implementation plan and design spec

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Automated: `bun test` (109/109 passing), `pnpm check-types` (clean), `pnpm lint` (0 errors, no new warnings). Manual interactive smoke test (sidebar nav, actual game/mods) is still pending — marked as draft until that's done.

## Screenshots (if applicable)
<img width="1651" height="1030" alt="Screenshot_20260729_111057" src="https://github.com/user-attachments/assets/739d3513-ce71-4836-b646-4b29f9498629" />

## Checklist

- [x] I have read the Contributing Guidelines and AI Policy
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a dedicated desktop **Hero Skins** page to the Customization sidebar (new `/skins` route) with hero search, per-hero skin counts, NSFW-blurred previews, default-skin cards, conflict badges, and selection enforcing **one active skin per hero**.
- Implemented hero skin swapping via the existing install/uninstall pipeline, including conflict resolution/reset behavior, restart reminders when the game is running, and UI disabling while a swap is in progress.
- Extracted and centralized install orchestration into a new `useInstallAction` hook and updated the existing Mods install UI to use it, ensuring **critical-path confirmation** and consistent side-effects across both Mods and Skins.
- Ensured skin swaps **await verified install results** by resolving swap completion only after persisted install state leaves `Installing`.
- Added shared skin utilities and UI components:
  - grouping skins by hero (including hero override precedence and eligibility rules),
  - swap/reset/no-op decision logic (`swapHeroSkin`),
  - keyboard/ARIA-friendly `SkinCard` and `DefaultSkinCard`, plus `HeroList`, `SkinGrid`, and `SkinVariantControls`.
- Improved install error normalization in `use-install-with-collection` by adding `toUnknownError`, preserving message content for non-standard thrown values.

## Testing

- 109/109 unit tests passing
- Type checks clean
- No lint errors
- Manual interactive smoke testing pending

## Scope

- Changes are limited to the **desktop app** (`apps/desktop`) and its `@deadlock-mods/desktop` changeset.
- No API, bot, web, docs, shared-package, database migrations, Tauri plugin changes, or Rust/FFI boundary changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->