### PR TITLE
fix(desktop): hide NSFW mods on dashboard

### DIFF
--- a/.changeset/hidden-choices-honor.md
+++ b/.changeset/hidden-choices-honor.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": patch
 ---
 
-Respect the "Remember Per-Item Choices" setting when applying stored NSFW show/hide overrides
+Respect remembered NSFW show/hide choices only when enabled

--- a/.changeset/hidden-choices-honor.md
+++ b/.changeset/hidden-choices-honor.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Respect the "Remember Per-Item Choices" setting when applying stored NSFW show/hide overrides

--- a/.changeset/quiet-guards-hide.md
+++ b/.changeset/quiet-guards-hide.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix hidden NSFW mods appearing on the dashboard

--- a/apps/desktop/src/components/dashboard/latest-mods-card.tsx
+++ b/apps/desktop/src/components/dashboard/latest-mods-card.tsx
@@ -2,14 +2,18 @@ import type { ModDto } from "@deadlock-mods/shared";
 import { Skeleton } from "@deadlock-mods/ui/components/skeleton";
 import { ClockIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { getMods } from "@/lib/api-client";
+import { filterHiddenNSFWItems } from "@/lib/mods/nsfw-visibility";
 import { STALE_TIME_API } from "@/lib/query-constants";
+import { usePersistedStore } from "@/lib/store";
 import { DashboardCard } from "./dashboard-card";
 import { LatestModItem } from "./latest-mod-item";
 
 export const LatestModsCard = () => {
   const { t } = useTranslation();
+  const hideNSFW = usePersistedStore((state) => state.nsfwSettings.hideNSFW);
   const { data: mods, isPending } = useQuery({
     queryKey: ["mods"],
     queryFn: getMods,
@@ -17,13 +21,18 @@ export const LatestModsCard = () => {
     refetchOnWindowFocus: false,
   });
 
-  const latestMods = mods
-    ?.sort(
-      (a, b) =>
-        new Date(b.remoteAddedAt).getTime() -
-        new Date(a.remoteAddedAt).getTime(),
-    )
-    .slice(0, 5);
+  const latestMods = useMemo(() => {
+    const visibleMods = filterHiddenNSFWItems(mods, hideNSFW);
+    return visibleMods
+      ? [...visibleMods]
+          .sort(
+            (a, b) =>
+              new Date(b.remoteAddedAt).getTime() -
+              new Date(a.remoteAddedAt).getTime(),
+          )
+          .slice(0, 5)
+      : undefined;
+  }, [hideNSFW, mods]);
 
   const modsContent =
     latestMods && latestMods.length > 0 ? (

--- a/apps/desktop/src/hooks/use-nsfw-blur.ts
+++ b/apps/desktop/src/hooks/use-nsfw-blur.ts
@@ -27,8 +27,9 @@ export function useNSFWBlur(item?: NSFWItem | null) {
     return shouldBlurNSFWItem({
       isNSFW: item.isNSFW,
       isVisibleOverride: getPerItemNSFWOverride(item.remoteId),
+      rememberOverrides: nsfwSettings.rememberPerItemOverrides,
     });
-  }, [item, getPerItemNSFWOverride]);
+  }, [item, nsfwSettings.rememberPerItemOverrides, getPerItemNSFWOverride]);
 
   const handleNSFWToggle = (visible: boolean) => {
     if (item && nsfwSettings.rememberPerItemOverrides) {

--- a/apps/desktop/src/hooks/use-nsfw-blur.ts
+++ b/apps/desktop/src/hooks/use-nsfw-blur.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { shouldBlurNSFWItem } from "@/lib/mods/nsfw-visibility";
 import { usePersistedStore } from "@/lib/store";
 
 interface NSFWItem {
@@ -21,19 +22,13 @@ export function useNSFWBlur(item?: NSFWItem | null) {
   );
 
   const shouldBlur = useMemo(() => {
-    if (!item?.isNSFW) {
-      return false; // Not NSFW, no need to blur
-    }
+    if (!item) return false;
 
-    // Check for per-item override first
-    const override = getPerItemNSFWOverride(item.remoteId);
-    if (override !== undefined) {
-      return !override; // If override says show (true), don't blur (false)
-    }
-
-    // Use global setting if no per-item override
-    return !nsfwSettings.hideNSFW; // If hiding NSFW globally, blur when visible
-  }, [item, nsfwSettings.hideNSFW, getPerItemNSFWOverride]);
+    return shouldBlurNSFWItem({
+      isNSFW: item.isNSFW,
+      isVisibleOverride: getPerItemNSFWOverride(item.remoteId),
+    });
+  }, [item, getPerItemNSFWOverride]);
 
   const handleNSFWToggle = (visible: boolean) => {
     if (item && nsfwSettings.rememberPerItemOverrides) {

--- a/apps/desktop/src/lib/mods/nsfw-visibility.test.ts
+++ b/apps/desktop/src/lib/mods/nsfw-visibility.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { filterHiddenNSFWItems, shouldBlurNSFWItem } from "./nsfw-visibility";
+
+describe("filterHiddenNSFWItems", () => {
+  const mods = [
+    { name: "NSFW mod A", isNSFW: true },
+    { name: "NSFW mod B", isNSFW: true },
+    { name: "SFW mod", isNSFW: false },
+  ];
+
+  it("removes NSFW items when hiding is enabled", () => {
+    expect(filterHiddenNSFWItems(mods, true)).toEqual([mods[2]]);
+  });
+
+  it("preserves the original list when hiding is disabled", () => {
+    expect(filterHiddenNSFWItems(mods, false)).toBe(mods);
+  });
+});
+
+describe("shouldBlurNSFWItem", () => {
+  it("blurs NSFW items by default, including hidden items that leak into the UI", () => {
+    expect(
+      shouldBlurNSFWItem({ isNSFW: true, isVisibleOverride: undefined }),
+    ).toBe(true);
+  });
+
+  it("honors a show override", () => {
+    expect(shouldBlurNSFWItem({ isNSFW: true, isVisibleOverride: true })).toBe(
+      false,
+    );
+  });
+
+  it("honors a hide override", () => {
+    expect(shouldBlurNSFWItem({ isNSFW: true, isVisibleOverride: false })).toBe(
+      true,
+    );
+  });
+
+  it("does not blur SFW items", () => {
+    expect(
+      shouldBlurNSFWItem({ isNSFW: false, isVisibleOverride: undefined }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/mods/nsfw-visibility.test.ts
+++ b/apps/desktop/src/lib/mods/nsfw-visibility.test.ts
@@ -20,25 +20,51 @@ describe("filterHiddenNSFWItems", () => {
 describe("shouldBlurNSFWItem", () => {
   it("blurs NSFW items by default, including hidden items that leak into the UI", () => {
     expect(
-      shouldBlurNSFWItem({ isNSFW: true, isVisibleOverride: undefined }),
+      shouldBlurNSFWItem({
+        isNSFW: true,
+        isVisibleOverride: undefined,
+        rememberOverrides: true,
+      }),
     ).toBe(true);
   });
 
   it("honors a show override", () => {
-    expect(shouldBlurNSFWItem({ isNSFW: true, isVisibleOverride: true })).toBe(
-      false,
-    );
+    expect(
+      shouldBlurNSFWItem({
+        isNSFW: true,
+        isVisibleOverride: true,
+        rememberOverrides: true,
+      }),
+    ).toBe(false);
   });
 
   it("honors a hide override", () => {
-    expect(shouldBlurNSFWItem({ isNSFW: true, isVisibleOverride: false })).toBe(
-      true,
-    );
+    expect(
+      shouldBlurNSFWItem({
+        isNSFW: true,
+        isVisibleOverride: false,
+        rememberOverrides: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores stored overrides when remembering per-item choices is disabled", () => {
+    expect(
+      shouldBlurNSFWItem({
+        isNSFW: true,
+        isVisibleOverride: true,
+        rememberOverrides: false,
+      }),
+    ).toBe(true);
   });
 
   it("does not blur SFW items", () => {
     expect(
-      shouldBlurNSFWItem({ isNSFW: false, isVisibleOverride: undefined }),
+      shouldBlurNSFWItem({
+        isNSFW: false,
+        isVisibleOverride: undefined,
+        rememberOverrides: true,
+      }),
     ).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/mods/nsfw-visibility.ts
+++ b/apps/desktop/src/lib/mods/nsfw-visibility.ts
@@ -1,0 +1,28 @@
+type NSFWItem = {
+  isNSFW: boolean;
+};
+
+type NSFWBlurState = NSFWItem & {
+  isVisibleOverride: boolean | undefined;
+};
+
+export const filterHiddenNSFWItems = <T extends NSFWItem>(
+  items: T[] | undefined,
+  hideNSFW: boolean,
+): T[] | undefined => {
+  if (!items || !hideNSFW) return items;
+
+  return items.filter((item) => !item.isNSFW);
+};
+
+export const shouldBlurNSFWItem = ({
+  isNSFW,
+  isVisibleOverride,
+}: NSFWBlurState): boolean => {
+  if (!isNSFW) return false;
+  if (isVisibleOverride !== undefined) return !isVisibleOverride;
+
+  // Blur by default, even for globally hidden items that leak onto
+  // surfaces without global NSFW filtering.
+  return true;
+};

--- a/apps/desktop/src/lib/mods/nsfw-visibility.ts
+++ b/apps/desktop/src/lib/mods/nsfw-visibility.ts
@@ -7,6 +7,11 @@ type NSFWBlurState = NSFWItem & {
   rememberOverrides: boolean;
 };
 
+/**
+ * Removes NSFW items when the user enabled global NSFW hiding.
+ * Preserves `undefined` input and returns the list unchanged when hiding is
+ * disabled.
+ */
 export const filterHiddenNSFWItems = <T extends NSFWItem>(
   items: T[] | undefined,
   hideNSFW: boolean,
@@ -16,6 +21,11 @@ export const filterHiddenNSFWItems = <T extends NSFWItem>(
   return items.filter((item) => !item.isNSFW);
 };
 
+/**
+ * Determines whether an item's preview must be blurred. Non-NSFW items are
+ * never blurred. A remembered per-item override takes precedence only when
+ * `rememberOverrides` is enabled; otherwise NSFW items blur by default.
+ */
 export const shouldBlurNSFWItem = ({
   isNSFW,
   isVisibleOverride,

--- a/apps/desktop/src/lib/mods/nsfw-visibility.ts
+++ b/apps/desktop/src/lib/mods/nsfw-visibility.ts
@@ -4,6 +4,7 @@ type NSFWItem = {
 
 type NSFWBlurState = NSFWItem & {
   isVisibleOverride: boolean | undefined;
+  rememberOverrides: boolean;
 };
 
 export const filterHiddenNSFWItems = <T extends NSFWItem>(
@@ -18,9 +19,12 @@ export const filterHiddenNSFWItems = <T extends NSFWItem>(
 export const shouldBlurNSFWItem = ({
   isNSFW,
   isVisibleOverride,
+  rememberOverrides,
 }: NSFWBlurState): boolean => {
   if (!isNSFW) return false;
-  if (isVisibleOverride !== undefined) return !isVisibleOverride;
+  if (rememberOverrides && isVisibleOverride !== undefined) {
+    return !isVisibleOverride;
+  }
 
   // Blur by default, even for globally hidden items that leak onto
   // surfaces without global NSFW filtering.

--- a/apps/desktop/src/pages/dashboard.tsx
+++ b/apps/desktop/src/pages/dashboard.tsx
@@ -15,11 +15,14 @@ import { useFeaturedMod } from "@/hooks/use-featured-mod";
 import { useTrendingByCategory } from "@/hooks/use-trending-by-category";
 import { getMods } from "@/lib/api-client";
 import { MOD_CATEGORY_ORDER } from "@/lib/constants";
+import { filterHiddenNSFWItems } from "@/lib/mods/nsfw-visibility";
 import { STALE_TIME_API } from "@/lib/query-constants";
+import { usePersistedStore } from "@/lib/store";
 
 const Dashboard = () => {
   const { t } = useTranslation();
   const DashboardPage = useThemeOverride("dashboardPage");
+  const hideNSFW = usePersistedStore((state) => state.nsfwSettings.hideNSFW);
 
   const { data: mods, isPending } = useQuery({
     queryKey: ["mods"],
@@ -28,8 +31,12 @@ const Dashboard = () => {
     refetchOnWindowFocus: false,
   });
 
-  const featured = useFeaturedMod(mods);
-  const trending = useTrendingByCategory(mods);
+  const visibleMods = useMemo(
+    () => filterHiddenNSFWItems(mods, hideNSFW),
+    [hideNSFW, mods],
+  );
+  const featured = useFeaturedMod(visibleMods);
+  const trending = useTrendingByCategory(visibleMods);
 
   const visibleCategories = useMemo(
     () =>


### PR DESCRIPTION
## Description

The dashboard builds its trending and latest lists from the raw mods list, ignoring the global NSFW setting (the featured pick already excludes NSFW). With "Hide NSFW" enabled, NSFW mods still appeared on the dashboard, and appeared unblurred, because the blur logic assumed globally hidden items would never render.

This PR:

- Adds a `filterHiddenNSFWItems` helper and applies it before the dashboard selects mods, so hidden NSFW mods no longer fill trending or latest slots.
- Extracts the blur decision into a pure, tested `shouldBlurNSFWItem` helper that fails closed: NSFW previews are blurred by default, including hidden items that reach pages without global filtering (My Mods, mod detail, skins). Per-item "Show" overrides still win, as described in #518.
- Second commit: the "Remember Per-Item Choices" setting gated saving overrides but not applying them, so choices made before disabling the setting kept taking effect. Stored overrides now go dormant while the setting is off and return when it is re-enabled.
- Fixes an incidental bug: the latest-mods card sorted the react-query cache array in place; it now sorts a copy.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Fixes #518 (closed, but still reproducible on current `main`; see Testing)

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code, Used for: code review, local before/after verification, and PR description

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Verified with a before/after comparison on Linux (Arch, Hyprland/Wayland) against the live API, with "Hide NSFW" enabled:

- **Before (main):** the Trending in Skins row showed NSFW mods unblurred, and the Latest Mods list included an NSFW entry.
- **After (this branch):** no NSFW mods on the dashboard; the lists backfill with the next SFW mods. Pages without global filtering blur NSFW items by default, and the per-item "Show" toggle still reveals them.

Full desktop suite passes (`bun test`, 121 tests), `tsgo --noEmit` is clean, and `pnpm lint` reports no new warnings.

## Screenshots (if applicable)

Before: `main` with "Hide NSFW" enabled; NSFW previews rendered fully exposed (pixelated here for GitHub):

<img width="1469" height="792" alt="before-dashboard-censored" src="https://github.com/user-attachments/assets/10f7eebb-fa76-4903-814c-20327b4532cb" />


After: this branch, same settings:

<img width="1469" height="792" alt="after-dashboard" src="https://github.com/user-attachments/assets/042600b3-4cb8-4e74-8296-89ec5296ca1d" />


## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

The dashboard filter intentionally ignores per-item "Show" overrides, matching how the mods page's global filter already behaves. The blur logic keeps the override-wins behavior discussed in #518.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the desktop dashboard to hide NSFW mods before selecting featured, trending, and latest lists.
- Added shared NSFW filtering and blur utilities.
- NSFW previews blur by default.
- Per-item “Show” and “Hide” overrides apply only when “Remember Per-Item Choices” is enabled.
- Prevented in-place sorting of the latest-mods cache array.
- Added tests for filtering, blur defaults, overrides, and non-NSFW items.
- Added desktop patch changesets.

Only the `@deadlock-mods/desktop` package changed. No API, bot, www, docs, shared-package, database, Tauri, or Rust FFI changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->