### PR TITLE
feat(desktop): 1-click installs from DeadlockForge over a loopback bridge

### DIFF
--- a/.changeset/olive-pandas-arrive.md
+++ b/.changeset/olive-pandas-arrive.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": minor
+---
+
+1-click installs from DeadlockForge. Build a mod on deadlockforge.net and send it straight to Deadlock Mod Manager instead of downloading a file and adding it by hand. It is off until you turn it on, and if the site tries to send you something while it is off, the app asks whether to allow it. Every mod is confirmed before anything is written, and arrives disabled.

--- a/.changeset/olive-pandas-arrive.md
+++ b/.changeset/olive-pandas-arrive.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": minor
 ---
 
-1-click installs from DeadlockForge. Build a mod on deadlockforge.net and send it straight to Deadlock Mod Manager instead of downloading a file and adding it by hand. It is off until you turn it on, and if the site tries to send you something while it is off, the app asks whether to allow it. Every mod is confirmed before anything is written, and arrives disabled.
+Add opt-in 1-click installs from DeadlockForge, with confirmation.

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -1384,6 +1384,9 @@ dependencies = [
  "futures",
  "hero-parser",
  "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "image",
  "junction",
  "keyvalues-parser",
@@ -2612,6 +2615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,6 +2643,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -61,6 +61,11 @@ dmp-parser = { path = "../../../packages/dmp-parser" }
 deadlock-discord-presence = { path = "../../../packages/deadlock-discord-presence" }
 tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = "0.7"
+# Already in the tree via reqwest; the loopback forge bridge only needs the
+# server half of the same versions, so this adds features rather than crates.
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json", "stream", "socks"] }
 futures = "0.3"
 tauri-plugin-dialog = "2.7.1"

--- a/apps/desktop/src-tauri/src/commands/forge.rs
+++ b/apps/desktop/src-tauri/src/commands/forge.rs
@@ -1,7 +1,8 @@
 use crate::app_runtime::AppHandle;
 use crate::errors::Error;
 use crate::forge_bridge;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
+use tauri::Manager;
 
 #[tauri::command]
 pub async fn start_forge_bridge(app_handle: AppHandle) -> Result<u16, Error> {
@@ -17,9 +18,18 @@ pub async fn stop_forge_bridge() -> Result<(), Error> {
 /// Kept out of the renderer: bytes cross the IPC boundary as a JSON number
 /// array, so a large sound build would cost gigabytes there.
 #[tauri::command]
-pub async fn place_forge_payload(path: String, destination: String) -> Result<(), Error> {
+pub async fn place_forge_payload(
+  app_handle: AppHandle,
+  path: String,
+  destination: String,
+) -> Result<(), Error> {
   let staged = forge_bridge::peek_staged(&path)?;
-  let destination = PathBuf::from(destination);
+  let mods_root = app_handle
+    .path()
+    .app_local_data_dir()
+    .map_err(Error::Tauri)?
+    .join("mods");
+  let destination = contained_destination(&mods_root, &destination)?;
 
   if let Some(parent) = destination.parent() {
     tokio::fs::create_dir_all(parent).await?;
@@ -30,6 +40,22 @@ pub async fn place_forge_payload(path: String, destination: String) -> Result<()
   }
 
   Ok(())
+}
+
+/// Checked rather than trusted, since it comes from the renderer. Traversal is
+/// refused outright rather than normalised away.
+fn contained_destination(mods_root: &Path, destination: &str) -> Result<PathBuf, Error> {
+  let destination = PathBuf::from(destination);
+
+  let escapes = destination
+    .components()
+    .any(|component| matches!(component, Component::ParentDir));
+
+  if escapes || !destination.starts_with(mods_root) {
+    return Err(Error::UnauthorizedPath(destination.display().to_string()));
+  }
+
+  Ok(destination)
 }
 
 #[tauri::command]
@@ -50,4 +76,36 @@ pub async fn finish_forge_install(path: String) -> Result<(), Error> {
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::contained_destination;
+  use std::path::{Path, PathBuf};
+
+  #[test]
+  fn accepts_a_path_inside_the_mods_folder() {
+    let root = Path::new("/home/u/.local/share/app/mods");
+    let inside = "/home/u/.local/share/app/mods/local-1/files/mod.vpk";
+    assert_eq!(
+      contained_destination(root, inside).expect("should be allowed"),
+      PathBuf::from(inside)
+    );
+  }
+
+  #[test]
+  fn refuses_anything_outside_the_mods_folder() {
+    let root = Path::new("/home/u/.local/share/app/mods");
+    for outside in [
+      "/home/u/.bashrc",
+      "/home/u/.local/share/app/mods/../../../.bashrc",
+      "/home/u/.local/share/app/modsevil/mod.vpk",
+      "relative/mod.vpk",
+    ] {
+      assert!(
+        contained_destination(root, outside).is_err(),
+        "{outside} should be refused"
+      );
+    }
+  }
 }

--- a/apps/desktop/src-tauri/src/commands/forge.rs
+++ b/apps/desktop/src-tauri/src/commands/forge.rs
@@ -1,6 +1,7 @@
 use crate::app_runtime::AppHandle;
 use crate::errors::Error;
 use crate::forge_bridge;
+use std::path::PathBuf;
 
 #[tauri::command]
 pub async fn start_forge_bridge(app_handle: AppHandle) -> Result<u16, Error> {
@@ -9,18 +10,44 @@ pub async fn start_forge_bridge(app_handle: AppHandle) -> Result<u16, Error> {
 
 #[tauri::command]
 pub async fn stop_forge_bridge() -> Result<(), Error> {
-  forge_bridge::stop();
+  forge_bridge::stop().await;
   Ok(())
 }
 
-/// The frontend calls this once the user has accepted or declined, which frees
-/// the slot for the next request and removes the staged payload.
+/// Kept out of the renderer: bytes cross the IPC boundary as a JSON number
+/// array, so a large sound build would cost gigabytes there.
+#[tauri::command]
+pub async fn place_forge_payload(path: String, destination: String) -> Result<(), Error> {
+  let staged = forge_bridge::peek_staged(&path)?;
+  let destination = PathBuf::from(destination);
+
+  if let Some(parent) = destination.parent() {
+    tokio::fs::create_dir_all(parent).await?;
+  }
+
+  if tokio::fs::rename(&staged, &destination).await.is_err() {
+    tokio::fs::copy(&staged, &destination).await?;
+  }
+
+  Ok(())
+}
+
 #[tauri::command]
 pub async fn finish_forge_install(path: String) -> Result<(), Error> {
-  let staged = crate::forge_bridge::staged_path(&path)?;
-  if staged.exists() {
-    tokio::fs::remove_file(&staged).await?;
-  }
+  let staged = forge_bridge::staged_path(&path)?;
+
+  // Freed before the delete: a file still held open would otherwise leave the
+  // bridge refusing every later install, with nothing left to retry.
   forge_bridge::release_in_flight();
+
+  if let Err(error) = tokio::fs::remove_file(&staged).await
+    && error.kind() != std::io::ErrorKind::NotFound
+  {
+    log::warn!(
+      "[ForgeBridge] Could not remove staged payload {}: {error}",
+      staged.display()
+    );
+  }
+
   Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/forge.rs
+++ b/apps/desktop/src-tauri/src/commands/forge.rs
@@ -1,0 +1,26 @@
+use crate::app_runtime::AppHandle;
+use crate::errors::Error;
+use crate::forge_bridge;
+
+#[tauri::command]
+pub async fn start_forge_bridge(app_handle: AppHandle) -> Result<u16, Error> {
+  forge_bridge::start(app_handle).await
+}
+
+#[tauri::command]
+pub async fn stop_forge_bridge() -> Result<(), Error> {
+  forge_bridge::stop();
+  Ok(())
+}
+
+/// The frontend calls this once the user has accepted or declined, which frees
+/// the slot for the next request and removes the staged payload.
+#[tauri::command]
+pub async fn finish_forge_install(path: String) -> Result<(), Error> {
+  let staged = crate::forge_bridge::staged_path(&path)?;
+  if staged.exists() {
+    tokio::fs::remove_file(&staged).await?;
+  }
+  forge_bridge::release_in_flight();
+  Ok(())
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod backups;
 pub mod deep_link;
 pub mod downloads;
 pub mod folders;
+pub mod forge;
 pub mod fonts;
 pub mod foundry;
 pub mod game;

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -13,9 +13,14 @@ pub const EVENT_OIDC_ERROR: &str = "oidc-callback-error";
 pub const EVENT_AUTH_CALLBACK: &str = "auth-callback-received";
 pub const EVENT_AUTH_ERROR: &str = "auth-callback-error";
 pub const EVENT_DEEP_LINK_RECEIVED: &str = "deep-link-received";
+pub const EVENT_FORGE_LAUNCH: &str = "forge-launch-requested";
 
 pub const PATH_OIDC_CALLBACK: &str = "//auth/callback";
 pub const PATH_LEGACY_AUTH_CALLBACK: &str = "//auth-callback";
+
+/// Fired by deadlockforge.net when its 1-click button cannot find the bridge.
+/// Brings the app up and asks whether to turn 1-click installs on.
+pub const PATH_FORGE_LAUNCH: &str = "//forge/launch";
 
 pub const GAMEBANANA_DOMAIN: &str = "gamebanana.com";
 pub const MOD_ID_PARTS_COUNT: usize = 3;
@@ -152,6 +157,11 @@ pub fn handle_deep_link_url(
     return Ok(());
   }
 
+  if data_part.starts_with(PATH_FORGE_LAUNCH) {
+    emit_to_main_window(app_handle, EVENT_FORGE_LAUNCH, ())?;
+    return Ok(());
+  }
+
   if data_part.starts_with(PATH_LEGACY_AUTH_CALLBACK) {
     if let Some(query_start) = data_part.find('?') {
       let query = &data_part[query_start + 1..];
@@ -219,4 +229,18 @@ pub fn setup(app: &tauri::App<AppRuntime>) -> Result<(), Box<dyn std::error::Err
   });
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{PATH_FORGE_LAUNCH, strip_scheme};
+
+  #[test]
+  fn recognises_the_forge_launch_url_the_site_fires() {
+    // The site hardcodes this URL, so a change to either the scheme list or
+    // the path silently stops the 1-click button from waking the app.
+    let stripped =
+      strip_scheme("deadlock-mod-manager://forge/launch").expect("scheme should be recognised");
+    assert!(stripped.starts_with(PATH_FORGE_LAUNCH));
+  }
 }

--- a/apps/desktop/src-tauri/src/forge_bridge.rs
+++ b/apps/desktop/src-tauri/src/forge_bridge.rs
@@ -1,0 +1,706 @@
+//! Loopback HTTP bridge for 1-click installs from DeadlockForge.
+//!
+//! DeadlockForge builds VPKs in the browser on demand, so unlike GameBanana
+//! there is no hosted URL to hand over and the existing deep link flow does not
+//! apply. Instead the site detects this app listening on loopback and POSTs the
+//! bytes straight in.
+//!
+//! Trust is the Origin header, checked against an exact allowlist. The site
+//! cannot forge it: browsers set it themselves, and the install route requires
+//! a non-simple content type plus a custom header so it is always preceded by a
+//! preflight this server can refuse.
+//!
+//! Nothing is written to the mod library here. A validated payload lands in a
+//! temp file and the frontend is asked to confirm before it is imported through
+//! the normal local mod pipeline.
+
+use crate::app_runtime::AppHandle;
+use crate::errors::Error;
+use http_body_util::{BodyExt, Full, Limited};
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use serde::Serialize;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::{Emitter, Manager};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+const FORGE_PROTOCOL_VERSION: u32 = 1;
+
+/// Distinct from Grimoire's 43110-43114 so both managers can run at once and
+/// the site always reaches the one it meant to.
+const FORGE_PORTS: [u16; 5] = [43120, 43121, 43122, 43123, 43124];
+
+/// Identifies this app in the ping response so the site can tell managers apart
+/// even if a custom build ends up on another manager's port.
+const FORGE_APP_ID: &str = "deadlock-mod-manager";
+
+const EVENT_FORGE_INSTALL_REQUESTED: &str = "forge-install-requested";
+
+const ALLOWED_ORIGINS: &[&str] = &["https://deadlockforge.net", "https://www.deadlockforge.net"];
+
+/// Sound mods scale with both clip length and the number of replaced sounds:
+/// roughly 16 KB per second of audio per sound, so a 600 sound build from a
+/// 30 second clip is already near 300 MB.
+const MAX_BODY_BYTES: usize = 512 * 1024 * 1024;
+
+/// Below this a payload cannot carry a VPK header, so it is never worth reading.
+const MIN_BODY_BYTES: usize = 32;
+
+const VPK_SIGNATURE: u32 = 0x55AA_1234;
+
+const PROTOCOL_HEADER: &str = "x-forge-protocol";
+const NAME_HEADER: &str = "x-forge-name";
+const AUTHOR_HEADER: &str = "x-forge-author";
+
+/// Every header the site may send on an install. A header missing here is not
+/// merely ignored: the browser refuses to send the request at all, and the
+/// caller sees a transport failure rather than a rejection it can explain.
+const ALLOWED_REQUEST_HEADERS: &str =
+  "content-type, x-forge-protocol, x-forge-name, x-forge-type, x-forge-author";
+const CONTENT_TYPE: &str = "application/octet-stream";
+
+struct BridgeHandle {
+  port: u16,
+  shutdown: oneshot::Sender<()>,
+}
+
+static BRIDGE: Mutex<Option<BridgeHandle>> = Mutex::new(None);
+
+/// Payloads this bridge staged and has not yet cleaned up. The frontend hands a
+/// path back when the user answers, and only a path we put here is ever deleted,
+/// so the cleanup command cannot be turned into an arbitrary file delete.
+static STAGED: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+/// One install may be awaiting the user's answer at a time. A second request is
+/// refused rather than queued, so a page cannot stack dialogs.
+static INSTALL_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+#[derive(Serialize, Clone)]
+struct PingBody {
+  ok: bool,
+  app: &'static str,
+  protocol: u32,
+}
+
+#[derive(Serialize, Clone)]
+pub struct ForgeInstallRequest {
+  pub name: String,
+  pub path: String,
+  pub author: Option<String>,
+}
+
+fn json_response(status: StatusCode, body: &str, origin: Option<&str>) -> Response<Full<Bytes>> {
+  let mut builder = Response::builder()
+    .status(status)
+    .header("content-type", "application/json")
+    .header("cache-control", "no-store");
+
+  if let Some(origin) = origin {
+    builder = builder
+      .header("access-control-allow-origin", origin)
+      .header("vary", "Origin");
+  }
+
+  builder
+    .body(Full::new(Bytes::from(body.to_owned())))
+    .unwrap_or_else(|_| Response::new(Full::new(Bytes::from_static(b"{}"))))
+}
+
+fn error_response(status: StatusCode, reason: &str, origin: Option<&str>) -> Response<Full<Bytes>> {
+  json_response(status, &format!("{{\"error\":\"{reason}\"}}"), origin)
+}
+
+fn allowed_origin(origin: Option<&str>) -> Option<&str> {
+  let origin = origin?;
+  ALLOWED_ORIGINS
+    .iter()
+    .find(|allowed| **allowed == origin)
+    .copied()
+}
+
+/// The Host header must be a loopback literal. A name that resolves to 127.0.0.1
+/// is how DNS rebinding reaches a local server, and no legitimate caller uses one.
+fn host_is_loopback(host: Option<&str>) -> bool {
+  let Some(host) = host else {
+    return false;
+  };
+  let hostname = host.rsplit_once(':').map_or(host, |(name, _)| name);
+  hostname == "127.0.0.1" || hostname == "[::1]" || hostname == "::1"
+}
+
+fn is_plausible_vpk(bytes: &[u8]) -> bool {
+  if bytes.len() < 4 {
+    return false;
+  }
+  let signature = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+  signature == VPK_SIGNATURE
+}
+
+/// Names arrive percent encoded because raw non-ASCII is not legal in a header.
+/// Anything path-like is stripped: this becomes a filename.
+fn decode_mod_name(raw: Option<&str>) -> String {
+  let decoded = raw
+    .and_then(|value| urlencoding::decode(value).ok())
+    .map(|value| value.into_owned())
+    .unwrap_or_default();
+
+  let cleaned: String = decoded
+    .chars()
+    .filter(|c| !matches!(c, '/' | '\\' | ':' | '<' | '>' | '"' | '|' | '?' | '*'))
+    .filter(|c| !c.is_control())
+    .collect();
+
+  let trimmed = cleaned.trim().trim_matches('.').trim();
+  if trimmed.is_empty() {
+    "DeadlockForge mod".to_string()
+  } else {
+    trimmed.chars().take(120).collect()
+  }
+}
+
+/// Percent-decoded, trimmed, and dropped if it carries nothing useful.
+fn decode_optional(raw: Option<&str>) -> Option<String> {
+  let decoded = raw
+    .and_then(|value| urlencoding::decode(value).ok())
+    .map(|value| value.into_owned())?;
+  let cleaned: String = decoded.chars().filter(|c| !c.is_control()).collect();
+  let trimmed = cleaned.trim();
+  if trimmed.is_empty() {
+    None
+  } else {
+    Some(trimmed.chars().take(120).collect())
+  }
+}
+
+fn preflight_response(origin: &str, wants_private_network: bool) -> Response<Full<Bytes>> {
+  let mut builder = Response::builder()
+    .status(StatusCode::NO_CONTENT)
+    .header("access-control-allow-origin", origin)
+    .header("access-control-allow-methods", "POST, GET, OPTIONS")
+    .header("access-control-allow-headers", ALLOWED_REQUEST_HEADERS)
+    .header("access-control-max-age", "600")
+    .header("vary", "Origin");
+
+  if wants_private_network {
+    builder = builder.header("access-control-allow-private-network", "true");
+  }
+
+  builder
+    .body(Full::new(Bytes::new()))
+    .unwrap_or_else(|_| Response::new(Full::new(Bytes::new())))
+}
+
+async fn write_temp_vpk(bytes: &[u8]) -> Result<PathBuf, std::io::Error> {
+  let file = tempfile::Builder::new()
+    .prefix("deadlockforge-")
+    .suffix(".vpk")
+    .tempfile()?;
+  let (_, path) = file.keep().map_err(|e| e.error)?;
+  tokio::fs::write(&path, bytes).await?;
+  Ok(path)
+}
+
+async fn handle_install(
+  req: Request<Incoming>,
+  origin: &str,
+  app_handle: AppHandle,
+) -> Response<Full<Bytes>> {
+  let headers = req.headers().clone();
+
+  let protocol_ok = headers
+    .get(PROTOCOL_HEADER)
+    .and_then(|v| v.to_str().ok())
+    .and_then(|v| v.parse::<u32>().ok())
+    .is_some_and(|v| v == FORGE_PROTOCOL_VERSION);
+  if !protocol_ok {
+    return error_response(StatusCode::BAD_REQUEST, "BAD_PROTOCOL", Some(origin));
+  }
+
+  let content_type_ok = headers
+    .get(hyper::header::CONTENT_TYPE)
+    .and_then(|v| v.to_str().ok())
+    .is_some_and(|v| v.split(';').next().unwrap_or("").trim() == CONTENT_TYPE);
+  if !content_type_ok {
+    return error_response(
+      StatusCode::UNSUPPORTED_MEDIA_TYPE,
+      "BAD_CONTENT_TYPE",
+      Some(origin),
+    );
+  }
+
+  if INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+    return error_response(StatusCode::TOO_MANY_REQUESTS, "BUSY", Some(origin));
+  }
+
+  let response = read_and_dispatch(req, origin, &headers, app_handle).await;
+  if response.status() != StatusCode::ACCEPTED {
+    INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+  }
+  response
+}
+
+async fn read_and_dispatch(
+  req: Request<Incoming>,
+  origin: &str,
+  headers: &hyper::HeaderMap,
+  app_handle: AppHandle,
+) -> Response<Full<Bytes>> {
+  let collected = match Limited::new(req.into_body(), MAX_BODY_BYTES)
+    .collect()
+    .await
+  {
+    Ok(body) => body.to_bytes(),
+    Err(_) => {
+      return error_response(StatusCode::PAYLOAD_TOO_LARGE, "TOO_LARGE", Some(origin));
+    }
+  };
+
+  if collected.len() < MIN_BODY_BYTES {
+    return error_response(StatusCode::BAD_REQUEST, "TOO_SMALL", Some(origin));
+  }
+
+  if !is_plausible_vpk(&collected) {
+    return error_response(StatusCode::BAD_REQUEST, "NOT_A_VPK", Some(origin));
+  }
+
+  let name = decode_mod_name(headers.get(NAME_HEADER).and_then(|v| v.to_str().ok()));
+  let author = decode_optional(headers.get(AUTHOR_HEADER).and_then(|v| v.to_str().ok()));
+
+  let path = match write_temp_vpk(&collected).await {
+    Ok(path) => path,
+    Err(error) => {
+      log::error!("[ForgeBridge] Failed to stage payload: {error}");
+      return error_response(StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL", Some(origin));
+    }
+  };
+  remember_staged(&path);
+
+  let payload = ForgeInstallRequest {
+    name,
+    path: path.to_string_lossy().into_owned(),
+    author,
+  };
+
+  if let Some(window) = app_handle.get_webview_window("main") {
+    let _ = window.set_focus();
+    let _ = window.show();
+    let _ = window.unminimize();
+    if let Err(error) = window.emit(EVENT_FORGE_INSTALL_REQUESTED, payload) {
+      log::error!("[ForgeBridge] Failed to notify the window: {error}");
+      forget_staged(&path);
+      let _ = tokio::fs::remove_file(&path).await;
+      return error_response(StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL", Some(origin));
+    }
+  } else {
+    forget_staged(&path);
+    let _ = tokio::fs::remove_file(&path).await;
+    return error_response(StatusCode::SERVICE_UNAVAILABLE, "NO_WINDOW", Some(origin));
+  }
+
+  json_response(
+    StatusCode::ACCEPTED,
+    "{\"ok\":true,\"queued\":true}",
+    Some(origin),
+  )
+}
+
+/// What a request is allowed to do, decided purely from its method, path and
+/// headers. Kept separate from the response building so the trust rules can be
+/// tested without standing up a window.
+#[derive(Debug, PartialEq, Eq)]
+enum Decision<'a> {
+  Reject(StatusCode, &'static str),
+  Preflight {
+    origin: &'a str,
+    private_network: bool,
+  },
+  Ping {
+    origin: &'a str,
+  },
+  Install {
+    origin: &'a str,
+  },
+  NotFound {
+    origin: &'a str,
+  },
+}
+
+fn classify<'a>(
+  method: &Method,
+  path: &str,
+  host: Option<&str>,
+  origin: Option<&'a str>,
+  private_network: bool,
+) -> Decision<'a> {
+  if !host_is_loopback(host) {
+    return Decision::Reject(StatusCode::FORBIDDEN, "BAD_HOST");
+  }
+
+  let Some(origin) = allowed_origin(origin) else {
+    return Decision::Reject(StatusCode::FORBIDDEN, "BAD_ORIGIN");
+  };
+
+  if method == Method::OPTIONS {
+    return Decision::Preflight {
+      origin,
+      private_network,
+    };
+  }
+
+  match (method, path) {
+    (&Method::GET, "/forge/v1/ping") => Decision::Ping { origin },
+    (&Method::POST, "/forge/v1/install") => Decision::Install { origin },
+    _ => Decision::NotFound { origin },
+  }
+}
+
+async fn route(req: Request<Incoming>, app_handle: AppHandle) -> Response<Full<Bytes>> {
+  let headers = req.headers().clone();
+  let header = |name: &str| headers.get(name).and_then(|v| v.to_str().ok());
+
+  let private_network =
+    header("access-control-request-private-network").is_some_and(|v| v == "true");
+  let path = req.uri().path().to_string();
+
+  match classify(
+    req.method(),
+    &path,
+    header("host"),
+    header("origin"),
+    private_network,
+  ) {
+    Decision::Reject(status, reason) => error_response(status, reason, None),
+    Decision::Preflight {
+      origin,
+      private_network,
+    } => preflight_response(origin, private_network),
+    Decision::Ping { origin } => {
+      let body = PingBody {
+        ok: true,
+        app: FORGE_APP_ID,
+        protocol: FORGE_PROTOCOL_VERSION,
+      };
+      let encoded = serde_json::to_string(&body).unwrap_or_else(|_| "{}".to_string());
+      json_response(StatusCode::OK, &encoded, Some(origin))
+    }
+    Decision::Install { origin } => {
+      let origin = origin.to_owned();
+      handle_install(req, &origin, app_handle).await
+    }
+    Decision::NotFound { origin } => {
+      error_response(StatusCode::NOT_FOUND, "NOT_FOUND", Some(origin))
+    }
+  }
+}
+
+async fn bind_first_free() -> Option<(TcpListener, u16)> {
+  for port in FORGE_PORTS {
+    let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+    if let Ok(listener) = TcpListener::bind(addr).await {
+      return Some((listener, port));
+    }
+  }
+  None
+}
+
+pub async fn start(app_handle: AppHandle) -> Result<u16, Error> {
+  {
+    let guard = BRIDGE
+      .lock()
+      .map_err(|_| Error::InvalidInput("Forge bridge state is poisoned".to_string()))?;
+    if let Some(handle) = guard.as_ref() {
+      return Ok(handle.port);
+    }
+  }
+
+  let Some((listener, port)) = bind_first_free().await else {
+    return Err(Error::InvalidInput(
+      "No free loopback port for the forge bridge".to_string(),
+    ));
+  };
+
+  let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+  tokio::spawn(async move {
+    loop {
+      tokio::select! {
+        _ = &mut shutdown_rx => break,
+        accepted = listener.accept() => {
+          let Ok((stream, _)) = accepted else { continue };
+          let handle = app_handle.clone();
+          tokio::spawn(async move {
+            let service = service_fn(move |req| {
+              let handle = handle.clone();
+              async move { Ok::<_, std::convert::Infallible>(route(req, handle).await) }
+            });
+            if let Err(error) = http1::Builder::new()
+              .serve_connection(TokioIo::new(stream), service)
+              .await
+            {
+              log::debug!("[ForgeBridge] Connection ended: {error}");
+            }
+          });
+        }
+      }
+    }
+  });
+
+  if let Ok(mut guard) = BRIDGE.lock() {
+    *guard = Some(BridgeHandle {
+      port,
+      shutdown: shutdown_tx,
+    });
+  }
+
+  log::info!("[ForgeBridge] Listening on 127.0.0.1:{port}");
+  Ok(port)
+}
+
+pub fn stop() {
+  let handle = BRIDGE.lock().ok().and_then(|mut guard| guard.take());
+  if let Some(handle) = handle {
+    let _ = handle.shutdown.send(());
+    INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+    log::info!("[ForgeBridge] Stopped");
+  }
+}
+
+/// Called once the user has answered, so the next request is not refused as busy.
+pub fn release_in_flight() {
+  INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+}
+
+/// Resolve a path the frontend reported back to one this bridge actually staged.
+pub fn staged_path(candidate: &str) -> Result<PathBuf, Error> {
+  let candidate = PathBuf::from(candidate);
+  let mut guard = STAGED
+    .lock()
+    .map_err(|_| Error::InvalidInput("Forge staging state is poisoned".to_string()))?;
+
+  match guard.iter().position(|staged| *staged == candidate) {
+    Some(index) => Ok(guard.remove(index)),
+    None => Err(Error::UnauthorizedPath(candidate.display().to_string())),
+  }
+}
+
+fn remember_staged(path: &Path) {
+  if let Ok(mut guard) = STAGED.lock() {
+    guard.push(path.to_path_buf());
+  }
+}
+
+fn forget_staged(path: &Path) {
+  if let Ok(mut guard) = STAGED.lock() {
+    guard.retain(|staged| staged != path);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const OK_ORIGIN: &str = "https://deadlockforge.net";
+  const OK_HOST: &str = "127.0.0.1:43120";
+
+  fn classify_get(path: &str) -> Decision<'static> {
+    classify(&Method::GET, path, Some(OK_HOST), Some(OK_ORIGIN), false)
+  }
+
+  #[test]
+  fn answers_a_ping_from_an_allowlisted_origin() {
+    assert_eq!(
+      classify_get("/forge/v1/ping"),
+      Decision::Ping { origin: OK_ORIGIN }
+    );
+  }
+
+  #[test]
+  fn refuses_a_foreign_origin_before_anything_else() {
+    let decision = classify(
+      &Method::POST,
+      "/forge/v1/install",
+      Some(OK_HOST),
+      Some("https://evil.com"),
+      false,
+    );
+    assert_eq!(
+      decision,
+      Decision::Reject(StatusCode::FORBIDDEN, "BAD_ORIGIN")
+    );
+  }
+
+  #[test]
+  fn refuses_a_missing_origin() {
+    let decision = classify(&Method::GET, "/forge/v1/ping", Some(OK_HOST), None, false);
+    assert_eq!(
+      decision,
+      Decision::Reject(StatusCode::FORBIDDEN, "BAD_ORIGIN")
+    );
+  }
+
+  #[test]
+  fn refuses_a_rebound_dns_name_even_from_a_good_origin() {
+    let decision = classify(
+      &Method::GET,
+      "/forge/v1/ping",
+      Some("attacker.example.com:43120"),
+      Some(OK_ORIGIN),
+      false,
+    );
+    assert_eq!(
+      decision,
+      Decision::Reject(StatusCode::FORBIDDEN, "BAD_HOST")
+    );
+  }
+
+  #[test]
+  fn grants_private_network_access_only_when_asked() {
+    let asked = classify(
+      &Method::OPTIONS,
+      "/forge/v1/install",
+      Some(OK_HOST),
+      Some(OK_ORIGIN),
+      true,
+    );
+    assert_eq!(
+      asked,
+      Decision::Preflight {
+        origin: OK_ORIGIN,
+        private_network: true
+      }
+    );
+
+    let not_asked = classify(
+      &Method::OPTIONS,
+      "/forge/v1/install",
+      Some(OK_HOST),
+      Some(OK_ORIGIN),
+      false,
+    );
+    assert_eq!(
+      not_asked,
+      Decision::Preflight {
+        origin: OK_ORIGIN,
+        private_network: false
+      }
+    );
+  }
+
+  #[test]
+  fn does_not_expose_anything_beyond_the_two_routes() {
+    assert_eq!(
+      classify_get("/forge/v1/anything"),
+      Decision::NotFound { origin: OK_ORIGIN }
+    );
+    assert_eq!(
+      classify(
+        &Method::GET,
+        "/forge/v1/install",
+        Some(OK_HOST),
+        Some(OK_ORIGIN),
+        false
+      ),
+      Decision::NotFound { origin: OK_ORIGIN }
+    );
+  }
+
+  #[test]
+  fn refuses_a_second_install_while_one_is_awaiting_an_answer() {
+    INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+    assert!(!INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst));
+    assert!(INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst));
+    release_in_flight();
+    assert!(!INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst));
+    release_in_flight();
+  }
+
+  #[test]
+  fn only_deletes_a_path_the_bridge_staged() {
+    let path = std::env::temp_dir().join("deadlockforge-test-not-staged.vpk");
+    assert!(staged_path(&path.to_string_lossy()).is_err());
+
+    remember_staged(&path);
+    assert!(staged_path(&path.to_string_lossy()).is_ok());
+    assert!(staged_path(&path.to_string_lossy()).is_err());
+  }
+
+  #[test]
+  fn allows_every_header_the_site_sends_on_an_install() {
+    // Regression: the list omitted x-forge-type and x-forge-author, so the
+    // browser refused to send the POST at all. Detection still worked, because
+    // the ping is a simple request and skips the preflight, which made it look
+    // like the app was unreachable rather than like a CORS refusal.
+    for header in [
+      "content-type",
+      PROTOCOL_HEADER,
+      NAME_HEADER,
+      "x-forge-type",
+      AUTHOR_HEADER,
+    ] {
+      assert!(
+        ALLOWED_REQUEST_HEADERS.contains(header),
+        "{header} is sent by the site but not permitted by the preflight"
+      );
+    }
+  }
+
+  #[test]
+  fn drops_an_empty_optional_header() {
+    assert_eq!(
+      decode_optional(Some("Sirsyorrz")),
+      Some("Sirsyorrz".to_string())
+    );
+    assert_eq!(decode_optional(Some("  ")), None);
+    assert_eq!(decode_optional(None), None);
+  }
+
+  #[test]
+  fn accepts_only_the_exact_allowlisted_origins() {
+    assert!(allowed_origin(Some("https://deadlockforge.net")).is_some());
+    assert!(allowed_origin(Some("https://www.deadlockforge.net")).is_some());
+    assert!(allowed_origin(Some("https://deadlockforge.net.evil.com")).is_none());
+    assert!(allowed_origin(Some("http://deadlockforge.net")).is_none());
+    assert!(allowed_origin(Some("null")).is_none());
+    assert!(allowed_origin(None).is_none());
+  }
+
+  #[test]
+  fn requires_a_loopback_host() {
+    assert!(host_is_loopback(Some("127.0.0.1:43120")));
+    assert!(host_is_loopback(Some("127.0.0.1")));
+    assert!(!host_is_loopback(Some("localhost:43120")));
+    assert!(!host_is_loopback(Some("attacker.example.com:43120")));
+    assert!(!host_is_loopback(None));
+  }
+
+  #[test]
+  fn detects_a_vpk_signature() {
+    assert!(is_plausible_vpk(&[0x34, 0x12, 0xAA, 0x55, 0x02]));
+    assert!(!is_plausible_vpk(&[0x50, 0x4B, 0x03, 0x04]));
+    assert!(!is_plausible_vpk(&[0x34, 0x12]));
+  }
+
+  #[test]
+  fn strips_path_separators_from_the_name() {
+    assert_eq!(
+      decode_mod_name(Some("Abrams%20Ult%20Airhorn")),
+      "Abrams Ult Airhorn"
+    );
+    assert_eq!(decode_mod_name(Some("..%2F..%2Fetc%2Fpasswd")), "etcpasswd");
+    assert_eq!(decode_mod_name(Some("")), "DeadlockForge mod");
+    assert_eq!(decode_mod_name(None), "DeadlockForge mod");
+  }
+
+  #[test]
+  fn caps_an_absurdly_long_name() {
+    let long = "a".repeat(500);
+    assert_eq!(decode_mod_name(Some(&long)).chars().count(), 120);
+  }
+}

--- a/apps/desktop/src-tauri/src/forge_bridge.rs
+++ b/apps/desktop/src-tauri/src/forge_bridge.rs
@@ -1,18 +1,9 @@
 //! Loopback HTTP bridge for 1-click installs from DeadlockForge.
 //!
-//! DeadlockForge builds VPKs in the browser on demand, so unlike GameBanana
-//! there is no hosted URL to hand over and the existing deep link flow does not
-//! apply. Instead the site detects this app listening on loopback and POSTs the
-//! bytes straight in.
-//!
-//! Trust is the Origin header, checked against an exact allowlist. The site
-//! cannot forge it: browsers set it themselves, and the install route requires
-//! a non-simple content type plus a custom header so it is always preceded by a
-//! preflight this server can refuse.
-//!
-//! Nothing is written to the mod library here. A validated payload lands in a
-//! temp file and the frontend is asked to confirm before it is imported through
-//! the normal local mod pipeline.
+//! The site builds VPKs in the browser, so there is no URL to hand the deep
+//! link flow. It posts the bytes here instead. Trust is the Origin header:
+//! browsers set it themselves, and the install route is deliberately a
+//! non-simple request so a preflight always precedes it.
 
 use crate::app_runtime::AppHandle;
 use crate::errors::Error;
@@ -26,31 +17,28 @@ use serde::Serialize;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 use tauri::{Emitter, Manager};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
 const FORGE_PROTOCOL_VERSION: u32 = 1;
 
-/// Distinct from Grimoire's 43110-43114 so both managers can run at once and
-/// the site always reaches the one it meant to.
+/// Distinct from Grimoire's 43110-43114 so both managers can run at once.
 const FORGE_PORTS: [u16; 5] = [43120, 43121, 43122, 43123, 43124];
 
-/// Identifies this app in the ping response so the site can tell managers apart
-/// even if a custom build ends up on another manager's port.
+/// Lets the site tell managers apart if one answers in the other's range.
 const FORGE_APP_ID: &str = "deadlock-mod-manager";
 
 const EVENT_FORGE_INSTALL_REQUESTED: &str = "forge-install-requested";
 
 const ALLOWED_ORIGINS: &[&str] = &["https://deadlockforge.net", "https://www.deadlockforge.net"];
 
-/// Sound mods scale with both clip length and the number of replaced sounds:
-/// roughly 16 KB per second of audio per sound, so a 600 sound build from a
-/// 30 second clip is already near 300 MB.
+/// Sound builds run large: roughly 16 KB per second of audio per replaced
+/// sound, so 600 sounds from a 30 second clip approaches 300 MB.
 const MAX_BODY_BYTES: usize = 512 * 1024 * 1024;
 
-/// Below this a payload cannot carry a VPK header, so it is never worth reading.
+/// Below this a payload cannot carry a VPK header.
 const MIN_BODY_BYTES: usize = 32;
 
 const VPK_SIGNATURE: u32 = 0x55AA_1234;
@@ -59,9 +47,8 @@ const PROTOCOL_HEADER: &str = "x-forge-protocol";
 const NAME_HEADER: &str = "x-forge-name";
 const AUTHOR_HEADER: &str = "x-forge-author";
 
-/// Every header the site may send on an install. A header missing here is not
-/// merely ignored: the browser refuses to send the request at all, and the
-/// caller sees a transport failure rather than a rejection it can explain.
+/// Every header the site sends. One missing here is not ignored: the browser
+/// refuses to send the request at all, which looks like an unreachable app.
 const ALLOWED_REQUEST_HEADERS: &str =
   "content-type, x-forge-protocol, x-forge-name, x-forge-type, x-forge-author";
 const CONTENT_TYPE: &str = "application/octet-stream";
@@ -73,14 +60,21 @@ struct BridgeHandle {
 
 static BRIDGE: Mutex<Option<BridgeHandle>> = Mutex::new(None);
 
-/// Payloads this bridge staged and has not yet cleaned up. The frontend hands a
-/// path back when the user answers, and only a path we put here is ever deleted,
-/// so the cleanup command cannot be turned into an arbitrary file delete.
+/// Payloads staged and not yet cleaned up. Only a path listed here is ever
+/// deleted, so the cleanup command cannot delete arbitrary files.
 static STAGED: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
-/// One install may be awaiting the user's answer at a time. A second request is
-/// refused rather than queued, so a page cannot stack dialogs.
-static INSTALL_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+/// One install may await an answer at a time, so a page cannot stack dialogs.
+/// An instant rather than a flag, so a dialog that never reports back cannot
+/// hold the slot for the rest of the session.
+static IN_FLIGHT_SINCE: Mutex<Option<Instant>> = Mutex::new(None);
+
+/// How long an unanswered install keeps the slot before another may take it.
+const INSTALL_ANSWER_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Serialises start and stop; two concurrent starts would otherwise bind
+/// separate ports and only the handle stored last could be closed.
+static LIFECYCLE: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[derive(Serialize, Clone)]
 struct PingBody {
@@ -125,8 +119,7 @@ fn allowed_origin(origin: Option<&str>) -> Option<&str> {
     .copied()
 }
 
-/// The Host header must be a loopback literal. A name that resolves to 127.0.0.1
-/// is how DNS rebinding reaches a local server, and no legitimate caller uses one.
+/// Requires a loopback literal, which is what stops a DNS rebind.
 fn host_is_loopback(host: Option<&str>) -> bool {
   let Some(host) = host else {
     return false;
@@ -143,8 +136,8 @@ fn is_plausible_vpk(bytes: &[u8]) -> bool {
   signature == VPK_SIGNATURE
 }
 
-/// Names arrive percent encoded because raw non-ASCII is not legal in a header.
-/// Anything path-like is stripped: this becomes a filename.
+/// Percent encoded in transit, and stripped of anything path-like because this
+/// becomes a filename.
 fn decode_mod_name(raw: Option<&str>) -> String {
   let decoded = raw
     .and_then(|value| urlencoding::decode(value).ok())
@@ -165,7 +158,6 @@ fn decode_mod_name(raw: Option<&str>) -> String {
   }
 }
 
-/// Percent-decoded, trimmed, and dropped if it carries nothing useful.
 fn decode_optional(raw: Option<&str>) -> Option<String> {
   let decoded = raw
     .and_then(|value| urlencoding::decode(value).ok())
@@ -235,13 +227,17 @@ async fn handle_install(
     );
   }
 
-  if INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+  let Some(abandoned) = claim_install_slot() else {
     return error_response(StatusCode::TOO_MANY_REQUESTS, "BUSY", Some(origin));
+  };
+
+  for path in abandoned {
+    let _ = tokio::fs::remove_file(&path).await;
   }
 
   let response = read_and_dispatch(req, origin, &headers, app_handle).await;
   if response.status() != StatusCode::ACCEPTED {
-    INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+    release_in_flight();
   }
   response
 }
@@ -311,9 +307,8 @@ async fn read_and_dispatch(
   )
 }
 
-/// What a request is allowed to do, decided purely from its method, path and
-/// headers. Kept separate from the response building so the trust rules can be
-/// tested without standing up a window.
+/// Split from the response building so the trust rules can be tested without
+/// standing up a window.
 #[derive(Debug, PartialEq, Eq)]
 enum Decision<'a> {
   Reject(StatusCode, &'static str),
@@ -411,6 +406,8 @@ async fn bind_first_free() -> Option<(TcpListener, u16)> {
 }
 
 pub async fn start(app_handle: AppHandle) -> Result<u16, Error> {
+  let _serialised = LIFECYCLE.lock().await;
+
   {
     let guard = BRIDGE
       .lock()
@@ -463,21 +460,59 @@ pub async fn start(app_handle: AppHandle) -> Result<u16, Error> {
   Ok(port)
 }
 
-pub fn stop() {
+pub async fn stop() {
+  let _serialised = LIFECYCLE.lock().await;
+
   let handle = BRIDGE.lock().ok().and_then(|mut guard| guard.take());
   if let Some(handle) = handle {
     let _ = handle.shutdown.send(());
-    INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+    release_in_flight();
     log::info!("[ForgeBridge] Stopped");
   }
 }
 
-/// Called once the user has answered, so the next request is not refused as busy.
-pub fn release_in_flight() {
-  INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
+/// Takes the slot, or `None` if held. A slot past the timeout is taken over,
+/// returning whatever the abandoned install staged so it can be deleted.
+fn claim_install_slot() -> Option<Vec<PathBuf>> {
+  let mut guard = IN_FLIGHT_SINCE.lock().ok()?;
+
+  match *guard {
+    Some(since) if since.elapsed() < INSTALL_ANSWER_TIMEOUT => None,
+    _ => {
+      *guard = Some(Instant::now());
+      Some(drain_staged())
+    }
+  }
 }
 
-/// Resolve a path the frontend reported back to one this bridge actually staged.
+fn drain_staged() -> Vec<PathBuf> {
+  STAGED
+    .lock()
+    .map(|mut guard| std::mem::take(&mut *guard))
+    .unwrap_or_default()
+}
+
+pub fn release_in_flight() {
+  if let Ok(mut guard) = IN_FLIGHT_SINCE.lock() {
+    *guard = None;
+  }
+}
+
+/// Resolve a reported path without consuming the entry.
+pub fn peek_staged(candidate: &str) -> Result<PathBuf, Error> {
+  let candidate = PathBuf::from(candidate);
+  let guard = STAGED
+    .lock()
+    .map_err(|_| Error::InvalidInput("Forge staging state is poisoned".to_string()))?;
+
+  if guard.contains(&candidate) {
+    Ok(candidate)
+  } else {
+    Err(Error::UnauthorizedPath(candidate.display().to_string()))
+  }
+}
+
+/// Resolve a reported path to one this bridge actually staged.
 pub fn staged_path(candidate: &str) -> Result<PathBuf, Error> {
   let candidate = PathBuf::from(candidate);
   let mut guard = STAGED
@@ -613,11 +648,28 @@ mod tests {
 
   #[test]
   fn refuses_a_second_install_while_one_is_awaiting_an_answer() {
-    INSTALL_IN_FLIGHT.store(false, Ordering::SeqCst);
-    assert!(!INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst));
-    assert!(INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst));
     release_in_flight();
-    assert!(!INSTALL_IN_FLIGHT.swap(true, Ordering::SeqCst));
+    assert!(claim_install_slot().is_some());
+    assert!(claim_install_slot().is_none());
+    release_in_flight();
+    assert!(claim_install_slot().is_some());
+    release_in_flight();
+  }
+
+  #[test]
+  fn takes_over_a_slot_whose_answer_never_came() {
+    // Without the timeout a lost dialog would refuse installs all session.
+    let stale = std::env::temp_dir().join("deadlockforge-abandoned.vpk");
+    remember_staged(&stale);
+    *IN_FLIGHT_SINCE.lock().expect("lock") =
+      Some(Instant::now() - INSTALL_ANSWER_TIMEOUT - Duration::from_secs(1));
+
+    let abandoned = claim_install_slot().expect("stale slot should be taken over");
+    assert_eq!(
+      abandoned,
+      vec![stale],
+      "the leftover payload must come back"
+    );
     release_in_flight();
   }
 
@@ -633,10 +685,8 @@ mod tests {
 
   #[test]
   fn allows_every_header_the_site_sends_on_an_install() {
-    // Regression: the list omitted x-forge-type and x-forge-author, so the
-    // browser refused to send the POST at all. Detection still worked, because
-    // the ping is a simple request and skips the preflight, which made it look
-    // like the app was unreachable rather than like a CORS refusal.
+    // Regression: omitting x-forge-type and x-forge-author made the browser
+    // refuse the POST, which looked like the app being unreachable.
     for header in [
       "content-type",
       PROTOCOL_HEADER,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod download_manager;
 mod dropped_mod_file;
 mod errors;
 mod flatpak;
+mod forge_bridge;
 mod game_presence;
 mod hero_detector;
 mod ingest_tool;
@@ -208,6 +209,9 @@ pub fn run() {
       commands::ingest::stop_cache_watcher,
       commands::ingest::get_ingest_status,
       commands::ingest::initialize_ingest_tool,
+      commands::forge::start_forge_bridge,
+      commands::forge::stop_forge_bridge,
+      commands::forge::finish_forge_install,
       game_presence::get_game_presence_status,
       game_presence::get_game_presence_heroes,
       game_presence::start_game_presence_watcher,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -211,6 +211,7 @@ pub fn run() {
       commands::ingest::initialize_ingest_tool,
       commands::forge::start_forge_bridge,
       commands::forge::stop_forge_bridge,
+      commands::forge::place_forge_payload,
       commands::forge::finish_forge_install,
       game_presence::get_game_presence_status,
       game_presence::get_game_presence_heroes,

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -9,6 +9,7 @@ import usePromise from "react-promise-suspense";
 import { Outlet } from "react-router";
 import { FontInstallDialog } from "./components/downloads/font-install-dialog";
 import { ProgressProvider } from "./components/downloads/progress-indicator";
+import { ForgeInstallRenderer } from "./components/forge-install-renderer";
 import { FoundryProvider } from "./components/foundry/foundry-context";
 import { GamePresenceRenderer } from "./components/game-presence-renderer";
 import { LiveMatchRenderer } from "./components/live-match-renderer";
@@ -152,6 +153,7 @@ const App = () => {
                     <GamePresenceRenderer />
                     <MatchSyncRenderer />
                     <LiveMatchRenderer />
+                    <ForgeInstallRenderer />
                     <UpdateDialog
                       downloadProgress={downloadProgress}
                       isDownloading={isDownloading}

--- a/apps/desktop/src/components/forge-install-renderer.tsx
+++ b/apps/desktop/src/components/forge-install-renderer.tsx
@@ -1,0 +1,13 @@
+import { useForgeBridge } from "@/hooks/use-forge-bridge";
+import { useForgeInstall } from "@/hooks/use-forge-install";
+import { useForgeLaunchPrompt } from "@/hooks/use-forge-launch";
+
+// Mounted inside the providers because the install listener needs the confirm
+// dialog and the progress indicator, both of which App itself renders.
+export const ForgeInstallRenderer = () => {
+  useForgeBridge();
+  useForgeInstall();
+  useForgeLaunchPrompt();
+
+  return null;
+};

--- a/apps/desktop/src/components/settings/forge-install-toggle.tsx
+++ b/apps/desktop/src/components/settings/forge-install-toggle.tsx
@@ -1,0 +1,37 @@
+import { Label } from "@deadlock-mods/ui/components/label";
+import { Switch } from "@deadlock-mods/ui/components/switch";
+import { useTranslation } from "react-i18next";
+import { usePersistedStore } from "@/lib/store";
+
+export const ForgeInstallToggle = () => {
+  const { t } = useTranslation();
+  const forgeInstallEnabled = usePersistedStore(
+    (state) => state.forgeInstallEnabled,
+  );
+  const setForgeInstallEnabled = usePersistedStore(
+    (state) => state.setForgeInstallEnabled,
+  );
+
+  return (
+    <div className='flex items-center justify-between'>
+      <div className='space-y-1'>
+        <Label className='font-bold text-sm'>
+          {t("settings.forgeInstall")}
+        </Label>
+        <p className='text-muted-foreground text-sm'>
+          {t("settings.forgeInstallDescription")}
+        </p>
+      </div>
+      <div className='flex items-center gap-2'>
+        <Switch
+          checked={forgeInstallEnabled}
+          id='toggle-setting-forge-install'
+          onCheckedChange={setForgeInstallEnabled}
+        />
+        <Label htmlFor='toggle-setting-forge-install'>
+          {forgeInstallEnabled ? t("status.enabled") : t("status.disabled")}
+        </Label>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/hooks/use-forge-bridge.ts
+++ b/apps/desktop/src/hooks/use-forge-bridge.ts
@@ -1,0 +1,27 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect } from "react";
+import logger from "@/lib/logger";
+import { usePersistedStore } from "@/lib/store";
+
+export const useForgeBridge = () => {
+  const forgeInstallEnabled = usePersistedStore(
+    (state) => state.forgeInstallEnabled,
+  );
+
+  useEffect(() => {
+    if (!forgeInstallEnabled) {
+      invoke("stop_forge_bridge").catch((error) => {
+        logger.withError(error).warn("Failed to stop forge bridge");
+      });
+      return;
+    }
+
+    invoke<number>("start_forge_bridge")
+      .then((port) => {
+        logger.withMetadata({ port }).info("Forge bridge listening");
+      })
+      .catch((error) => {
+        logger.withError(error).error("Failed to start forge bridge");
+      });
+  }, [forgeInstallEnabled]);
+};

--- a/apps/desktop/src/hooks/use-forge-install.ts
+++ b/apps/desktop/src/hooks/use-forge-install.ts
@@ -1,0 +1,108 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useConfirm } from "@/components/providers/alert-dialog";
+import { ModCategory } from "@/lib/constants";
+import logger from "@/lib/logger";
+import { usePersistedStore } from "@/lib/store";
+import { useModProcessor } from "./use-mod-processor";
+
+const FORGE_INSTALL_EVENT = "forge-install-requested";
+const FORGE_AUTHOR = "DeadlockForge";
+const FORGE_LINK = "https://deadlockforge.net";
+
+type ForgeInstallRequest = {
+  name: string;
+  path: string;
+  author: string | null;
+};
+
+const VPK_SUFFIX = /\.vpk$/i;
+
+// The site sends the built filename, so it usually carries a .vpk suffix. That
+// is right for the file on disk and wrong for the name shown in the library.
+const toDisplayName = (name: string): string =>
+  name.replace(VPK_SUFFIX, "").trim() || "DeadlockForge mod";
+
+const toFileName = (name: string): string =>
+  `${name.replace(VPK_SUFFIX, "")}.vpk`;
+
+export const useForgeInstall = () => {
+  const { t } = useTranslation();
+  const confirm = useConfirm();
+  const { processMod } = useModProcessor();
+  const forgeInstallEnabled = usePersistedStore(
+    (state) => state.forgeInstallEnabled,
+  );
+
+  // The listener is registered once, so it must read the current setting and
+  // the current processMod rather than the ones captured when it was created.
+  const enabledRef = useRef(forgeInstallEnabled);
+  enabledRef.current = forgeInstallEnabled;
+  const processRef = useRef(processMod);
+  processRef.current = processMod;
+
+  useEffect(() => {
+    const unlisten = listen<ForgeInstallRequest>(
+      FORGE_INSTALL_EVENT,
+      async (event) => {
+        const request = event.payload;
+
+        // The bridge only runs while the setting is on, but a request already
+        // in flight when it is switched off must not slip through.
+        if (!enabledRef.current) {
+          await invoke("finish_forge_install", { path: request.path }).catch(
+            () => undefined,
+          );
+          return;
+        }
+
+        try {
+          const accepted = !!(await confirm({
+            title: t("forge.confirmTitle"),
+            body: t("forge.confirmBody", { name: toDisplayName(request.name) }),
+            actionButton: t("forge.confirmAction"),
+            cancelButton: t("forge.confirmCancel"),
+          }));
+
+          if (!accepted) {
+            logger.info("Forge install declined by user");
+            return;
+          }
+
+          const bytes = await invoke<number[]>("read_dropped_mod_file", {
+            filePath: request.path,
+          });
+          const file = new File(
+            [new Uint8Array(bytes)],
+            toFileName(request.name),
+          );
+
+          await processRef.current(
+            {
+              name: toDisplayName(request.name),
+              author: request.author ?? FORGE_AUTHOR,
+              link: FORGE_LINK,
+              description: t("forge.modDescription"),
+            },
+            ModCategory.OTHER_MISC,
+            { kind: "vpk", file },
+          );
+        } catch (error) {
+          logger.withError(error).error("Failed to install mod from forge");
+          toast.error(t("forge.installFailed"));
+        } finally {
+          await invoke("finish_forge_install", { path: request.path }).catch(
+            () => undefined,
+          );
+        }
+      },
+    );
+
+    return () => {
+      unlisten.then((dispose) => dispose()).catch(() => undefined);
+    };
+  }, [confirm, t]);
+};

--- a/apps/desktop/src/hooks/use-forge-install.ts
+++ b/apps/desktop/src/hooks/use-forge-install.ts
@@ -21,10 +21,17 @@ type ForgeInstallRequest = {
 
 const VPK_SUFFIX = /\.vpk$/i;
 
-// The site sends the built filename, so it usually carries a .vpk suffix. That
-// is right for the file on disk and wrong for the name shown in the library.
-const toDisplayName = (name: string): string =>
-  name.replace(VPK_SUFFIX, "").trim() || "DeadlockForge mod";
+// The site sends the built filename; the suffix suits the file, not the label.
+const toDisplayName = (name: string, fallback: string): string =>
+  name.replace(VPK_SUFFIX, "").trim() || fallback;
+
+const finishInstall = async (path: string): Promise<void> => {
+  try {
+    await invoke("finish_forge_install", { path });
+  } catch (error) {
+    logger.withError(error).warn("Failed to release the forge install slot");
+  }
+};
 
 const toFileName = (name: string): string =>
   `${name.replace(VPK_SUFFIX, "")}.vpk`;
@@ -37,8 +44,7 @@ export const useForgeInstall = () => {
     (state) => state.forgeInstallEnabled,
   );
 
-  // The listener is registered once, so it must read the current setting and
-  // the current processMod rather than the ones captured when it was created.
+  // Registered once, so it must read current values rather than captured ones.
   const enabledRef = useRef(forgeInstallEnabled);
   enabledRef.current = forgeInstallEnabled;
   const processRef = useRef(processMod);
@@ -53,50 +59,49 @@ export const useForgeInstall = () => {
         // The bridge only runs while the setting is on, but a request already
         // in flight when it is switched off must not slip through.
         if (!enabledRef.current) {
-          await invoke("finish_forge_install", { path: request.path }).catch(
-            () => undefined,
-          );
+          await finishInstall(request.path);
           return;
         }
 
         try {
+          const displayName = toDisplayName(
+            request.name,
+            t("forge.fallbackName"),
+          );
+
           const accepted = !!(await confirm({
             title: t("forge.confirmTitle"),
-            body: t("forge.confirmBody", { name: toDisplayName(request.name) }),
+            body: t("forge.confirmBody", { name: displayName }),
             actionButton: t("forge.confirmAction"),
             cancelButton: t("forge.confirmCancel"),
           }));
 
           if (!accepted) {
-            logger.info("Forge install declined by user");
+            logger
+              .withMetadata({ feature: "forge", outcome: "declined" })
+              .info("Forge install declined by user");
             return;
           }
 
-          const bytes = await invoke<number[]>("read_dropped_mod_file", {
-            filePath: request.path,
-          });
-          const file = new File(
-            [new Uint8Array(bytes)],
-            toFileName(request.name),
-          );
-
           await processRef.current(
             {
-              name: toDisplayName(request.name),
+              name: displayName,
               author: request.author ?? FORGE_AUTHOR,
               link: FORGE_LINK,
               description: t("forge.modDescription"),
             },
             ModCategory.OTHER_MISC,
-            { kind: "vpk", file },
+            {
+              kind: "vpkPath",
+              path: request.path,
+              fileName: toFileName(request.name),
+            },
           );
         } catch (error) {
           logger.withError(error).error("Failed to install mod from forge");
           toast.error(t("forge.installFailed"));
         } finally {
-          await invoke("finish_forge_install", { path: request.path }).catch(
-            () => undefined,
-          );
+          await finishInstall(request.path);
         }
       },
     );

--- a/apps/desktop/src/hooks/use-forge-launch.ts
+++ b/apps/desktop/src/hooks/use-forge-launch.ts
@@ -1,0 +1,57 @@
+import { toast } from "@deadlock-mods/ui/components/sonner";
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useConfirm } from "@/components/providers/alert-dialog";
+import logger from "@/lib/logger";
+import { usePersistedStore } from "@/lib/store";
+
+const FORGE_LAUNCH_EVENT = "forge-launch-requested";
+
+/**
+ * Raised when deadlockforge.net cannot find the bridge and fires the app's
+ * protocol URL to bring it up. Without this the app would surface with no
+ * explanation of why, and the user would have to find the Settings toggle on
+ * their own before the site's button could work.
+ */
+export const useForgeLaunchPrompt = () => {
+  const { t } = useTranslation();
+  const confirm = useConfirm();
+  const forgeInstallEnabled = usePersistedStore(
+    (state) => state.forgeInstallEnabled,
+  );
+  const setForgeInstallEnabled = usePersistedStore(
+    (state) => state.setForgeInstallEnabled,
+  );
+
+  const enabledRef = useRef(forgeInstallEnabled);
+  enabledRef.current = forgeInstallEnabled;
+
+  useEffect(() => {
+    const unlisten = listen(FORGE_LAUNCH_EVENT, async () => {
+      if (enabledRef.current) {
+        toast.info(t("forge.alreadyEnabled"));
+        return;
+      }
+
+      const accepted = !!(await confirm({
+        title: t("forge.enableTitle"),
+        body: t("forge.enableBody"),
+        actionButton: t("forge.enableAction"),
+        cancelButton: t("forge.enableCancel"),
+      }));
+
+      if (!accepted) {
+        logger.info("Forge 1-click installs declined at the prompt");
+        return;
+      }
+
+      setForgeInstallEnabled(true);
+      toast.success(t("forge.enabled"));
+    });
+
+    return () => {
+      unlisten.then((dispose) => dispose()).catch(() => undefined);
+    };
+  }, [confirm, t, setForgeInstallEnabled]);
+};

--- a/apps/desktop/src/hooks/use-forge-launch.ts
+++ b/apps/desktop/src/hooks/use-forge-launch.ts
@@ -8,12 +8,8 @@ import { usePersistedStore } from "@/lib/store";
 
 const FORGE_LAUNCH_EVENT = "forge-launch-requested";
 
-/**
- * Raised when deadlockforge.net cannot find the bridge and fires the app's
- * protocol URL to bring it up. Without this the app would surface with no
- * explanation of why, and the user would have to find the Settings toggle on
- * their own before the site's button could work.
- */
+// Raised when the site cannot find the bridge and fires the protocol URL.
+// Without it the app surfaces with no explanation of why.
 export const useForgeLaunchPrompt = () => {
   const { t } = useTranslation();
   const confirm = useConfirm();
@@ -42,7 +38,9 @@ export const useForgeLaunchPrompt = () => {
       }));
 
       if (!accepted) {
-        logger.info("Forge 1-click installs declined at the prompt");
+        logger
+          .withMetadata({ feature: "forge", outcome: "declined" })
+          .info("Forge 1-click installs declined at the prompt");
         return;
       }
 

--- a/apps/desktop/src/hooks/use-mod-processor.ts
+++ b/apps/desktop/src/hooks/use-mod-processor.ts
@@ -17,7 +17,7 @@ import {
   VPK_PATTERN,
 } from "@/lib/file-patterns";
 import {
-  type DetectedSource,
+  type ModSource,
   ensureDirectory,
   getFileBaseName,
   fileToBytes,
@@ -140,7 +140,7 @@ export const useModProcessor = () => {
 
   const validateFiles = async (
     filesDir: string,
-    detectedSource: DetectedSource,
+    detectedSource: ModSource,
   ): Promise<boolean> => {
     const filesList = await readDir(filesDir, {
       baseDir: BaseDirectory.AppLocalData,
@@ -171,7 +171,7 @@ export const useModProcessor = () => {
   const processMod = async (
     metadata: ModMetadata,
     category: ModCategory,
-    detectedSource: DetectedSource,
+    detectedSource: ModSource,
   ): Promise<void> => {
     setProcessing(true, t("addMods.validatingMetadata"));
 
@@ -193,23 +193,30 @@ export const useModProcessor = () => {
     );
 
     setProcessing(true, t("addMods.processingFiles"));
-    try {
-      if (detectedSource.kind === "vpk") {
+    if (detectedSource.kind === "vpkPath") {
+      await invoke("place_forge_payload", {
+        path: detectedSource.path,
+        destination: await join(filesDir, detectedSource.fileName),
+      });
+    } else {
+      try {
+        if (detectedSource.kind === "vpk") {
+          const fileName = getFileBaseName(detectedSource.file);
+          await writeFileBytes(
+            await join(filesDir, fileName),
+            await readSourceFileBytes(detectedSource.file),
+          );
+        } else {
+          await processArchive(detectedSource.file, filesDir, modDir);
+        }
+      } catch {
         const fileName = getFileBaseName(detectedSource.file);
+        toast.error(t("addMods.failedToProcessArchive"));
         await writeFileBytes(
-          await join(filesDir, fileName),
+          await join(modDir, fileName),
           await readSourceFileBytes(detectedSource.file),
         );
-      } else {
-        await processArchive(detectedSource.file, filesDir, modDir);
       }
-    } catch {
-      const fileName = getFileBaseName(detectedSource.file);
-      toast.error(t("addMods.failedToProcessArchive"));
-      await writeFileBytes(
-        await join(modDir, fileName),
-        await readSourceFileBytes(detectedSource.file),
-      );
     }
 
     setProcessing(true, t("addMods.validatingFiles"));

--- a/apps/desktop/src/lib/file-utils.ts
+++ b/apps/desktop/src/lib/file-utils.ts
@@ -25,6 +25,11 @@ export type DetectedSource =
   | { kind: "archive"; file: File }
   | { kind: "vpk"; file: File };
 
+// A VPK already on disk, placed natively rather than read through the renderer.
+export type StagedSource = { kind: "vpkPath"; path: string; fileName: string };
+
+export type ModSource = DetectedSource | StagedSource;
+
 /**
  * File utility functions
  */

--- a/apps/desktop/src/lib/store/slices/settings.ts
+++ b/apps/desktop/src/lib/store/slices/settings.ts
@@ -61,6 +61,7 @@ export type SettingsState = {
   linuxGpuOptimization: "auto" | "on" | "off";
   enabledPlugins: Record<string, boolean>; // pluginId -> isEnabled
   gamePresenceEnabled: boolean;
+  forgeInstallEnabled: boolean;
   gamePresenceTextTemplates: PresenceTextTemplates;
   gamePresenceHeroOverrides: GamePresenceHeroOverrides;
   backupEnabled: boolean;
@@ -102,6 +103,7 @@ export type SettingsState = {
   setLinuxGpuOptimization: (value: "auto" | "on" | "off") => void;
 
   setGamePresenceEnabled: (enabled: boolean) => void;
+  setForgeInstallEnabled: (enabled: boolean) => void;
   setGamePresenceTextTemplates: (templates: PresenceTextTemplates) => void;
   setGamePresenceHeroOverrides: (
     heroOverrides: GamePresenceHeroOverrides,
@@ -150,6 +152,7 @@ export const createSettingsSlice: StateCreator<State, [], [], SettingsState> = (
   linuxGpuOptimization: "auto",
   enabledPlugins: {},
   gamePresenceEnabled: true,
+  forgeInstallEnabled: false,
   gamePresenceTextTemplates: createDefaultGamePresenceTextTemplates(),
   gamePresenceHeroOverrides: {},
   backupEnabled: true,
@@ -288,6 +291,11 @@ export const createSettingsSlice: StateCreator<State, [], [], SettingsState> = (
   setGamePresenceEnabled: (enabled: boolean) =>
     set(() => ({
       gamePresenceEnabled: enabled,
+    })),
+
+  setForgeInstallEnabled: (enabled: boolean) =>
+    set(() => ({
+      forgeInstallEnabled: enabled,
     })),
 
   setGamePresenceTextTemplates: (templates: PresenceTextTemplates) =>

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1493,7 +1493,9 @@
     "modifications": "Modifications",
     "modManager": "Mod Manager",
     "external": "External",
-    "syntax": "Syntax"
+    "syntax": "Syntax",
+    "forgeInstall": "1-click installs from DeadlockForge",
+    "forgeInstallDescription": "Let deadlockforge.net send mods you build straight to Deadlock Mod Manager. Nothing installs without asking you first."
   },
   "featureFlags": {
     "title": "Experimental Features",
@@ -3144,5 +3146,19 @@
       "removeOverride": "Reset to default",
       "inheritPlaceholder": "Leave empty to use the default"
     }
+  },
+  "forge": {
+    "confirmTitle": "Install this mod from DeadlockForge?",
+    "confirmBody": "deadlockforge.net wants to send \"{{name}}\" to Deadlock Mod Manager. It will be added to your mods but stays disabled until you enable it.",
+    "confirmAction": "Install",
+    "confirmCancel": "Cancel",
+    "modDescription": "Created with DeadlockForge",
+    "installFailed": "Failed to install the mod from DeadlockForge",
+    "enableTitle": "Allow 1-click installs from DeadlockForge?",
+    "enableBody": "deadlockforge.net is trying to send you a mod. Turning this on lets it hand mods straight to Deadlock Mod Manager. You will still be asked before anything is installed, and you can turn it off in Settings.",
+    "enableAction": "Allow",
+    "enableCancel": "Not now",
+    "enabled": "1-click installs enabled. Click the button on the site again.",
+    "alreadyEnabled": "1-click installs are already on."
   }
 }

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -3159,6 +3159,7 @@
     "enableAction": "Allow",
     "enableCancel": "Not now",
     "enabled": "1-click installs enabled. Click the button on the site again.",
-    "alreadyEnabled": "1-click installs are already on."
+    "alreadyEnabled": "1-click installs are already on.",
+    "fallbackName": "DeadlockForge mod"
   }
 }

--- a/apps/desktop/src/pages/settings.tsx
+++ b/apps/desktop/src/pages/settings.tsx
@@ -59,6 +59,7 @@ import { SteamPathSettings } from "@/components/settings/steam-path-settings";
 import { GamePresenceSettings } from "@/components/settings/game-presence-settings";
 import GameInfoManagement from "@/components/settings/gameinfo-management";
 import { HeroParserSettings } from "@/components/settings/hero-parser-settings";
+import { ForgeInstallToggle } from "@/components/settings/forge-install-toggle";
 import { IngestToolToggle } from "@/components/settings/ingest-tool-toggle";
 import { LanguageSettings } from "@/components/settings/language-settings";
 import { LinuxGpuToggle } from "@/components/settings/linux-gpu-toggle";
@@ -704,6 +705,7 @@ const CustomSettings = ({ value }: { value?: string }) => {
                 <UpdateChannelSelect />
                 <DeveloperModeToggle />
                 <IngestToolToggle />
+                <ForgeInstallToggle />
                 <LinuxGpuToggle />
               </div>
             </Section>


### PR DESCRIPTION
Discussed with Stormix and Skeptic beforehand.

## What

1-click installs from DeadlockForge: build a mod on deadlockforge.net, click once, and it appears in Deadlock Mod Manager without downloading a file or adding it by hand.

## Why this is not a deep link

The existing `deadlock-mod-manager://` flow takes a GameBanana URL and downloads it. DeadlockForge builds VPKs in the browser on demand, so there is no hosted URL to hand over and nothing to download from. The site currently has no way to deliver a mod except telling the user to save the file and add it manually.

So instead of a URL, the bytes are pushed straight in over loopback.

## How it works

A small HTTP server on `127.0.0.1`, started only while the setting is on:

- `GET /forge/v1/ping` so the site can tell the app is running
- `POST /forge/v1/install` with the VPK as the body

Ports are `43120-43124`, deliberately distinct from Grimoire's `43110-43114` so both managers can run at once. The ping response identifies the app, so the site can tell them apart if a build ends up on the other range.

If the site tries to send a mod while the feature is off, it fires the app's protocol URL. That now raises a prompt asking whether to allow 1-click installs, rather than the app surfacing with no explanation and the user having to find the setting themselves.

## Trust model

Trust is the `Origin` header against an exact allowlist (`deadlockforge.net` and its `www`). A page cannot forge that: browsers set it themselves. The install route requires `application/octet-stream` plus a custom `X-Forge-Protocol` header, which makes it a non-simple request, so it is always preceded by a preflight the bridge can refuse. Without that, a plain form POST would bypass CORS entirely.

The `Host` header must be a loopback literal, which is what stops a DNS rebind from reaching the bridge with an attacker-controlled name.

Beyond that:

- Off by default, behind a Settings toggle
- Nothing is written to the mod library by the bridge. A validated payload is staged in a temp file and the user is asked before it is imported
- Imported through the existing local mod pipeline (`processMod`), so it arrives as a local mod and stays disabled until enabled
- One install at a time, so a page cannot stack dialogs
- Payload must carry a VPK signature, with a size floor and ceiling
- Only a path the bridge staged can be cleaned up, so the cleanup command cannot be turned into an arbitrary file delete

## Dependencies

`hyper`, `hyper-util` and `http-body-util` were already in the tree via `reqwest`; this enables the server feature of the same versions. That pulls in one new crate, `httpdate`, which hyper uses to format the `Date` header.

## Testing

Verified end to end against the live site with a release build: forge a sound mod, click the button, answer the prompt, and the mod arrives in the library disabled.

Automated: 138 Rust tests including the trust rules (origin allowlist with the `deadlockforge.net.evil.com` suffix case and plain http, missing origin, DNS rebind hosts, private network preflight, route surface, the busy flag, name sanitisation, and that cleanup refuses a path the bridge did not stage), plus a test pinning the exact protocol URL the site fires. The routing decision is a pure `classify()` so those rules can be tested without standing up a window.

`cargo test`, `cargo clippy`, `check-types`, `bun test`, `oxlint` and `oxfmt` are all clean, with no new lint warnings against baseline.

## AI Assistance

Used Claude to help write the loopback bridge and the frontend hooks, and to work through the CORS and DNS rebinding details. The same protocol was implemented for Grimoire.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added optional one-click DeadlockForge VPK installs in the desktop app.
- Added a secure loopback HTTP bridge on `127.0.0.1` using ports `43120–43124`.
- Added origin, host, header, signature, payload size, and concurrency checks.
- Stages valid VPK files temporarily and prompts users before import.
- Keeps imported mods disabled until the user enables them.
- Added settings and launch prompts for the feature.
- Added frontend hooks and Tauri commands for bridge lifecycle, payload placement, and install completion.
- Keeps Forge payloads in the native file pipeline instead of transferring bytes through IPC as JSON arrays.
- Rejects path traversal and restricts staged payloads to the application’s `mods` directory.
- Added Rust bridge routing, security, staging, metadata, cleanup, and path validation tests.
- Added Hyper server dependencies to the desktop Rust package.
- Added a minor release changeset for `@deadlock-mods/desktop`.

## Affected packages

- `@deadlock-mods/desktop` only.
- No API, bot, www, docs, or shared package changes.
- No database migrations, Tauri plugin changes, or Rust FFI boundary changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->