### PR TITLE
fix(release): harden AUR package definitions

### DIFF
--- a/distribution/aur/deadlock-modmanager-bin/PKGBUILD
+++ b/distribution/aur/deadlock-modmanager-bin/PKGBUILD
@@ -3,22 +3,22 @@ pkgname=deadlock-modmanager-bin
 pkgdesc='A mod manager for the Valve game Deadlock (binary)'
 _pkgver=1.1.0
 pkgver=${_pkgver}
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url='https://github.com/deadlock-mod-manager/deadlock-mod-manager'
 license=('GPL-3.0-only')
 depends=('webkit2gtk-4.1' 'cairo' 'desktop-file-utils' 'xdg-utils' 'gdk-pixbuf2'
          'glib2' 'gtk3' 'libsoup3' 'pango' 'openssl' 'bzip2' 'hicolor-icon-theme'
-         'gst-plugins-good')
+         'gst-plugins-good' 'glibc' 'libgcc' 'libstdc++' 'dbus')
 provides=('deadlock-modmanager')
 conflicts=('deadlock-modmanager' 'deadlock-modmanager-git')
 options=('!strip')
 source=("deadlock-modmanager-${pkgver}.deb::https://github.com/deadlock-mod-manager/deadlock-mod-manager/releases/download/v${_pkgver}/Deadlock.Mod.Manager_${_pkgver}_amd64.deb"
-        "deadlock-modmanager.desktop::https://raw.githubusercontent.com/deadlock-mod-manager/deadlock-mod-manager/main/distribution/aur/deadlock-modmanager.desktop"
-        "dev.stormix.deadlock-mod-manager.metainfo.xml::https://raw.githubusercontent.com/deadlock-mod-manager/deadlock-mod-manager/main/apps/desktop/src-tauri/dev.stormix.deadlock-mod-manager.metainfo.xml")
-sha256sums=('SKIP'
-            'SKIP'
-            'SKIP')
+        "deadlock-modmanager.desktop::https://raw.githubusercontent.com/deadlock-mod-manager/deadlock-mod-manager/v${_pkgver}/distribution/aur/deadlock-modmanager.desktop"
+        "dev.stormix.deadlock-mod-manager.metainfo.xml::https://raw.githubusercontent.com/deadlock-mod-manager/deadlock-mod-manager/v${_pkgver}/apps/desktop/src-tauri/dev.stormix.deadlock-mod-manager.metainfo.xml")
+sha256sums=('18a1eb0e68d794365ff67be2e9a733b93de0902246d956b17b73cc6430205009'
+            '74f91f52da072e31df1dd9df8e7339aa6328e8f6ed11e9b565858c6b9fab0740'
+            '9972534fb418587adc14ec23c231f60c0082bc317072c5ae69a6e1e48018a7c5')
 
 package() {
     tar xf data.tar.gz -C "${pkgdir}"
@@ -38,17 +38,4 @@ package() {
 
     install -Dm644 "${srcdir}/dev.stormix.deadlock-mod-manager.metainfo.xml" \
         "${pkgdir}/usr/share/metainfo/dev.stormix.deadlock-mod-manager.metainfo.xml"
-}
-
-post_install() {
-    gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor
-    update-desktop-database -q
-}
-
-post_upgrade() {
-    post_install
-}
-
-post_remove() {
-    post_install
 }

--- a/distribution/aur/deadlock-modmanager/PKGBUILD
+++ b/distribution/aur/deadlock-modmanager/PKGBUILD
@@ -3,18 +3,17 @@ pkgname=deadlock-modmanager
 pkgdesc='A mod manager for the Valve game Deadlock'
 _pkgver=1.1.0
 pkgver=${_pkgver}
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url='https://github.com/deadlock-mod-manager/deadlock-mod-manager'
 license=('GPL-3.0-only')
-makedepends=('cargo' 'cargo-tauri' 'pnpm' 'lld' 'gcc')
+makedepends=('cargo' 'cargo-tauri' 'pnpm')
 depends=('webkit2gtk-4.1' 'cairo' 'desktop-file-utils' 'xdg-utils' 'gdk-pixbuf2'
          'glib2' 'gtk3' 'libsoup3' 'pango' 'openssl' 'bzip2' 'hicolor-icon-theme'
-         'gst-plugins-good')
+         'gst-plugins-good' 'glibc' 'libgcc' 'libstdc++' 'dbus')
 conflicts=('deadlock-modmanager-bin' 'deadlock-modmanager-git')
-options=('!lto')
 source=("${pkgname}-${_pkgver}.tar.gz::https://github.com/deadlock-mod-manager/deadlock-mod-manager/archive/refs/tags/v${_pkgver}.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('d37f382cc3708ed6cd2de12e43fc92f0f00eb96bcbd711659e773118c10a31b1')
 
 prepare() {
     cd "${srcdir}/deadlock-mod-manager-${_pkgver}/apps/desktop"
@@ -25,9 +24,10 @@ prepare() {
 }
 
 build() {
-    export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
     export CC=gcc
     export CXX=g++
+    export CFLAGS+=" -ffat-lto-objects"
+    export CXXFLAGS+=" -ffat-lto-objects"
     export CARGO_TARGET_DIR=target
     export VITE_API_URL="https://api.deadlockmods.app"
     export VITE_WEB_URL="https://deadlockmods.app"


### PR DESCRIPTION
## Description

Apply the AUR feedback already incorporated into `deadlock-modmanager-git`
to the stable source package, and harden both release package definitions.

- enable Arch LTO flags without disabling LTO globally
- rely on Rust's bundled LLD and remove redundant build dependencies
- declare the binary's direct runtime library dependencies
- pin release metadata to the v1.1.0 tag with verified SHA-256 checksums
- remove ineffective package-local cache update functions
- increment both package releases to `pkgrel=2`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [x] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

Based on maintainer feedback from the public AUR package comments.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Codex, Used for: auditing the PKGBUILDs, applying the packaging fixes, and running build verification

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes in both development and production-like environments

Validation performed on Arch Linux:

- all three PKGBUILDs pass `namcap` linting
- `deadlock-modmanager-bin` 1.1.0-2 builds successfully with verified sources
- `deadlock-modmanager` 1.1.0-2 builds and packages successfully
- `readelf -p .comment` confirms bundled LLD 22.1.6 is used without `lld`
  in `makedepends` or an explicit linker argument
- package-level `namcap` no longer reports missing `glibc`, `libgcc`,
  `libstdc++`, or `dbus` dependencies
- `pnpm lint` completes with the repository's existing warnings and no errors
- `pnpm format` passes

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - not applicable to distribution-only files

## Additional Notes

`namcap` retains pre-existing advisory warnings for potentially unnecessary
runtime dependencies. Those were left unchanged because they require runtime
feature testing before removal.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions
