### PR TITLE
feat(desktop): Some small foundry and hero skin improvments

### DIFF
--- a/apps/desktop/src/components/foundry/foundry-context.tsx
+++ b/apps/desktop/src/components/foundry/foundry-context.tsx
@@ -17,6 +17,7 @@ import {
   decodeFoundryTexture,
   exportFoundryWorkspace,
   foundryPaintTargets,
+  getPrimaryModelPath,
   paintFoundryTarget,
   prepareFoundryWorkspace,
   releaseFoundryArchives,
@@ -137,22 +138,6 @@ const isTextureEntry = (path: string | null): path is string =>
 
 const isModelEntry = (path: string | null): path is string =>
   path?.endsWith(".vmesh_c") || path?.endsWith(".vmdl_c") || false;
-
-/**
- * The entry to show first.
- *
- * The backend resolves the hero's actual body model through the game's
- * `heroes.vdata_c`, so `primaryModelPath` is an answer rather than a guess and
- * is used whenever it is there. The local fallback only covers a manifest from
- * an older backend or a skin with no hero: a `.vmdl_c` assembles the whole
- * character, so it beats a lone `.vmesh_c`, which is one body part.
- */
-const getInitialModelPath = (manifest: FoundryManifest): string | null => {
-  if (manifest.primaryModelPath) return manifest.primaryModelPath;
-  const model = manifest.models.find((entry) => entry.path.endsWith(".vmdl_c"));
-  const mesh = manifest.models.find((entry) => entry.path.endsWith(".vmesh_c"));
-  return model?.path ?? mesh?.path ?? manifest.models[0]?.path ?? null;
-};
 
 /** Every entry path a default-hero workspace has to unpack from the base pak. */
 const manifestEntryPaths = (manifest: FoundryManifest): string[] =>
@@ -455,7 +440,7 @@ export const FoundryProvider = ({ children }: { children: ReactNode }) => {
           return null;
         }
         setManifest(result);
-        const initialModel = getInitialModelPath(result);
+        const initialModel = getPrimaryModelPath(result);
         setPrimaryModelPath(initialModel);
         selectEntryPath(initialModel);
         setActiveTab("assets");

--- a/apps/desktop/src/components/foundry/foundry-empty-state.tsx
+++ b/apps/desktop/src/components/foundry/foundry-empty-state.tsx
@@ -5,10 +5,13 @@ import {
   HammerIcon,
   UploadSimpleIcon,
 } from "@phosphor-icons/react";
+import { toast } from "@deadlock-mods/ui/components/sonner";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useConfirm } from "@/components/providers/alert-dialog";
 import logger from "@/lib/logger";
+import { usePersistedStore } from "@/lib/store";
 import { useFoundry } from "./foundry-context";
 import { FoundryImportDialog } from "./foundry-import-dialog";
 import { FoundryLoadingBar } from "./foundry-loading-bar";
@@ -81,8 +84,46 @@ const EntryCard = ({
 export const FoundryEmptyState = () => {
   const { t } = useTranslation();
   const { status } = useFoundry();
+  const confirm = useConfirm();
+  const forgeInstallEnabled = usePersistedStore(
+    (state) => state.forgeInstallEnabled,
+  );
+  const setForgeInstallEnabled = usePersistedStore(
+    (state) => state.setForgeInstallEnabled,
+  );
   const [importOpen, setImportOpen] = useState(false);
   const analyzing = status === "analyzing";
+
+  const openForge = () => {
+    openUrl(DEADLOCK_FORGE_URL).catch((error) => {
+      logger.withError(error).error("[Foundry] Could not open Deadlock Forge");
+    });
+  };
+
+  // The 1-click handoff only works if the bridge is on, and the site gives no
+  // hint that it is off. Offer the switch here, then leave for the site either
+  // way.
+  const handleForgeClick = async () => {
+    if (forgeInstallEnabled) {
+      openForge();
+      return;
+    }
+
+    const accepted = !!(await confirm({
+      title: t("forge.openTitle"),
+      body: t("forge.openBody"),
+      actionButton: t("forge.openAction"),
+      actionButtonVariant: "default",
+      cancelButton: t("forge.openCancel"),
+    }));
+
+    if (accepted) {
+      setForgeInstallEnabled(true);
+      toast.success(t("forge.openEnabled"));
+    }
+
+    openForge();
+  };
 
   return (
     <div className='flex h-full w-full flex-col items-center justify-center gap-8 p-8'>
@@ -115,13 +156,7 @@ export const FoundryEmptyState = () => {
           description={t("foundry.empty.forgeDescription")}
           external
           icon={<FireIcon className='h-8 w-8' weight='duotone' />}
-          onClick={() => {
-            openUrl(DEADLOCK_FORGE_URL).catch((error) => {
-              logger
-                .withError(error)
-                .error("[Foundry] Could not open Deadlock Forge");
-            });
-          }}
+          onClick={handleForgeClick}
           title={t("foundry.empty.forgeTitle")}
         />
       </div>

--- a/apps/desktop/src/components/settings/model-preview-toggle.tsx
+++ b/apps/desktop/src/components/settings/model-preview-toggle.tsx
@@ -1,0 +1,48 @@
+import { Label } from "@deadlock-mods/ui/components/label";
+import { Switch } from "@deadlock-mods/ui/components/switch";
+import { WarningIcon } from "@phosphor-icons/react";
+import { useTranslation } from "react-i18next";
+import { usePersistedStore } from "@/lib/store";
+
+/** One switch for both 3D previews: the Hero Skins panel and the Mod Foundry. */
+export const ModelPreviewToggle = () => {
+  const { t } = useTranslation();
+  const enabled = usePersistedStore((state) => state.foundry3dPreviewEnabled);
+  const setEnabled = usePersistedStore(
+    (state) => state.setFoundry3dPreviewEnabled,
+  );
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex items-center justify-between'>
+        <div className='space-y-1'>
+          <Label className='font-bold text-sm'>
+            {t("settings.modelPreview")}
+          </Label>
+          <p className='text-muted-foreground text-sm'>
+            {t("settings.modelPreviewDescription")}
+          </p>
+        </div>
+        <div className='flex items-center gap-2'>
+          <Switch
+            checked={enabled}
+            id='toggle-setting-model-preview'
+            onCheckedChange={setEnabled}
+          />
+          <Label htmlFor='toggle-setting-model-preview'>
+            {enabled ? t("status.enabled") : t("status.disabled")}
+          </Label>
+        </div>
+      </div>
+
+      {enabled && (
+        <div className='flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5'>
+          <WarningIcon className='mt-0.5 h-4 w-4 shrink-0 text-amber-500' />
+          <p className='text-xs leading-relaxed'>
+            {t("settings.modelPreviewWarning")}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/skins/skin-card.tsx
+++ b/apps/desktop/src/components/skins/skin-card.tsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
 } from "@deadlock-mods/ui/components/tooltip";
 import { Check, Trash2 } from "@deadlock-mods/ui/icons";
+import { CubeIcon } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { NSFWBlur } from "@/components/mod-browsing/nsfw-blur";
 import { SkinVariantControls } from "@/components/skins/skin-variant-controls";
@@ -13,11 +14,44 @@ import { useNSFWBlur } from "@/hooks/use-nsfw-blur";
 import { cn } from "@/lib/utils";
 import type { LocalMod } from "@/types/mods";
 
+const PreviewButton = ({
+  label,
+  disabled,
+  onPreview,
+}: {
+  label: string;
+  disabled: boolean;
+  onPreview: () => void;
+}) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button
+        aria-label={label}
+        className='h-7 w-7'
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          onPreview();
+        }}
+        onKeyDown={(e) => e.stopPropagation()}
+        size='icon'
+        variant='secondary'>
+        <CubeIcon className='h-3.5 w-3.5' weight='duotone' />
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent>{label}</TooltipContent>
+  </Tooltip>
+);
+
 interface SkinCardProps {
   mod: LocalMod;
   isActive: boolean;
   disabled: boolean;
+  /** True while this skin is the one the 3D panel is showing. */
+  isPreviewing: boolean;
   onSelect: () => void;
+  /** Show this skin in the 3D panel without making it the active one. */
+  onPreview: () => void;
   onDelete: () => void;
 }
 
@@ -25,7 +59,9 @@ export const SkinCard = ({
   mod,
   isActive,
   disabled,
+  isPreviewing,
   onSelect,
+  onPreview,
   onDelete,
 }: SkinCardProps) => {
   const { t } = useTranslation();
@@ -45,6 +81,7 @@ export const SkinCard = ({
         "group/skin relative cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         isActive && "ring-2 ring-primary",
+        !isActive && isPreviewing && "ring-1 ring-primary/50",
         disabled && "pointer-events-none opacity-60",
       )}
       onClick={handleSelect}
@@ -61,24 +98,31 @@ export const SkinCard = ({
       }}
       role='button'
       tabIndex={disabled ? -1 : 0}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            aria-label={t("skins.deleteSkin")}
-            className='absolute top-2 right-2 z-10 h-7 w-7 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/skin:opacity-100 group-focus-within/skin:opacity-100'
-            disabled={disabled}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            onKeyDown={(e) => e.stopPropagation()}
-            size='icon'
-            variant='destructive'>
-            <Trash2 className='h-3.5 w-3.5' />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>{t("skins.deleteSkin")}</TooltipContent>
-      </Tooltip>
+      <div className='absolute top-2 right-2 z-10 flex gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/skin:opacity-100 group-focus-within/skin:opacity-100'>
+        <PreviewButton
+          disabled={disabled}
+          label={t("skins.preview.previewSkin")}
+          onPreview={onPreview}
+        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={t("skins.deleteSkin")}
+              className='h-7 w-7'
+              disabled={disabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              onKeyDown={(e) => e.stopPropagation()}
+              size='icon'
+              variant='destructive'>
+              <Trash2 className='h-3.5 w-3.5' />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t("skins.deleteSkin")}</TooltipContent>
+        </Tooltip>
+      </div>
       {mod.images.length > 0 ? (
         <NSFWBlur
           blurStrength={nsfwSettings.blurStrength}
@@ -116,13 +160,17 @@ export const SkinCard = ({
 interface DefaultSkinCardProps {
   isActive: boolean;
   disabled: boolean;
+  isPreviewing: boolean;
   onSelect: () => void;
+  onPreview: () => void;
 }
 
 export const DefaultSkinCard = ({
   isActive,
   disabled,
+  isPreviewing,
   onSelect,
+  onPreview,
 }: DefaultSkinCardProps) => {
   const { t } = useTranslation();
 
@@ -137,9 +185,10 @@ export const DefaultSkinCard = ({
       aria-disabled={disabled}
       aria-pressed={isActive}
       className={cn(
-        "cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
+        "group/skin relative cursor-pointer overflow-hidden shadow-none transition-colors hover:border-primary",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         isActive && "ring-2 ring-primary",
+        !isActive && isPreviewing && "ring-1 ring-primary/50",
         disabled && "pointer-events-none opacity-60",
       )}
       onClick={handleSelect}
@@ -151,6 +200,13 @@ export const DefaultSkinCard = ({
       }}
       role='button'
       tabIndex={disabled ? -1 : 0}>
+      <div className='absolute top-2 right-2 z-10 opacity-0 transition-opacity focus-within:opacity-100 group-hover/skin:opacity-100 group-focus-within/skin:opacity-100'>
+        <PreviewButton
+          disabled={disabled}
+          label={t("skins.preview.previewDefault")}
+          onPreview={onPreview}
+        />
+      </div>
       <div className='flex h-32 w-full items-center justify-center bg-muted text-muted-foreground'>
         {t("skins.default")}
       </div>

--- a/apps/desktop/src/components/skins/skin-grid.tsx
+++ b/apps/desktop/src/components/skins/skin-grid.tsx
@@ -17,7 +17,10 @@ interface SkinGridProps {
   skins: LocalMod[];
   activeIds: Set<string>;
   disabled: boolean;
+  /** Which skin the 3D panel is showing: a mod id, or null for the default. */
+  previewedId: string | null;
   onSelect: (mod: LocalMod | null) => void;
+  onPreview: (mod: LocalMod | null) => void;
   onAddSkin: () => void;
   onDelete: (mod: LocalMod) => void;
 }
@@ -27,7 +30,9 @@ export const SkinGrid = ({
   skins,
   activeIds,
   disabled,
+  previewedId,
   onSelect,
+  onPreview,
   onAddSkin,
   onDelete,
 }: SkinGridProps) => {
@@ -72,15 +77,19 @@ export const SkinGrid = ({
           <DefaultSkinCard
             disabled={disabled}
             isActive={activeIds.size === 0}
+            isPreviewing={previewedId === null}
+            onPreview={() => onPreview(null)}
             onSelect={() => onSelect(null)}
           />
           {skins.map((mod) => (
             <SkinCard
               disabled={disabled}
               isActive={activeIds.has(mod.remoteId)}
+              isPreviewing={previewedId === mod.remoteId}
               key={mod.remoteId}
               mod={mod}
               onDelete={() => onDelete(mod)}
+              onPreview={() => onPreview(mod)}
               onSelect={() => onSelect(mod)}
             />
           ))}

--- a/apps/desktop/src/components/skins/skin-preview-panel.tsx
+++ b/apps/desktop/src/components/skins/skin-preview-panel.tsx
@@ -1,0 +1,188 @@
+import { Button } from "@deadlock-mods/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@deadlock-mods/ui/components/empty";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deadlock-mods/ui/components/tooltip";
+import {
+  ArrowClockwiseIcon,
+  CubeIcon,
+  EyeSlashIcon,
+  WarningIcon,
+} from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { FoundrySkinAssembling } from "@/components/foundry/foundry-assembling";
+import { FoundryLoadingBar } from "@/components/foundry/foundry-loading-bar";
+import { FoundryModelViewer } from "@/components/foundry/foundry-model-viewer";
+import { useSkinModelPreview } from "@/hooks/use-skin-model-preview";
+import { usePersistedStore } from "@/lib/store";
+import type { LocalMod } from "@/types/mods";
+
+interface SkinPreviewPanelProps {
+  hero: string;
+  /** The skin to show, or null for the hero's default look. */
+  mod: LocalMod | null;
+}
+
+/**
+ * The 3D turntable beside the skin grid: the selected skin's hero model,
+ * decoded from its VPK and rendered with the Foundry's viewer.
+ *
+ * This is a look, not an editor — nothing here writes to the skin. The whole
+ * panel is behind the same setting as the Foundry's preview, because it is the
+ * same decode-and-render on the same GPU, and it fails in the same ways.
+ */
+export const SkinPreviewPanel = ({ hero, mod }: SkinPreviewPanelProps) => {
+  const { t } = useTranslation();
+  const enabled = usePersistedStore((state) => state.foundry3dPreviewEnabled);
+  const setEnabled = usePersistedStore(
+    (state) => state.setFoundry3dPreviewEnabled,
+  );
+  const preview = useSkinModelPreview(hero, mod, enabled);
+  const label = mod?.name ?? t("skins.preview.defaultLabel", { hero });
+
+  return (
+    // The panel scales with the window rather than holding one fixed width, so
+    // it keeps its share of the page from a small window up to a maximised one.
+    <aside className='flex w-[clamp(320px,28vw,640px)] shrink-0 flex-col gap-3'>
+      {enabled && (
+        <div className='flex items-start justify-between gap-2'>
+          <div className='min-w-0'>
+            <h3 className='truncate font-semibold text-sm'>
+              {t("skins.preview.title")}
+            </h3>
+            <p className='truncate text-muted-foreground text-xs' title={label}>
+              {label}
+            </p>
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label={t("skins.preview.hide")}
+                className='h-7 w-7 shrink-0'
+                onClick={() => setEnabled(false)}
+                size='icon'
+                variant='ghost'>
+                <EyeSlashIcon className='h-4 w-4' />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t("skins.preview.hide")}</TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
+      <div className='relative flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-lg border bg-gradient-to-b from-muted/40 to-background'>
+        {enabled ? (
+          <PreviewSurface label={label} preview={preview} />
+        ) : (
+          <PanelNotice
+            action={
+              <Button
+                onClick={() => setEnabled(true)}
+                size='sm'
+                variant='outline'>
+                {t("skins.preview.enable")}
+              </Button>
+            }
+            description={t("skins.preview.disabledHint")}
+            icon={
+              <CubeIcon
+                className='h-12 w-12 text-muted-foreground opacity-40'
+                weight='duotone'
+              />
+            }
+            title={t("skins.preview.disabled")}
+          />
+        )}
+      </div>
+    </aside>
+  );
+};
+
+interface PanelNoticeProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  action?: ReactNode;
+}
+
+const PanelNotice = ({
+  icon,
+  title,
+  description,
+  action,
+}: PanelNoticeProps) => (
+  <Empty className='border-0'>
+    <EmptyHeader>
+      <EmptyMedia>{icon}</EmptyMedia>
+      <EmptyTitle className='text-sm'>{title}</EmptyTitle>
+      <EmptyDescription className='text-xs'>{description}</EmptyDescription>
+    </EmptyHeader>
+    {action && <EmptyContent>{action}</EmptyContent>}
+  </Empty>
+);
+
+interface PreviewSurfaceProps {
+  preview: ReturnType<typeof useSkinModelPreview>;
+  label: string;
+}
+
+const PreviewSurface = ({ preview, label }: PreviewSurfaceProps) => {
+  const { t } = useTranslation();
+
+  // The assembling figure stands in for the model so the panel never sits empty.
+  if (preview.isPending) {
+    return (
+      <>
+        <FoundrySkinAssembling />
+        <div className='absolute inset-x-0 bottom-0 space-y-2 p-6'>
+          <p className='text-center text-muted-foreground text-sm'>
+            {t("skins.preview.loading")}
+          </p>
+          <FoundryLoadingBar />
+        </div>
+      </>
+    );
+  }
+
+  if (preview.isError || preview.data.kind === "unsupported") {
+    return (
+      <PanelNotice
+        action={
+          preview.isError ? (
+            <Button
+              icon={<ArrowClockwiseIcon className='h-4 w-4' />}
+              onClick={() => void preview.refetch()}
+              size='sm'
+              variant='outline'>
+              {t("skins.preview.retry")}
+            </Button>
+          ) : undefined
+        }
+        description={t("skins.preview.failedHint")}
+        icon={
+          <WarningIcon
+            className='h-12 w-12 text-amber-500 opacity-70'
+            weight='duotone'
+          />
+        }
+        title={t(
+          preview.isError
+            ? "skins.preview.failed"
+            : "skins.preview.unsupported",
+        )}
+      />
+    );
+  }
+
+  return <FoundryModelViewer dataUrl={preview.data.dataUrl} label={label} />;
+};

--- a/apps/desktop/src/hooks/use-skin-model-preview.ts
+++ b/apps/desktop/src/hooks/use-skin-model-preview.ts
@@ -1,0 +1,88 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import {
+  analyzeDefaultFoundryHero,
+  analyzeFoundryVpk,
+  decodeFoundryModel,
+  getPrimaryModelPath,
+  releaseFoundryArchives,
+  resolveModVpk,
+} from "@/lib/foundry";
+import { usePersistedStore } from "@/lib/store";
+import type { LocalMod } from "@/types/mods";
+
+/** `unsupported` is not a failure: the VPK simply holds no hero model. */
+export type SkinModel =
+  | { kind: "model"; dataUrl: string }
+  | { kind: "unsupported" };
+
+/** How long a decoded model survives with nothing on screen showing it. */
+const MODEL_CACHE_TIME_MS = 5 * 60 * 1000;
+
+/**
+ * The Foundry's model pipeline without the editor around it: no workspace is
+ * prepared, so nothing is unpacked to disk and nothing is written.
+ */
+const decodeSkinModel = async (
+  mod: LocalMod | null,
+  hero: string,
+  profileFolder: string | null,
+): Promise<SkinModel> => {
+  const manifest = mod
+    ? await analyzeFoundryVpk(
+        await resolveModVpk(
+          mod.remoteId ?? mod.id,
+          mod.installedVpks ?? [],
+          profileFolder,
+        ),
+      )
+    : await analyzeDefaultFoundryHero(hero);
+
+  const modelPath = manifest.isHeroSkin ? getPrimaryModelPath(manifest) : null;
+  if (!modelPath) {
+    return { kind: "unsupported" };
+  }
+  const model = await decodeFoundryModel(manifest.filePath, modelPath, null);
+  return { kind: "model", dataUrl: model.dataUrl };
+};
+
+/**
+ * The 3D preview for one hero skin, or for the hero's default look when `mod`
+ * is null, as everywhere else on the page. Disabled, nothing is decoded at all
+ * — the decode is the expensive part, and that is the point of the setting.
+ */
+export const useSkinModelPreview = (
+  hero: string,
+  mod: LocalMod | null,
+  enabled: boolean,
+) => {
+  const profileFolder = usePersistedStore(
+    (state) => state.profiles[state.activeProfileId]?.folderName ?? null,
+  );
+
+  // Parsed VPK indexes stay cached in the backend so switching skins is quick;
+  // a parsed pak01 is a large thing to hold onto once the page is gone.
+  useEffect(() => () => void releaseFoundryArchives(), []);
+
+  return useQuery({
+    // Everything resolveModVpk reads is in the key: they all decide which
+    // archive is opened, and so which model comes back.
+    queryKey: [
+      "skin-model-preview",
+      hero,
+      mod?.remoteId ?? mod?.id ?? null,
+      mod?.installedVpks ?? [],
+      mod?.activeVariantArchive ?? null,
+      profileFolder,
+    ],
+    queryFn: () => decodeSkinModel(mod, hero, profileFolder),
+    enabled,
+    // A skin's model only changes when the skin does, and that changes the key.
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: MODEL_CACHE_TIME_MS,
+    retry: false,
+    // The panel shows the failure in place, with a retry; a toast on top of
+    // that would say the same thing twice.
+    meta: { skipGlobalErrorHandler: true },
+  });
+};

--- a/apps/desktop/src/lib/foundry.ts
+++ b/apps/desktop/src/lib/foundry.ts
@@ -251,3 +251,21 @@ export const decodeFoundrySound = async (
     workspaceRoot,
   });
 };
+
+/**
+ * The model that stands in for a whole skin: the hero's body.
+ *
+ * The backend resolves the hero's actual body model through the game's
+ * `heroes.vdata_c`, so `primaryModelPath` is an answer rather than a guess and
+ * is used whenever it is there. The local fallback only covers a manifest from
+ * an older backend or a skin with no hero: a `.vmdl_c` assembles the whole
+ * character, so it beats a lone `.vmesh_c`, which is one body part.
+ */
+export const getPrimaryModelPath = (
+  manifest: FoundryManifest,
+): string | null => {
+  if (manifest.primaryModelPath) return manifest.primaryModelPath;
+  const model = manifest.models.find((entry) => entry.path.endsWith(".vmdl_c"));
+  const mesh = manifest.models.find((entry) => entry.path.endsWith(".vmesh_c"));
+  return model?.path ?? mesh?.path ?? manifest.models[0]?.path ?? null;
+};

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -57,7 +57,24 @@
     "addSkin": "Add Skin",
     "addSkinFor": "Browse skins for {{hero}}",
     "emptyTitle": "No skins for {{hero}} yet",
-    "deleteSkin": "Delete skin"
+    "deleteSkin": "Delete skin",
+    "preview": {
+      "title": "3D preview",
+      "nothingSelected": "No skin selected",
+      "placeholder": "Pick a skin to see it in 3D",
+      "defaultLabel": "{{hero}} — default skin",
+      "previewSkin": "Show in 3D",
+      "previewDefault": "Show the default skin in 3D",
+      "loading": "Loading model…",
+      "unsupported": "This VPK holds no hero model.",
+      "failed": "Couldn't decode this skin.",
+      "failedHint": "Not every skin can be decoded — an unusual or broken model may fail to load. The skin still installs and works in-game.",
+      "retry": "Try again",
+      "hide": "Hide the 3D preview",
+      "disabled": "3D preview is off",
+      "disabledHint": "Turn it on to see the selected skin's model here. It can be switched off again under Settings › Application › Appearance.",
+      "enable": "Turn the preview on"
+    }
   },
   "stats": {
     "title": "Stats",
@@ -1534,7 +1551,10 @@
     "external": "External",
     "syntax": "Syntax",
     "forgeInstall": "1-click installs from DeadlockForge",
-    "forgeInstallDescription": "Let deadlockforge.net send mods you build straight to Deadlock Mod Manager. Nothing installs without asking you first."
+    "forgeInstallDescription": "Let deadlockforge.net send mods you build straight to Deadlock Mod Manager. Nothing installs without asking you first.",
+    "modelPreview": "3D model preview",
+    "modelPreviewDescription": "Render skin models in the Hero Skins panel and the Mod Foundry.",
+    "modelPreviewWarning": "The preview decodes a whole character model and renders it on your GPU. It is the slowest part of opening a skin, and not every skin can be decoded — an unusual or broken model may fail to load or, rarely, upset the graphics driver. Behaviour varies between graphics drivers and platforms; switch this off if previews are slow, blank or crash."
   },
   "featureFlags": {
     "title": "Experimental Features",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -3199,6 +3199,11 @@
     "enableCancel": "Not now",
     "enabled": "1-click installs enabled. Click the button on the site again.",
     "alreadyEnabled": "1-click installs are already on.",
+    "openTitle": "1-click installs from DeadlockForge",
+    "openBody": "Let deadlockforge.net send mods you build straight to Deadlock Mod Manager. Nothing installs without asking you first. Turn it on now so the 1-click button on the site works, or open the site without it.",
+    "openAction": "Turn on and open",
+    "openCancel": "Open without it",
+    "openEnabled": "1-click installs enabled.",
     "fallbackName": "DeadlockForge mod"
   }
 }

--- a/apps/desktop/src/pages/settings.tsx
+++ b/apps/desktop/src/pages/settings.tsx
@@ -67,6 +67,7 @@ import { LoggingSettings } from "@/components/settings/logging-settings";
 import OccultGeometrySettings from "@/components/settings/occult-geometry-settings";
 import { PluginList } from "@/components/settings/plugin-list";
 import { MatchSyncSettings } from "@/components/settings/match-sync-settings";
+import { ModelPreviewToggle } from "@/components/settings/model-preview-toggle";
 import PrivacySettings from "@/components/settings/privacy-settings";
 import { ProxySettings } from "@/components/settings/proxy-settings";
 import Section, { SectionSkeleton } from "@/components/settings/section";
@@ -727,6 +728,8 @@ const CustomSettings = ({ value }: { value?: string }) => {
                 </div>
 
                 <VolumeControl />
+
+                <ModelPreviewToggle />
 
                 <OccultGeometrySettings />
               </div>

--- a/apps/desktop/src/pages/skins.tsx
+++ b/apps/desktop/src/pages/skins.tsx
@@ -6,6 +6,7 @@ import { FileSelectorDialog } from "@/components/downloads/file-selector-dialog"
 import PageTitle from "@/components/shared/page-title";
 import { HeroList, type HeroListEntry } from "@/components/skins/hero-list";
 import { SkinGrid } from "@/components/skins/skin-grid";
+import { SkinPreviewPanel } from "@/components/skins/skin-preview-panel";
 import { deriveActiveArchiveNames } from "@/hooks/use-mod-options";
 import { useSkinSwap } from "@/hooks/use-skin-swap";
 import useUninstall from "@/hooks/use-uninstall";
@@ -23,6 +24,11 @@ const Skins = () => {
   const { selectSkin, swappingHero, installAction } = useSkinSwap();
   const { uninstall } = useUninstall();
   const [selectedHero, setSelectedHero] = useState<string | null>(null);
+  // The skin the 3D panel shows, per hero, so coming back to a hero returns to
+  // what was on screen. A null entry is a deliberate pick of the default skin.
+  const [previewedByHero, setPreviewedByHero] = useState<
+    Map<string, string | null>
+  >(new Map());
 
   const groups = useMemo(() => groupSkinsByHero(localMods), [localMods]);
 
@@ -61,8 +67,26 @@ const Skins = () => {
     null;
   const selectedGroup = effectiveHero ? groups.get(effectiveHero) : undefined;
 
+  // Without a pick of their own, the panel shows what the hero currently wears.
+  const previewedId =
+    effectiveHero && previewedByHero.has(effectiveHero)
+      ? (previewedByHero.get(effectiveHero) ?? null)
+      : (selectedGroup?.active[0]?.remoteId ?? null);
+  const previewedMod =
+    selectedGroup?.skins.find((skin) => skin.remoteId === previewedId) ?? null;
+
+  const handlePreview = (mod: LocalMod | null) => {
+    if (effectiveHero) {
+      setPreviewedByHero((current) =>
+        new Map(current).set(effectiveHero, mod?.remoteId ?? null),
+      );
+    }
+  };
+
   const handleSelect = (mod: LocalMod | null) => {
     if (effectiveHero) {
+      // Making a skin active is also a way of picking it, so the panel follows.
+      handlePreview(mod);
       void selectSkin(effectiveHero, mod);
     }
   };
@@ -106,9 +130,14 @@ const Skins = () => {
             hero={effectiveHero}
             onAddSkin={handleAddSkin}
             onDelete={handleDelete}
+            onPreview={handlePreview}
             onSelect={handleSelect}
+            previewedId={previewedId}
             skins={selectedGroup?.skins ?? []}
           />
+        )}
+        {effectiveHero && (
+          <SkinPreviewPanel hero={effectiveHero} mod={previewedMod} />
         )}
       </div>
       <p className='shrink-0 py-3 text-muted-foreground text-xs'>


### PR DESCRIPTION
- Ask users to enable 1-click installs before opening DeadlockForge
- Persist the setting and notify users when it is enabled
- Allow opening DeadlockForge without enabling the integration## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #
- Fixes #
- Related to #

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: [name], Used for: [what it helped with]

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

<!-- Include screenshots of UI changes, before/after comparisons, or relevant visual evidence -->

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Desktop app**
  - Prompts users to enable 1-click installs before opening DeadlockForge.
  - Persists the setting and shows a success notification after enablement.
  - Allows DeadlockForge to open without enabling the integration.
  - Adds selectable 3D previews for default heroes and installed skins.
  - Adds a persisted model-preview setting in Appearance settings.
  - Reuses the Foundry pipeline to decode models.
  - Adds loading, unsupported, failure, and retry states.
  - Adds model caching and cleanup for improved preview performance.
  - Updates skin cards with preview controls and active preview styling.

No API, bot, www, docs, shared-package, database, Tauri plugin, or Rust FFI changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->