### PR TITLE
fix(desktop): prevent Flatpak window creation crashes

### DIFF
--- a/.changeset/calm-lions-launch.md
+++ b/.changeset/calm-lions-launch.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix Flatpak startup crashes on Wayland compositors

--- a/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.cef.yml
+++ b/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.cef.yml
@@ -14,7 +14,7 @@ finish-args:
   - --share=network
   - --share=ipc
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --device=dri
   - --filesystem=~/.steam
   - --filesystem=~/.local/share/Steam

--- a/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.yml
+++ b/apps/desktop/flatpak/dev.stormix.deadlock-mod-manager.yml
@@ -11,7 +11,7 @@ finish-args:
   - --share=network
   - --share=ipc
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --device=dri
   - --filesystem=~/.steam
   - --filesystem=~/.local/share/Steam


### PR DESCRIPTION
## Description

Fix Flatpak startup crashes on affected Wayland compositors by replacing
the conditional `fallback-x11` permission with plain `x11` access in both
Flatpak manifests.

Wayland remains enabled. X11 is now available when GTK detects a Wayland
session but fails to create a native Wayland window.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Tests (adding or updating tests)
- [ ] Chore (maintenance, dependency updates, etc.)

## Related Issues

- Fixes #596
- Fixes #597
- Fixes #603

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Codex, Used for: investigating the issue reports, implementing the manifest change, and running validation

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the Contributing Guidelines and AI Policy
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms
- [x] I have generated a changeset for my changes

## Additional Notes

Both manifests pass YAML parsing and `flatpak-builder --show-manifest`.
The repository linter and formatter also pass. Runtime confirmation on an
affected KDE Wayland or Niri environment is still required.

This change grants X11 access while Wayland is available. It does not force
the application to use X11, but it broadens the Flatpak display permission
to provide a reliable fallback.

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated both desktop Flatpak manifests to replace `fallback-x11` with `x11`.
- Retained Wayland access.
- Allows GTK to use Xwayland/X11 when native Wayland window creation fails.
- Added a changeset for `@deadlock-mods/desktop`.

## Scope

- Affects the desktop application only.
- No API, bot, www, docs, shared package, database, Tauri plugin, or Rust FFI changes.
- YAML and `flatpak-builder --show-manifest` validation passes.
- Runtime validation on affected KDE Wayland and Niri environments remains required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->