### PR TITLE
fix(desktop): stop the background plugin from permanently disabling themes

### DIFF
--- a/.changeset/brave-otters-swim.md
+++ b/.changeset/brave-otters-swim.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Turn off the Background plugin when a theme is selected

--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix themes turning off permanently when the Background plugin is enabled

--- a/apps/desktop/src/components/global-plugin-renderer.tsx
+++ b/apps/desktop/src/components/global-plugin-renderer.tsx
@@ -3,6 +3,7 @@ import { useFeatureFlags } from "@/hooks/use-feature-flags";
 import logger from "@/lib/logger";
 import { getPlugins } from "@/lib/plugins";
 import { usePersistedStore } from "@/lib/store";
+import { resolvePluginEnabled } from "@/lib/store/utils/plugin-slice";
 import type { PluginModule } from "@/plugins/types";
 import type { LoadedPlugin } from "@/types/plugins";
 
@@ -60,7 +61,7 @@ const GlobalPluginRenderer = () => {
       }
 
       // Then check local configuration
-      return enabledPlugins[pluginId] ?? false;
+      return resolvePluginEnabled(enabledPlugins, pluginId);
     };
   }, [enabledPlugins, featureFlagMap]);
 

--- a/apps/desktop/src/lib/store/migrate.test.ts
+++ b/apps/desktop/src/lib/store/migrate.test.ts
@@ -153,20 +153,15 @@ describe("safeMigrate", () => {
   });
 
   it("v25 (themes switch): drops the leftover enabledPlugins.themes entry", () => {
-    const state: Record<string, unknown> = {
-      enabledPlugins: { themes: false, background: true },
-    };
+    const state = { enabledPlugins: { themes: false, background: true } };
 
-    const result = safeMigrate(state, 24) as Record<string, unknown>;
-
-    const enabledPlugins = result.enabledPlugins as Record<string, boolean>;
-    expect("themes" in enabledPlugins).toBe(false);
-    expect(enabledPlugins.background).toBe(true);
+    expect(safeMigrate(state, 24)).toStrictEqual({
+      enabledPlugins: { background: true },
+    });
   });
 
   it("v25 (themes switch): tolerates a missing enabledPlugins map", () => {
-    const result = safeMigrate({}, 24) as Record<string, unknown>;
-    expect(result.enabledPlugins).toBeUndefined();
+    expect(safeMigrate({}, 24)).toStrictEqual({});
   });
 
   describe("specific step idempotency", () => {

--- a/apps/desktop/src/lib/store/migrate.test.ts
+++ b/apps/desktop/src/lib/store/migrate.test.ts
@@ -149,7 +149,24 @@ describe("safeMigrate", () => {
   it("LATEST_VERSION matches the highest step target", () => {
     const max = Math.max(...MIGRATION_STEPS.map((s) => s.to));
     expect(LATEST_VERSION).toBe(max);
-    expect(LATEST_VERSION).toBe(24);
+    expect(LATEST_VERSION).toBe(25);
+  });
+
+  it("v25 (themes switch): drops the leftover enabledPlugins.themes entry", () => {
+    const state: Record<string, unknown> = {
+      enabledPlugins: { themes: false, background: true },
+    };
+
+    const result = safeMigrate(state, 24) as Record<string, unknown>;
+
+    const enabledPlugins = result.enabledPlugins as Record<string, boolean>;
+    expect("themes" in enabledPlugins).toBe(false);
+    expect(enabledPlugins.background).toBe(true);
+  });
+
+  it("v25 (themes switch): tolerates a missing enabledPlugins map", () => {
+    const result = safeMigrate({}, 24) as Record<string, unknown>;
+    expect(result.enabledPlugins).toBeUndefined();
   });
 
   describe("specific step idempotency", () => {

--- a/apps/desktop/src/lib/store/migrate.ts
+++ b/apps/desktop/src/lib/store/migrate.ts
@@ -374,6 +374,15 @@ export const MIGRATION_STEPS: readonly MigrationStep[] = [
       state.steamPath ??= "";
     },
   },
+  {
+    to: 25,
+    label: "remove-themes-plugin-switch",
+    apply: (state) => {
+      // Themes is alwaysEnabled now, so nothing reads this persisted switch.
+      if (!isPlainObject(state.enabledPlugins)) return;
+      delete state.enabledPlugins.themes;
+    },
+  },
 ];
 
 const STEP_TARGET_VERSIONS: readonly number[] = MIGRATION_STEPS.map(

--- a/apps/desktop/src/lib/store/plugin-exclusion.test.ts
+++ b/apps/desktop/src/lib/store/plugin-exclusion.test.ts
@@ -127,6 +127,16 @@ describe("plugin exclusion via manifest disabledPlugins", () => {
     expect(result.pluginSettings).toEqual({ themes: themeSettings(undefined) });
   });
 
+  it("treats a non-string active theme as no selection", () => {
+    const result = applyPluginSettings(
+      { enabledPlugins: { background: true }, pluginSettings: {} },
+      "themes",
+      { activeSection: "pre-defined", activeTheme: null },
+    );
+
+    expect(result.enabledPlugins).toBeUndefined();
+  });
+
   it("settings for a plugin with its own toggle never change enablement", () => {
     const result = applyPluginSettings(
       { enabledPlugins: { background: true }, pluginSettings: {} },

--- a/apps/desktop/src/lib/store/plugin-exclusion.test.ts
+++ b/apps/desktop/src/lib/store/plugin-exclusion.test.ts
@@ -14,8 +14,12 @@ mock.module("@/lib/plugins", () => ({
   ],
 }));
 
-const { disablePlugin, enablePlugin, resolvePluginEnabled } =
-  await import("./utils/plugin-slice");
+const {
+  applyPluginSettings,
+  disablePlugin,
+  enablePlugin,
+  resolvePluginEnabled,
+} = await import("./utils/plugin-slice");
 
 const themeSettings = (activeTheme?: string) => ({
   activeSection: "pre-defined",
@@ -97,5 +101,40 @@ describe("plugin exclusion via manifest disabledPlugins", () => {
 
   it("ignores a stale disabled flag for an always-enabled plugin", () => {
     expect(resolvePluginEnabled({ themes: false }, "themes")).toBe(true);
+  });
+
+  it("selecting a theme disables the background plugin", () => {
+    const result = applyPluginSettings(
+      { enabledPlugins: { background: true }, pluginSettings: {} },
+      "themes",
+      themeSettings("bloodmoon"),
+    );
+
+    expect(result.enabledPlugins).toEqual({ background: false });
+    expect(result.pluginSettings).toEqual({
+      themes: themeSettings("bloodmoon"),
+    });
+  });
+
+  it("clearing the active theme leaves the background plugin alone", () => {
+    const result = applyPluginSettings(
+      { enabledPlugins: { background: true }, pluginSettings: {} },
+      "themes",
+      themeSettings(undefined),
+    );
+
+    expect(result.enabledPlugins).toBeUndefined();
+    expect(result.pluginSettings).toEqual({ themes: themeSettings(undefined) });
+  });
+
+  it("settings for a plugin with its own toggle never change enablement", () => {
+    const result = applyPluginSettings(
+      { enabledPlugins: { background: true }, pluginSettings: {} },
+      "background",
+      { opacity: 50 },
+    );
+
+    expect(result.enabledPlugins).toBeUndefined();
+    expect(result.pluginSettings).toEqual({ background: { opacity: 50 } });
   });
 });

--- a/apps/desktop/src/lib/store/plugin-exclusion.test.ts
+++ b/apps/desktop/src/lib/store/plugin-exclusion.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("@/lib/plugins", () => ({
+  getPlugins: () => [
+    {
+      manifest: {
+        id: "themes",
+        disabledPlugins: ["background"],
+        alwaysEnabled: true,
+      },
+    },
+    { manifest: { id: "background", disabledPlugins: [] } },
+    { manifest: { id: "flashbang", disabledPlugins: [] } },
+  ],
+}));
+
+const { disablePlugin, enablePlugin, resolvePluginEnabled } =
+  await import("./utils/plugin-slice");
+
+const themeSettings = (activeTheme?: string) => ({
+  activeSection: "pre-defined",
+  activeTheme,
+});
+
+describe("plugin exclusion via manifest disabledPlugins", () => {
+  it("enabling background does not disable the themes plugin", () => {
+    const result = enablePlugin(
+      {
+        enabledPlugins: { background: false },
+        pluginSettings: { themes: themeSettings("bloodmoon") },
+      },
+      "background",
+    );
+
+    expect(result.enabledPlugins).toEqual({ background: true });
+  });
+
+  it("enabling background clears the active theme instead", () => {
+    const result = enablePlugin(
+      {
+        enabledPlugins: { background: false },
+        pluginSettings: { themes: themeSettings("bloodmoon") },
+      },
+      "background",
+    );
+
+    expect(result.pluginSettings).toEqual({ themes: themeSettings(undefined) });
+  });
+
+  it("leaves theme settings untouched when nothing excludes themes", () => {
+    const result = enablePlugin(
+      {
+        enabledPlugins: { flashbang: false },
+        pluginSettings: { themes: themeSettings("bloodmoon") },
+      },
+      "flashbang",
+    );
+
+    expect(result.enabledPlugins).toEqual({ flashbang: true });
+    expect(result.pluginSettings).toEqual({
+      themes: themeSettings("bloodmoon"),
+    });
+  });
+
+  it("enabling an always-enabled plugin writes no persisted flag", () => {
+    const result = enablePlugin(
+      { enabledPlugins: {}, pluginSettings: {} },
+      "themes",
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("an always-enabled plugin cannot be disabled", () => {
+    const result = disablePlugin(
+      { enabledPlugins: {}, pluginSettings: {} },
+      "themes",
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("disables a plugin that has its own toggle", () => {
+    const result = disablePlugin(
+      { enabledPlugins: { background: true }, pluginSettings: {} },
+      "background",
+    );
+
+    expect(result.enabledPlugins).toEqual({ background: false });
+  });
+
+  it("resolves an always-enabled plugin as enabled without a persisted flag", () => {
+    expect(resolvePluginEnabled({}, "themes")).toBe(true);
+    expect(resolvePluginEnabled({}, "background")).toBe(false);
+    expect(resolvePluginEnabled({ background: true }, "background")).toBe(true);
+  });
+
+  it("ignores a stale disabled flag for an always-enabled plugin", () => {
+    expect(resolvePluginEnabled({ themes: false }, "themes")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/store/slices/settings.ts
+++ b/apps/desktop/src/lib/store/slices/settings.ts
@@ -6,10 +6,14 @@ import type {
 import { DEFAULT_NSFW_SETTINGS } from "@deadlock-mods/shared";
 import { v4 as uuidv4 } from "uuid";
 import type { StateCreator } from "zustand";
-import { getPlugins } from "@/lib/plugins";
 import type { CreateSettingSchema } from "@/lib/validation/create-setting";
 import type { LocalSetting, SystemSetting } from "@/types/settings";
 import type { State } from "..";
+import {
+  disablePlugin,
+  enablePlugin,
+  resolvePluginEnabled,
+} from "../utils/plugin-slice";
 
 export type TelemetrySettings = {
   analyticsEnabled: boolean;
@@ -135,7 +139,7 @@ export const createSettingsSlice: StateCreator<State, [], [], SettingsState> = (
   autoUpdateEnabled: true,
   crosshairsEnabled: true,
   linuxGpuOptimization: "auto",
-  enabledPlugins: { themes: true },
+  enabledPlugins: {},
   gamePresenceEnabled: true,
   gamePresenceTextTemplates: createDefaultGamePresenceTextTemplates(),
   gamePresenceHeroOverrides: {},
@@ -321,42 +325,13 @@ export const createSettingsSlice: StateCreator<State, [], [], SettingsState> = (
 
   // Plugin management
   togglePlugin: (pluginId: string) =>
-    set((state) => {
-      const current = state.enabledPlugins[pluginId] ?? false;
-      const willEnable = !current;
-
-      if (!willEnable) {
-        return {
-          enabledPlugins: { ...state.enabledPlugins, [pluginId]: false },
-        };
-      }
-
-      const all = getPlugins().map((p) => p.manifest);
-      const manifest = all.find((m) => m.id === pluginId);
-      const forwardDisable = Array.isArray(manifest?.disabledPlugins)
-        ? manifest!.disabledPlugins!
-        : [];
-      const reverseDisable = all
-        .filter(
-          (m) =>
-            Array.isArray(m.disabledPlugins) &&
-            m.disabledPlugins!.includes(pluginId),
-        )
-        .map((m) => m.id);
-
-      const next = { ...state.enabledPlugins, [pluginId]: true } as Record<
-        string,
-        boolean
-      >;
-      for (const id of forwardDisable) next[id] = false;
-      for (const id of reverseDisable) next[id] = false;
-
-      return {
-        enabledPlugins: next,
-      };
-    }),
+    set((state) =>
+      resolvePluginEnabled(state.enabledPlugins, pluginId)
+        ? disablePlugin(state, pluginId)
+        : enablePlugin(state, pluginId),
+    ),
 
   isPluginEnabled: (pluginId: string) => {
-    return get().enabledPlugins[pluginId] ?? false;
+    return resolvePluginEnabled(get().enabledPlugins, pluginId);
   },
 });

--- a/apps/desktop/src/lib/store/slices/ui.ts
+++ b/apps/desktop/src/lib/store/slices/ui.ts
@@ -1,7 +1,11 @@
 import type { StateCreator } from "zustand";
 import { SortType, TimePeriod } from "@/lib/constants";
 import type { State } from "..";
-import { disablePlugin, enablePlugin } from "../utils/plugin-slice";
+import {
+  applyPluginSettings,
+  disablePlugin,
+  enablePlugin,
+} from "../utils/plugin-slice";
 
 export type FilterMode = "include" | "exclude";
 
@@ -160,7 +164,5 @@ export const createUISlice: StateCreator<State, [], [], UIState> = (set) => ({
     ),
 
   setPluginSettings: (id: string, value: unknown) =>
-    set((state) => ({
-      pluginSettings: { ...state.pluginSettings, [id]: value },
-    })),
+    set((state) => applyPluginSettings(state, id, value)),
 });

--- a/apps/desktop/src/lib/store/slices/ui.ts
+++ b/apps/desktop/src/lib/store/slices/ui.ts
@@ -1,7 +1,7 @@
 import type { StateCreator } from "zustand";
 import { SortType, TimePeriod } from "@/lib/constants";
-import { getPlugins } from "@/lib/plugins";
 import type { State } from "..";
+import { disablePlugin, enablePlugin } from "../utils/plugin-slice";
 
 export type FilterMode = "include" | "exclude";
 
@@ -95,7 +95,7 @@ export const createUISlice: StateCreator<State, [], [], UIState> = (set) => ({
   hasCompletedOnboarding: false,
   showOccultGeometry: true,
   animateOccultGeometry: true,
-  enabledPlugins: { themes: true },
+  enabledPlugins: {},
   pluginSettings: {},
 
   forceShowWhatsNew: () =>
@@ -155,29 +155,9 @@ export const createUISlice: StateCreator<State, [], [], UIState> = (set) => ({
     })),
 
   setEnabledPlugin: (id: string, enabled: boolean) =>
-    set((state) => {
-      if (!enabled) {
-        return { enabledPlugins: { ...state.enabledPlugins, [id]: false } };
-      }
-      const all = getPlugins().map((p) => p.manifest);
-      const manifest = all.find((m) => m.id === id);
-      const forwardDisable = Array.isArray(manifest?.disabledPlugins)
-        ? manifest!.disabledPlugins!
-        : [];
-      const reverseDisable = all
-        .filter(
-          (m) =>
-            Array.isArray(m.disabledPlugins) && m.disabledPlugins!.includes(id),
-        )
-        .map((m) => m.id);
-      const next = { ...state.enabledPlugins, [id]: true } as Record<
-        string,
-        boolean
-      >;
-      for (const target of forwardDisable) next[target] = false;
-      for (const target of reverseDisable) next[target] = false;
-      return { enabledPlugins: next };
-    }),
+    set((state) =>
+      enabled ? enablePlugin(state, id) : disablePlugin(state, id),
+    ),
 
   setPluginSettings: (id: string, value: unknown) =>
     set((state) => ({

--- a/apps/desktop/src/lib/store/utils/plugin-slice.ts
+++ b/apps/desktop/src/lib/store/utils/plugin-slice.ts
@@ -30,14 +30,17 @@ const getExcludedPluginIds = (
   ]);
 
 const hasActiveTheme = (value: unknown): value is ThemePluginSettings =>
-  typeof value === "object" && value !== null && "activeTheme" in value;
+  typeof value === "object" &&
+  value !== null &&
+  "activeTheme" in value &&
+  typeof value.activeTheme === "string";
 
 const clearActiveTheme = (
   pluginSettings: State["pluginSettings"],
   pluginId: string,
 ): State["pluginSettings"] => {
   const settings = pluginSettings[pluginId];
-  if (!hasActiveTheme(settings) || settings.activeTheme === undefined) {
+  if (!hasActiveTheme(settings)) {
     return pluginSettings;
   }
 
@@ -94,7 +97,7 @@ export const applyPluginSettings = (
   value: unknown,
 ): Partial<PluginSliceState> => {
   const pluginSettings = { ...state.pluginSettings, [pluginId]: value };
-  if (!hasActiveTheme(value) || value.activeTheme === undefined) {
+  if (!hasActiveTheme(value)) {
     return { pluginSettings };
   }
 

--- a/apps/desktop/src/lib/store/utils/plugin-slice.ts
+++ b/apps/desktop/src/lib/store/utils/plugin-slice.ts
@@ -87,3 +87,27 @@ export const disablePlugin = (
   isAlwaysEnabled(getManifests(), pluginId)
     ? {}
     : { enabledPlugins: { ...state.enabledPlugins, [pluginId]: false } };
+
+export const applyPluginSettings = (
+  state: PluginSliceState,
+  pluginId: string,
+  value: unknown,
+): Partial<PluginSliceState> => {
+  const pluginSettings = { ...state.pluginSettings, [pluginId]: value };
+  if (!hasActiveTheme(value) || value.activeTheme === undefined) {
+    return { pluginSettings };
+  }
+
+  // Always-enabled plugins have no switch; their selection activates them.
+  const manifests = getManifests();
+  if (!isAlwaysEnabled(manifests, pluginId)) {
+    return { pluginSettings };
+  }
+
+  const enabledPlugins = { ...state.enabledPlugins };
+  for (const excludedId of getExcludedPluginIds(manifests, pluginId)) {
+    enabledPlugins[excludedId] = false;
+  }
+
+  return { enabledPlugins, pluginSettings };
+};

--- a/apps/desktop/src/lib/store/utils/plugin-slice.ts
+++ b/apps/desktop/src/lib/store/utils/plugin-slice.ts
@@ -1,0 +1,89 @@
+import { getPlugins } from "@/lib/plugins";
+import type { PluginManifest } from "@/types/plugins";
+import type { State } from "..";
+
+export type PluginSliceState = Pick<State, "enabledPlugins" | "pluginSettings">;
+
+type ThemePluginSettings = { activeTheme?: string };
+
+const getManifests = (): PluginManifest[] =>
+  getPlugins().map((plugin) => plugin.manifest);
+
+const isAlwaysEnabled = (
+  manifests: PluginManifest[],
+  pluginId: string,
+): boolean =>
+  manifests.some(
+    (manifest) => manifest.id === pluginId && manifest.alwaysEnabled === true,
+  );
+
+const getExcludedPluginIds = (
+  manifests: PluginManifest[],
+  pluginId: string,
+): Set<string> =>
+  new Set([
+    ...(manifests.find((manifest) => manifest.id === pluginId)
+      ?.disabledPlugins ?? []),
+    ...manifests
+      .filter((manifest) => manifest.disabledPlugins?.includes(pluginId))
+      .map((manifest) => manifest.id),
+  ]);
+
+const hasActiveTheme = (value: unknown): value is ThemePluginSettings =>
+  typeof value === "object" && value !== null && "activeTheme" in value;
+
+const clearActiveTheme = (
+  pluginSettings: State["pluginSettings"],
+  pluginId: string,
+): State["pluginSettings"] => {
+  const settings = pluginSettings[pluginId];
+  if (!hasActiveTheme(settings) || settings.activeTheme === undefined) {
+    return pluginSettings;
+  }
+
+  return {
+    ...pluginSettings,
+    [pluginId]: { ...settings, activeTheme: undefined },
+  };
+};
+
+/** Always-enabled plugins have no persisted switch, so a missing flag is not "disabled". */
+export const resolvePluginEnabled = (
+  enabledPlugins: State["enabledPlugins"],
+  pluginId: string,
+): boolean =>
+  isAlwaysEnabled(getManifests(), pluginId) ||
+  (enabledPlugins[pluginId] ?? false);
+
+export const enablePlugin = (
+  state: PluginSliceState,
+  pluginId: string,
+): Partial<PluginSliceState> => {
+  const manifests = getManifests();
+  if (isAlwaysEnabled(manifests, pluginId)) {
+    return {};
+  }
+
+  const enabledPlugins = { ...state.enabledPlugins, [pluginId]: true };
+  let pluginSettings = state.pluginSettings;
+
+  for (const excludedId of getExcludedPluginIds(manifests, pluginId)) {
+    // Always-enabled plugins have no toggle to switch them back on, so clear
+    // their selection rather than disabling them.
+    if (isAlwaysEnabled(manifests, excludedId)) {
+      pluginSettings = clearActiveTheme(pluginSettings, excludedId);
+    } else {
+      enabledPlugins[excludedId] = false;
+    }
+  }
+
+  return { enabledPlugins, pluginSettings };
+};
+
+export const disablePlugin = (
+  state: PluginSliceState,
+  pluginId: string,
+): Partial<PluginSliceState> =>
+  isAlwaysEnabled(getManifests(), pluginId)
+    ? {}
+    : { enabledPlugins: { ...state.enabledPlugins, [pluginId]: false } };

--- a/apps/desktop/src/pages/plugin.tsx
+++ b/apps/desktop/src/pages/plugin.tsx
@@ -22,8 +22,9 @@ const PluginEntry = () => {
     () => getPlugins().find((p) => p.manifest.id === id),
     [id],
   );
+  const alwaysEnabled = plugin?.manifest.alwaysEnabled === true;
   const isEnabled = usePersistedStore(
-    (s) => s.enabledPlugins[id ?? ""] ?? false,
+    (s) => alwaysEnabled || (s.enabledPlugins[id ?? ""] ?? false),
   );
   const setEnabled = usePersistedStore((s) => s.setEnabledPlugin);
 
@@ -111,7 +112,7 @@ const PluginEntry = () => {
                     if (!id) return;
                     setEnabled(id, checked);
                   }}
-                  disabled={!id}
+                  disabled={!id || alwaysEnabled}
                   className='data-[state=checked]:bg-primary'
                 />
               </div>

--- a/apps/desktop/src/plugins/themes/manifest.json
+++ b/apps/desktop/src/plugins/themes/manifest.json
@@ -9,5 +9,6 @@
   "icon": "public/icon.svg",
   "tags": ["official"],
   "entry": "./index.tsx",
-  "disabledPlugins": ["background"]
+  "disabledPlugins": ["background"],
+  "alwaysEnabled": true
 }

--- a/apps/desktop/src/types/plugins.ts
+++ b/apps/desktop/src/types/plugins.ts
@@ -12,6 +12,7 @@ export type PluginManifest = {
   tags?: PluginTag[];
   entry?: string; // module entry relative path (e.g., ./src/index.tsx)
   disabledPlugins?: string[]; // plugin IDs to disable when this plugin is enabled
+  alwaysEnabled?: boolean; // has no toggle in the plugins list and cannot be disabled
 };
 
 export type LoadedPlugin = {

--- a/apps/docs/content/docs/developer-docs/plugins/themes.mdx
+++ b/apps/docs/content/docs/developer-docs/plugins/themes.mdx
@@ -23,7 +23,8 @@ Technical reference for the Themes plugin which provides pre-defined themes, cus
   "icon": "public/icon.svg",
   "tags": ["official"],
   "entry": "./index.tsx",
-  "disabledPlugins": ["background"]
+  "disabledPlugins": ["background"],
+  "alwaysEnabled": true
 }
 ```
 
@@ -264,13 +265,16 @@ setSettings(manifest.id, {
 
 ## Plugin Conflicts
 
-The Themes plugin automatically disables the Background plugin to prevent conflicts:
+Themes and Background both paint a fullscreen layer, so only one of them can be active at a time:
 
 ```json
 {
-  "disabledPlugins": ["background"]
+  "disabledPlugins": ["background"],
+  "alwaysEnabled": true
 }
 ```
+
+Themes is `alwaysEnabled`: it has no switch in the plugins list, so the exclusion is driven by the theme selection instead. Selecting a theme disables the Background plugin, and enabling Background clears the active theme.
 
 ## Image Handling
 


### PR DESCRIPTION
## Description

Enabling the Background plugin turned Themes off permanently. Themes is hidden from the plugins list, so there was no toggle to turn it back on, the only way out was editing or resetting the save file.

**Cause:** `a9284a36` removed the stale `enabledPlugins.themes` gating from four places but missed `GlobalPluginRenderer`, which is the only place a plugin's `Render` is actually mounted. Enabling Background still set `enabledPlugins.themes = false`, so the theme silently stopped rendering.

**Fix:** Themes is now `alwaysEnabled` in its manifest and can no longer be switched off. Enabling Background clears the selected theme instead, so you can always recover by picking a theme again.

**Also fixed:** the exclusion only worked one way. With Background already on, selecting a theme left both active, each painting a fullscreen layer. This was already reachable on `main` (v21 force-enables Themes without disabling
Background), but it's close enough to the same bug that the last commit closes it too.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #598 

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code, Used for: tracing the root cause through git history, creating regression tests. The bug was reproduced myself, verified every behavior in the running app and each change was reviewed before committing.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Checked in the running app:

- a theme renders with no `enabledPlugins.themes` entry at all
- enabling Background clears the theme, and it can be re-selected afterwards (impossible before, this was the core bug)
- selecting a theme while Background is on now switches Background off
- Background keeps its own settings, so re-enabling restores the previous image
- the v25 migration ran on a real save (v24 -> v25) with no data loss

`pnpm test` (14/14),
`pnpm check-types` (11/11),
`oxlint`, `oxfmt` and the production `ui:build` are all clean.

## Screenshots (if applicable)

A video of the bug is in #598.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

- **v25 migration** drops the leftover `enabledPlugins.themes` entry, as asked in the issue. Nothing reads it once Themes is `alwaysEnabled`, so it's cleanup rather than a fix. One caveat: since both `nightly` and `release` ship, a nightly -> stable downgrade afterwards leaves the key missing, and older builds read that as `false`, turning Themes off again. Happy to drop that commit if you'd rather leave the key alone.
- `enabledPlugins: { themes: true }` was removed from both slice defaults, since a plugin that can't be toggled shouldn't seed a switch.
- Only tested on Windows.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed permanent Themes disablement when Background is enabled.
- Marked Themes as `alwaysEnabled` and centralized plugin enablement logic.
- Enabling Background now clears the active theme.
- Selecting a theme now disables Background.
- Added migration v25 to remove obsolete `enabledPlugins.themes` state.
- Removed Themes from default plugin state.
- Added regression and migration tests.
- Updated Themes plugin documentation and release changesets.

## Affected areas

- **Desktop:** Plugin state, rendering, settings, migration, UI, and tests.
- **Docs:** Themes plugin documentation.
- **API, bot, www, and shared packages:** No changes.
- **Dependencies, Tauri plugins, database schema, and Rust FFI:** No changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->