### PR TITLE
fix(desktop): Recover from stale VPK records

### DIFF
--- a/.changeset/lazy-donkeys-repeat.md
+++ b/.changeset/lazy-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Recover from stale VPK records instead of failing the mod load order save

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -14,7 +14,7 @@ use crate::mod_manager::{
 };
 use log;
 use std::{
-  collections::HashSet,
+  collections::{BTreeMap, HashSet},
   path::{Component, Path, PathBuf},
 };
 use tauri::Manager;
@@ -215,6 +215,163 @@ impl ModManager {
     }
 
     changed
+  }
+
+  /// Drop VPK claims recorded by more than one mod, keeping the first claimant in load order.
+  ///
+  /// A VPK file has exactly one owner on disk, so a shared claim always means a stale record.
+  /// Refusing to reorder in that case leaves the profile permanently unorderable, so the later
+  /// claimants give up the claim instead; they are reconciled as uninstalled by the caller.
+  fn dedupe_reorder_mapping(
+    mod_vpk_mapping: Vec<(String, Vec<String>)>,
+  ) -> (Vec<(String, Vec<String>)>, Vec<String>) {
+    let mut claimed: HashSet<String> = HashSet::new();
+    let mut deduped = Vec::new();
+    let mut dropped_mod_ids = Vec::new();
+
+    for (mod_id, vpks) in mod_vpk_mapping {
+      let mut kept = Vec::new();
+      for vpk in vpks {
+        if claimed.insert(vpk.clone()) {
+          kept.push(vpk);
+        } else {
+          log::warn!("Dropping stale claim on {vpk} by mod {mod_id}: already owned by another mod");
+        }
+      }
+
+      if kept.is_empty() {
+        dropped_mod_ids.push(mod_id);
+      } else {
+        deduped.push((mod_id, kept));
+      }
+    }
+
+    (deduped, dropped_mod_ids)
+  }
+
+  /// Rewrite manifest entries that were not part of a reorder mapping.
+  ///
+  /// Reordering renumbers every enabled VPK in the addons folder, including files these entries
+  /// still reference. Without this, their recorded names point at another mod's file and the next
+  /// reorder sees duplicate claims.
+  fn resync_unmapped_manifest_entries(
+    addons_path: &Path,
+    manifest: &mut ProfileVpkManifest,
+    mapped_mod_ids: &HashSet<String>,
+    renamed_unclaimed: &BTreeMap<String, String>,
+  ) {
+    for (mod_id, entry) in &mut manifest.mods {
+      if mapped_mod_ids.contains(mod_id) {
+        continue;
+      }
+
+      let resynced: Vec<String> = entry
+        .current_vpks
+        .iter()
+        .filter_map(|vpk| {
+          let filename = Self::vpk_filenames(std::slice::from_ref(vpk))
+            .pop()
+            .unwrap_or_else(|| vpk.clone());
+
+          // Disabled (prefixed) VPKs are never touched by a reorder.
+          if !VpkManager::is_enabled_vpk_name(&filename) {
+            return Some(filename);
+          }
+
+          match renamed_unclaimed.get(&filename) {
+            Some(new_name) => {
+              log::info!("Resynced {filename} -> {new_name} for unmapped mod {mod_id}");
+              Some(new_name.clone())
+            }
+            None => {
+              log::warn!("Dropping stale VPK {filename} from unmapped mod {mod_id} after reorder");
+              None
+            }
+          }
+        })
+        .filter(|vpk| addons_path.join(vpk).exists())
+        .collect();
+
+      entry.current_vpks = resynced;
+      if entry.current_vpks.is_empty() {
+        entry.enabled = false;
+      }
+    }
+  }
+
+  /// Reorder the given mapping and bring the whole manifest back in sync with what is on disk.
+  fn apply_reorder(
+    &self,
+    addons_path: &Path,
+    manifest: &mut ProfileVpkManifest,
+    mod_vpk_mapping: Vec<(String, Vec<String>)>,
+  ) -> Result<Vec<(String, Vec<String>)>, Error> {
+    // Only `pak##_dir.vpk` files take part in a reorder; prefixed (disabled) VPKs stay put and
+    // must survive the manifest rewrite, so they are set aside and re-attached afterwards.
+    let mut preserved_vpks: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut reorderable = Vec::new();
+    for (mod_id, vpks) in mod_vpk_mapping {
+      let (enabled_vpks, other_vpks): (Vec<String>, Vec<String>) = Self::vpk_filenames(&vpks)
+        .into_iter()
+        .partition(|vpk| VpkManager::is_enabled_vpk_name(vpk));
+
+      if !other_vpks.is_empty() {
+        preserved_vpks.insert(mod_id.clone(), other_vpks);
+      }
+
+      if !enabled_vpks.is_empty() {
+        reorderable.push((mod_id, enabled_vpks));
+      }
+    }
+
+    let (mod_vpk_mapping, dropped_mod_ids) = Self::dedupe_reorder_mapping(reorderable);
+
+    // Reported back so callers can drop the stale VPK names from their own state too.
+    let mut dropped_mappings = Vec::new();
+    for mod_id in dropped_mod_ids {
+      let remaining_vpks = preserved_vpks.remove(&mod_id).unwrap_or_default();
+      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
+        entry.current_vpks = remaining_vpks.clone();
+        entry.enabled = !remaining_vpks.is_empty();
+      }
+      dropped_mappings.push((mod_id, remaining_vpks));
+    }
+
+    if mod_vpk_mapping.is_empty() {
+      return Ok(dropped_mappings);
+    }
+
+    let mapped_mod_ids: HashSet<String> = mod_vpk_mapping
+      .iter()
+      .map(|(mod_id, _)| mod_id.clone())
+      .collect();
+
+    let outcome = self
+      .vpk_manager
+      .reorder_vpks(&mod_vpk_mapping, addons_path)?;
+
+    let mut updated_mappings = dropped_mappings;
+    for (mod_id, new_vpk_names) in outcome.mappings {
+      let mut current_vpks = new_vpk_names;
+      current_vpks.extend(preserved_vpks.remove(&mod_id).unwrap_or_default());
+
+      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
+        entry.enabled = !current_vpks.is_empty();
+        entry.current_vpks = current_vpks.clone();
+        entry.disabled_vpks.clear();
+      }
+
+      updated_mappings.push((mod_id, current_vpks));
+    }
+
+    Self::resync_unmapped_manifest_entries(
+      addons_path,
+      manifest,
+      &mapped_mod_ids,
+      &outcome.renamed_unclaimed,
+    );
+
+    Ok(updated_mappings)
   }
 
   pub fn stop_game(&mut self) -> Result<(), Error> {
@@ -583,17 +740,9 @@ impl ModManager {
       return Ok(());
     }
 
-    let updated_vpk_mappings = self
-      .vpk_manager
-      .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
+    let updated_vpk_mappings = self.apply_reorder(&addons_path, &mut manifest, mod_vpk_mapping)?;
 
     for (mod_id, new_vpk_names) in updated_vpk_mappings {
-      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
-        entry.enabled = true;
-        entry.current_vpks = new_vpk_names.clone();
-        entry.disabled_vpks.clear();
-      }
-
       if let Some(mut mod_entry) = self.mod_repository.remove_mod(&mod_id) {
         mod_entry.installed_vpks = new_vpk_names;
         self.mod_repository.add_mod(mod_entry);
@@ -664,17 +813,9 @@ impl ModManager {
     }
 
     // Reorder the VPK files and get the updated mappings
-    let updated_mappings = self
-      .vpk_manager
-      .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
+    let updated_mappings = self.apply_reorder(&addons_path, &mut manifest, mod_vpk_mapping)?;
 
     for (remote_id, new_vpks) in &updated_mappings {
-      if let Some(entry) = manifest.mods.get_mut(remote_id) {
-        entry.enabled = true;
-        entry.current_vpks = new_vpks.clone();
-        entry.disabled_vpks.clear();
-      }
-
       if let Some(mut mod_entry) = self.mod_repository.remove_mod(remote_id) {
         mod_entry.installed_vpks = new_vpks.clone();
         self.mod_repository.add_mod(mod_entry);
@@ -741,19 +882,11 @@ impl ModManager {
     }
 
     // Reorder the VPK files
-    let updated_vpk_mappings = self
-      .vpk_manager
-      .reorder_vpks(&mod_vpk_mapping, &addons_path)?;
+    let updated_vpk_mappings = self.apply_reorder(&addons_path, &mut manifest, mod_vpk_mapping)?;
 
     // Update mod data with new VPK names and re-add to repository
     let mut result_mods = Vec::new();
     for (mod_id, new_vpk_names) in updated_vpk_mappings {
-      if let Some(entry) = manifest.mods.get_mut(&mod_id) {
-        entry.enabled = true;
-        entry.current_vpks = new_vpk_names.clone();
-        entry.disabled_vpks.clear();
-      }
-
       if let Some(index) = updated_mods
         .iter()
         .position(|mod_entry| mod_entry.id == mod_id)
@@ -1233,6 +1366,191 @@ mod tests {
     assert!(changed);
     assert!(!entry.enabled);
     assert!(entry.current_vpks.is_empty());
+  }
+
+  #[test]
+  fn reorder_dedupe_keeps_first_claimant_of_a_shared_vpk() {
+    let (deduped, dropped) = ModManager::dedupe_reorder_mapping(vec![
+      ("first".to_string(), vec!["pak01_dir.vpk".to_string()]),
+      (
+        "second".to_string(),
+        vec!["pak01_dir.vpk".to_string(), "pak02_dir.vpk".to_string()],
+      ),
+      ("third".to_string(), vec!["pak01_dir.vpk".to_string()]),
+    ]);
+
+    assert_eq!(
+      deduped,
+      vec![
+        ("first".to_string(), vec!["pak01_dir.vpk".to_string()]),
+        ("second".to_string(), vec!["pak02_dir.vpk".to_string()]),
+      ]
+    );
+    assert_eq!(dropped, vec!["third".to_string()]);
+  }
+
+  #[test]
+  fn reorder_keeps_prefixed_vpks_attached_to_their_mod() {
+    let temp = tempfile::tempdir().unwrap();
+    let addons_path = temp.path();
+    write_vpk(addons_path, "pak01_dir.vpk");
+    write_vpk(addons_path, "665094_pak05_dir.vpk");
+
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mods.insert(
+      "665094".to_string(),
+      ProfileVpkManifestEntry {
+        enabled: true,
+        current_vpks: vec!["665094_pak05_dir.vpk".to_string()],
+        ..Default::default()
+      },
+    );
+    manifest.mods.insert(
+      "123456".to_string(),
+      ProfileVpkManifestEntry {
+        enabled: true,
+        current_vpks: vec!["pak01_dir.vpk".to_string()],
+        ..Default::default()
+      },
+    );
+
+    let manager = test_manager(addons_path);
+    let updated = manager
+      .apply_reorder(
+        addons_path,
+        &mut manifest,
+        vec![
+          (
+            "665094".to_string(),
+            vec!["665094_pak05_dir.vpk".to_string()],
+          ),
+          ("123456".to_string(), vec!["pak01_dir.vpk".to_string()]),
+        ],
+      )
+      .unwrap();
+
+    // A prefixed VPK is not reorderable, so its mod keeps the file instead of losing the record.
+    assert_eq!(
+      manifest.mods["665094"].current_vpks,
+      vec!["665094_pak05_dir.vpk".to_string()]
+    );
+    assert!(manifest.mods["665094"].enabled);
+    assert!(addons_path.join("665094_pak05_dir.vpk").exists());
+    assert_eq!(
+      updated,
+      vec![("123456".to_string(), vec!["pak01_dir.vpk".to_string()])]
+    );
+  }
+
+  #[test]
+  fn reorder_reports_mods_that_lost_a_duplicate_claim() {
+    let temp = tempfile::tempdir().unwrap();
+    let addons_path = temp.path();
+    write_vpk(addons_path, "pak01_dir.vpk");
+
+    let mut manifest = ProfileVpkManifest::default();
+    for mod_id in ["first", "second"] {
+      manifest.mods.insert(
+        mod_id.to_string(),
+        ProfileVpkManifestEntry {
+          enabled: true,
+          current_vpks: vec!["pak01_dir.vpk".to_string()],
+          ..Default::default()
+        },
+      );
+    }
+
+    let manager = test_manager(addons_path);
+    let updated = manager
+      .apply_reorder(
+        addons_path,
+        &mut manifest,
+        vec![
+          ("first".to_string(), vec!["pak01_dir.vpk".to_string()]),
+          ("second".to_string(), vec!["pak01_dir.vpk".to_string()]),
+        ],
+      )
+      .unwrap();
+
+    assert_eq!(
+      updated,
+      vec![
+        ("second".to_string(), Vec::new()),
+        ("first".to_string(), vec!["pak01_dir.vpk".to_string()]),
+      ]
+    );
+    assert!(!manifest.mods["second"].enabled);
+    assert!(manifest.mods["second"].current_vpks.is_empty());
+    assert!(manifest.mods["first"].enabled);
+  }
+
+  #[test]
+  fn reorder_resync_follows_renamed_unclaimed_vpks() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "pak02_dir.vpk");
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mods.insert(
+      "unmapped".to_string(),
+      ProfileVpkManifestEntry {
+        enabled: true,
+        current_vpks: vec!["pak07_dir.vpk".to_string()],
+        ..Default::default()
+      },
+    );
+
+    let renamed = BTreeMap::from([("pak07_dir.vpk".to_string(), "pak02_dir.vpk".to_string())]);
+    ModManager::resync_unmapped_manifest_entries(
+      temp.path(),
+      &mut manifest,
+      &HashSet::new(),
+      &renamed,
+    );
+
+    let entry = &manifest.mods["unmapped"];
+    assert!(entry.enabled);
+    assert_eq!(entry.current_vpks, vec!["pak02_dir.vpk".to_string()]);
+  }
+
+  #[test]
+  fn reorder_resync_drops_stale_names_but_keeps_disabled_vpks() {
+    let temp = tempfile::tempdir().unwrap();
+    write_vpk(temp.path(), "665094_pak05_dir.vpk");
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mods.insert(
+      "665094".to_string(),
+      ProfileVpkManifestEntry {
+        enabled: true,
+        current_vpks: vec![
+          "pak34_dir.vpk".to_string(),
+          "665094_pak05_dir.vpk".to_string(),
+        ],
+        ..Default::default()
+      },
+    );
+    manifest.mods.insert(
+      "mapped".to_string(),
+      ProfileVpkManifestEntry {
+        enabled: true,
+        current_vpks: vec!["pak01_dir.vpk".to_string()],
+        ..Default::default()
+      },
+    );
+
+    ModManager::resync_unmapped_manifest_entries(
+      temp.path(),
+      &mut manifest,
+      &HashSet::from(["mapped".to_string()]),
+      &BTreeMap::new(),
+    );
+
+    let entry = &manifest.mods["665094"];
+    assert_eq!(entry.current_vpks, vec!["665094_pak05_dir.vpk".to_string()]);
+    assert!(entry.enabled);
+    // Mapped entries are updated by the reorder itself and must not be touched here.
+    assert_eq!(
+      manifest.mods["mapped"].current_vpks,
+      vec!["pak01_dir.vpk".to_string()]
+    );
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -1391,10 +1391,11 @@ mod tests {
 
   #[test]
   fn reorder_keeps_prefixed_vpks_attached_to_their_mod() {
-    let temp = tempfile::tempdir().unwrap();
-    let addons_path = temp.path();
-    write_vpk(addons_path, "pak01_dir.vpk");
-    write_vpk(addons_path, "665094_pak05_dir.vpk");
+    let game = game_dir();
+    let addons_path = game.path().join("game").join("citadel").join("addons");
+    fs::create_dir_all(&addons_path).unwrap();
+    write_vpk(&addons_path, "pak01_dir.vpk");
+    write_vpk(&addons_path, "665094_pak05_dir.vpk");
 
     let mut manifest = ProfileVpkManifest::default();
     manifest.mods.insert(
@@ -1414,10 +1415,10 @@ mod tests {
       },
     );
 
-    let manager = test_manager(addons_path);
+    let manager = test_manager(game.path());
     let updated = manager
       .apply_reorder(
-        addons_path,
+        &addons_path,
         &mut manifest,
         vec![
           (
@@ -1444,9 +1445,10 @@ mod tests {
 
   #[test]
   fn reorder_reports_mods_that_lost_a_duplicate_claim() {
-    let temp = tempfile::tempdir().unwrap();
-    let addons_path = temp.path();
-    write_vpk(addons_path, "pak01_dir.vpk");
+    let game = game_dir();
+    let addons_path = game.path().join("game").join("citadel").join("addons");
+    fs::create_dir_all(&addons_path).unwrap();
+    write_vpk(&addons_path, "pak01_dir.vpk");
 
     let mut manifest = ProfileVpkManifest::default();
     for mod_id in ["first", "second"] {
@@ -1460,10 +1462,10 @@ mod tests {
       );
     }
 
-    let manager = test_manager(addons_path);
+    let manager = test_manager(game.path());
     let updated = manager
       .apply_reorder(
-        addons_path,
+        &addons_path,
         &mut manifest,
         vec![
           ("first".to_string(), vec!["pak01_dir.vpk".to_string()]),

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -16,6 +16,16 @@ pub enum MissingVpkPolicy {
   Reconcile,
 }
 
+/// Result of a reorder pass over the addons directory.
+#[derive(Debug, Default)]
+pub struct ReorderOutcome {
+  /// (mod_id, new vpk filenames) for every mod in the requested mapping.
+  pub mappings: Vec<(String, Vec<String>)>,
+  /// Enabled VPKs that no mod in the mapping claimed, as `old filename -> new filename`.
+  /// Reordering renumbers these too, so recorded names elsewhere must follow them.
+  pub renamed_unclaimed: BTreeMap<String, String>,
+}
+
 /// Manages VPK file operations and installation
 pub struct VpkManager {
   filesystem: FileSystemHelper,
@@ -61,7 +71,7 @@ impl VpkManager {
     &self,
     mod_vpk_mapping: &[(String, Vec<String>)], // (mod_id, vpk_filenames)
     addons_path: &Path,
-  ) -> Result<Vec<(String, Vec<String>)>, Error> {
+  ) -> Result<ReorderOutcome, Error> {
     if !addons_path.exists() {
       return Err(Error::Io(std::io::Error::new(
         std::io::ErrorKind::NotFound,
@@ -160,7 +170,8 @@ impl VpkManager {
       updated_mappings.push((mod_id.clone(), new_vpk_names));
     }
 
-    // Step 3: Restore any orphaned VPKs (VPKs not managed by our mod system)
+    // Step 3: Restore any unclaimed VPKs (enabled VPKs no mod in the mapping asked for)
+    let mut renamed_unclaimed = BTreeMap::new();
     if temp_dir.exists() {
       // Move any remaining VPKs back to addons directory with sequential numbering
       for entry in std::fs::read_dir(&temp_dir)? {
@@ -168,15 +179,16 @@ impl VpkManager {
         let path = entry.path();
 
         if path.is_file() && path.extension().is_some_and(|ext| ext == "vpk") {
-          // Find next available number for orphaned VPK
-          let orphaned_name = format!("pak{:02}_dir.vpk", current_number);
-          let orphaned_path = addons_path.join(&orphaned_name);
+          // Find next available number for unclaimed VPK
+          let unclaimed_name = format!("pak{:02}_dir.vpk", current_number);
+          let unclaimed_path = addons_path.join(&unclaimed_name);
 
-          std::fs::rename(&path, &orphaned_path)?;
+          std::fs::rename(&path, &unclaimed_path)?;
           current_number += 1;
 
           if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
-            log::info!("Restored orphaned VPK file: {filename} -> {orphaned_name}");
+            renamed_unclaimed.insert(filename.to_string(), unclaimed_name.clone());
+            log::info!("Restored unclaimed VPK file: {filename} -> {unclaimed_name}");
           }
         }
       }
@@ -185,7 +197,10 @@ impl VpkManager {
     }
 
     log::info!("VPK reordering completed successfully");
-    Ok(updated_mappings)
+    Ok(ReorderOutcome {
+      mappings: updated_mappings,
+      renamed_unclaimed,
+    })
   }
 
   fn duplicate_reorder_vpk_assignments(mod_vpk_mapping: &[(String, Vec<String>)]) -> Vec<String> {
@@ -686,7 +701,7 @@ impl VpkManager {
     None
   }
 
-  fn is_enabled_vpk_name(filename: &str) -> bool {
+  pub fn is_enabled_vpk_name(filename: &str) -> bool {
     Self::enabled_vpk_number(filename).is_some()
   }
 
@@ -942,11 +957,38 @@ mod tests {
       .unwrap();
 
     assert_eq!(
-      updated,
+      updated.mappings,
       vec![("123456".to_string(), vec!["pak01_dir.vpk".to_string()])]
     );
+    assert!(updated.renamed_unclaimed.is_empty());
     assert!(addons_path.join("local-abc-123_original.vpk").exists());
     assert!(!addons_path.join("pak02_dir.vpk").exists());
+  }
+
+  #[test]
+  fn reorder_reports_renamed_unclaimed_vpks() {
+    let temp = tempfile::tempdir().unwrap();
+    let addons_path = temp.path();
+    write_vpk(addons_path, "pak01_dir.vpk");
+    write_vpk(addons_path, "pak05_dir.vpk");
+
+    let manager = VpkManager::new();
+    let updated = manager
+      .reorder_vpks(
+        &[("123456".to_string(), vec!["pak05_dir.vpk".to_string()])],
+        addons_path,
+      )
+      .unwrap();
+
+    assert_eq!(
+      updated.mappings,
+      vec![("123456".to_string(), vec!["pak01_dir.vpk".to_string()])]
+    );
+    assert_eq!(
+      updated.renamed_unclaimed.get("pak01_dir.vpk"),
+      Some(&"pak02_dir.vpk".to_string())
+    );
+    assert!(addons_path.join("pak02_dir.vpk").exists());
   }
 
   #[test]

--- a/apps/desktop/src/components/my-mods/mod-ordering-dialog.tsx
+++ b/apps/desktop/src/components/my-mods/mod-ordering-dialog.tsx
@@ -210,7 +210,9 @@ export const ModOrderingDialog = ({
       toast.success(t("modOrdering.orderSaved"));
       setOpen(false);
     } catch (error) {
-      toast.error(t("modOrdering.orderSaveFailed"));
+      toast.error(t("modOrdering.orderSaveFailed"), {
+        description: error instanceof Error ? error.message : String(error),
+      });
       console.error("Failed to save mod order:", error);
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
- Reconcile renamed VPKs when saving mod load order
- Surface underlying save errors in the ordering dialog

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [x] No significant AI assistance used
- [ ] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Desktop:** Recovers mod load-order saves from stale VPK records after VPK renames or deletions.
- Reconciles duplicate and shared enabled VPK claims while preserving disabled and prefixed VPKs.
- Resynchronizes unmapped manifest entries and reports mods that lose all reorderable VPK claims.
- Uses the reconciliation logic across all desktop reorder workflows.
- Shows underlying save errors in the mod ordering dialog.
- Adds tests for duplicate claims, preserved VPKs, dropped mappings, renamed VPKs, and manifest resynchronization.
- Adds a patch changeset for `@deadlock-mods/desktop`.

No API, bot, www, docs, shared package, database, Tauri plugin, or Rust FFI changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->