### PR TITLE
fix(desktop): report Linux game launch failures

### DIFF
--- a/.changeset/eager-herons-launch.md
+++ b/.changeset/eager-herons-launch.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Report Steam launch failures and confirm Deadlock starts after each request

--- a/apps/desktop/src-tauri/src/commands/game.rs
+++ b/apps/desktop/src-tauri/src/commands/game.rs
@@ -1,11 +1,41 @@
+use std::future::pending;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::app_runtime::AppHandle;
 use crate::errors::Error;
+use crate::mod_manager::steam_uri_launcher::SteamUriLaunchMonitor;
+use futures::FutureExt;
 use tauri::Emitter;
 
+use super::game_process::{GAME_START_TIMEOUT, GameStartOutcome, wait_for_game_start};
 use super::gameinfo::reset_to_vanilla_internal;
 use super::state::MANAGER;
+
+const GAME_LAUNCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+async fn await_launched_game(monitor: SteamUriLaunchMonitor) -> Result<(), Error> {
+  let launcher = monitor.wait().fuse();
+  let game = wait_for_game_start(GAME_START_TIMEOUT, GAME_LAUNCH_POLL_INTERVAL, pending()).fuse();
+  futures::pin_mut!(launcher, game);
+
+  loop {
+    futures::select! {
+      launcher_result = launcher => launcher_result?,
+      game_result = game => return match game_result? {
+        GameStartOutcome::Running => {
+          log::info!("Confirmed Deadlock process started");
+          Ok(())
+        }
+        GameStartOutcome::TimedOut => Err(Error::GameLaunchFailed(format!(
+          "Steam accepted the launch request, but Deadlock did not start within {} seconds",
+          GAME_START_TIMEOUT.as_secs()
+        ))),
+        GameStartOutcome::Cancelled => unreachable!("normal game launches are not cancellable"),
+      }
+    }
+  }
+}
 
 #[tauri::command]
 pub async fn find_game_path() -> Result<String, Error> {
@@ -75,24 +105,29 @@ pub async fn start_game(
 
   let first_result = {
     let mut mod_manager = MANAGER.lock().unwrap();
-    mod_manager.run_game(vanilla, additional_args.clone(), profile_folder.clone())
+    mod_manager.prepare_game_launch(vanilla, additional_args.clone(), profile_folder.clone())
   };
 
-  if let Err(Error::GameConfigParse(ref msg)) = first_result {
-    log::warn!("Game config parse failed: {msg}, attempting auto-reset to vanilla");
+  let request = match first_result {
+    Ok(request) => request,
+    Err(Error::GameConfigParse(msg)) => {
+      log::warn!("Game config parse failed: {msg}, attempting auto-reset to vanilla");
 
-    reset_to_vanilla_internal().await?;
+      reset_to_vanilla_internal().await?;
 
-    let mut mod_manager = MANAGER.lock().unwrap();
-    mod_manager.run_game(vanilla, additional_args, profile_folder)?;
+      let request = {
+        let mut mod_manager = MANAGER.lock().unwrap();
+        mod_manager.prepare_game_launch(vanilla, additional_args, profile_folder)?
+      };
 
-    app_handle.emit("gameinfo-auto-reset", ()).ok();
-    log::info!("Auto-recovery succeeded, game launched after gameinfo reset");
+      app_handle.emit("gameinfo-auto-reset", ()).ok();
+      log::info!("Auto-recovery succeeded after gameinfo reset");
+      request
+    }
+    Err(error) => return Err(error),
+  };
 
-    return Ok(());
-  }
-
-  first_result
+  await_launched_game(request.spawn()?).await
 }
 
 /// Launch the game without touching `gameinfo.gi`.
@@ -105,10 +140,14 @@ pub async fn start_game(
 pub async fn launch_game_direct(additional_args: String) -> Result<(), Error> {
   log::info!("Launching game without gameinfo changes, args: {additional_args:?}");
 
-  let mod_manager = MANAGER.lock().unwrap();
-  mod_manager
-    .get_steam_manager()
-    .launch_game(&additional_args)
+  let request = {
+    let mod_manager = MANAGER.lock().unwrap();
+    mod_manager
+      .get_steam_manager()
+      .game_launch_request(&additional_args)?
+  };
+
+  await_launched_game(request.spawn()?).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/game.rs
+++ b/apps/desktop/src-tauri/src/commands/game.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use crate::app_runtime::AppHandle;
 use crate::errors::Error;
 use crate::mod_manager::steam_uri_launcher::SteamUriLaunchMonitor;
-use futures::FutureExt;
 use tauri::Emitter;
 
 use super::game_process::{GAME_START_TIMEOUT, GameStartOutcome, wait_for_game_start};
@@ -15,25 +14,28 @@ use super::state::MANAGER;
 const GAME_LAUNCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 async fn await_launched_game(monitor: SteamUriLaunchMonitor) -> Result<(), Error> {
-  let launcher = monitor.wait().fuse();
-  let game = wait_for_game_start(GAME_START_TIMEOUT, GAME_LAUNCH_POLL_INTERVAL, pending()).fuse();
-  futures::pin_mut!(launcher, game);
+  let launcher = monitor.wait();
+  let game = wait_for_game_start(GAME_START_TIMEOUT, GAME_LAUNCH_POLL_INTERVAL, pending());
+  tokio::pin!(launcher, game);
 
-  loop {
-    futures::select! {
-      launcher_result = launcher => launcher_result?,
-      game_result = game => return match game_result? {
-        GameStartOutcome::Running => {
-          log::info!("Confirmed Deadlock process started");
-          Ok(())
-        }
-        GameStartOutcome::TimedOut => Err(Error::GameLaunchFailed(format!(
-          "Steam accepted the launch request, but Deadlock did not start within {} seconds",
-          GAME_START_TIMEOUT.as_secs()
-        ))),
-        GameStartOutcome::Cancelled => unreachable!("normal game launches are not cancellable"),
-      }
+  let outcome = tokio::select! {
+    launcher_result = &mut launcher => {
+      launcher_result?;
+      game.await?
     }
+    game_result = &mut game => game_result?,
+  };
+
+  match outcome {
+    GameStartOutcome::Running => {
+      log::info!("Confirmed Deadlock process started");
+      Ok(())
+    }
+    GameStartOutcome::TimedOut => Err(Error::GameLaunchFailed(format!(
+      "Steam accepted the launch request, but Deadlock did not start within {} seconds",
+      GAME_START_TIMEOUT.as_secs()
+    ))),
+    GameStartOutcome::Cancelled => unreachable!("normal game launches are not cancellable"),
   }
 }
 

--- a/apps/desktop/src-tauri/src/commands/game_process.rs
+++ b/apps/desktop/src-tauri/src/commands/game_process.rs
@@ -27,14 +27,11 @@ pub(super) async fn is_game_running() -> Result<bool, Error> {
   .map_err(|error| Error::BackgroundTaskFailed(format!("Process check task failed: {error}")))?
 }
 
-pub(super) async fn wait_for_game_start<Cancel>(
+pub(super) async fn wait_for_game_start(
   timeout: Duration,
   poll_interval: Duration,
-  cancel: Cancel,
-) -> Result<GameStartOutcome, Error>
-where
-  Cancel: Future<Output = ()>,
-{
+  cancel: impl Future<Output = ()>,
+) -> Result<GameStartOutcome, Error> {
   if running_in_flatpak() {
     let mut console_log = ConsoleLogTail::from_end(&game_path()?);
     return wait_for_game_start_with_check(
@@ -49,16 +46,15 @@ where
   wait_for_game_start_with_check(timeout, poll_interval, is_game_running, cancel).await
 }
 
-async fn wait_for_game_start_with_check<Check, CheckFuture, Cancel>(
+async fn wait_for_game_start_with_check<Check, CheckFuture>(
   timeout: Duration,
   poll_interval: Duration,
   mut check: Check,
-  cancel: Cancel,
+  cancel: impl Future<Output = ()>,
 ) -> Result<GameStartOutcome, Error>
 where
   Check: FnMut() -> CheckFuture,
   CheckFuture: Future<Output = Result<bool, Error>>,
-  Cancel: Future<Output = ()>,
 {
   let deadline = tokio::time::sleep(timeout);
   tokio::pin!(deadline);

--- a/apps/desktop/src-tauri/src/commands/game_process.rs
+++ b/apps/desktop/src-tauri/src/commands/game_process.rs
@@ -1,0 +1,129 @@
+use std::future::{Future, ready};
+use std::time::Duration;
+
+use crate::errors::Error;
+use crate::flatpak::running_in_flatpak;
+use crate::mod_manager::console_log_watcher::ConsoleLogTail;
+
+use super::state::{MANAGER, game_path};
+
+pub(super) const GAME_START_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum GameStartOutcome {
+  Running,
+  TimedOut,
+  Cancelled,
+}
+
+pub(super) async fn is_game_running() -> Result<bool, Error> {
+  tokio::task::spawn_blocking(|| {
+    let mut manager = MANAGER
+      .lock()
+      .map_err(|_| Error::BackgroundTaskFailed("Mod manager lock poisoned".to_string()))?;
+    manager.is_game_running()
+  })
+  .await
+  .map_err(|error| Error::BackgroundTaskFailed(format!("Process check task failed: {error}")))?
+}
+
+pub(super) async fn wait_for_game_start<Cancel>(
+  timeout: Duration,
+  poll_interval: Duration,
+  cancel: Cancel,
+) -> Result<GameStartOutcome, Error>
+where
+  Cancel: Future<Output = ()>,
+{
+  if running_in_flatpak() {
+    let mut console_log = ConsoleLogTail::from_end(&game_path()?);
+    return wait_for_game_start_with_check(
+      timeout,
+      poll_interval,
+      move || ready(Ok(console_log.read_new().is_some())),
+      cancel,
+    )
+    .await;
+  }
+
+  wait_for_game_start_with_check(timeout, poll_interval, is_game_running, cancel).await
+}
+
+async fn wait_for_game_start_with_check<Check, CheckFuture, Cancel>(
+  timeout: Duration,
+  poll_interval: Duration,
+  mut check: Check,
+  cancel: Cancel,
+) -> Result<GameStartOutcome, Error>
+where
+  Check: FnMut() -> CheckFuture,
+  CheckFuture: Future<Output = Result<bool, Error>>,
+  Cancel: Future<Output = ()>,
+{
+  let deadline = tokio::time::sleep(timeout);
+  tokio::pin!(deadline);
+  tokio::pin!(cancel);
+
+  loop {
+    if check().await? {
+      return Ok(GameStartOutcome::Running);
+    }
+
+    tokio::select! {
+      _ = &mut deadline => return Ok(GameStartOutcome::TimedOut),
+      _ = &mut cancel => return Ok(GameStartOutcome::Cancelled),
+      _ = tokio::time::sleep(poll_interval) => {}
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::future::pending;
+
+  use super::*;
+
+  #[tokio::test]
+  async fn reports_running_when_the_game_appears() {
+    let mut checks = 0;
+    let result = wait_for_game_start_with_check(
+      Duration::from_secs(1),
+      Duration::ZERO,
+      || {
+        checks += 1;
+        ready(Ok(checks == 3))
+      },
+      pending(),
+    )
+    .await;
+
+    assert_eq!(result.unwrap(), GameStartOutcome::Running);
+    assert_eq!(checks, 3);
+  }
+
+  #[tokio::test]
+  async fn reports_timeout() {
+    let result = wait_for_game_start_with_check(
+      Duration::ZERO,
+      Duration::ZERO,
+      || ready(Ok(false)),
+      pending(),
+    )
+    .await;
+
+    assert_eq!(result.unwrap(), GameStartOutcome::TimedOut);
+  }
+
+  #[tokio::test]
+  async fn reports_cancellation() {
+    let result = wait_for_game_start_with_check(
+      Duration::from_secs(1),
+      Duration::ZERO,
+      || ready(Ok(false)),
+      ready(()),
+    )
+    .await;
+
+    assert_eq!(result.unwrap(), GameStartOutcome::Cancelled);
+  }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod fonts;
 pub mod forge;
 pub mod foundry;
 pub mod game;
+mod game_process;
 pub mod gameinfo;
 pub mod ingest;
 pub mod live_match;

--- a/apps/desktop/src-tauri/src/commands/server_connect.rs
+++ b/apps/desktop/src-tauri/src/commands/server_connect.rs
@@ -23,10 +23,9 @@ use crate::app_runtime::AppHandle;
 use crate::errors::Error;
 use crate::mod_manager::console_log_watcher::ConsoleLogTail;
 
+use super::game_process::{self, GAME_START_TIMEOUT, GameStartOutcome};
 use super::state::{MANAGER, SERVER_CONNECT_WATCHDOG, game_path};
 
-/// How long we wait for the Deadlock process to show up after launching.
-const GAME_START_TIMEOUT: Duration = Duration::from_secs(180);
 /// Overall budget for getting connected once the process is up.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(240);
 /// Grace period after the client reaches the menu before we re-issue connect.
@@ -87,17 +86,6 @@ fn emit(app: &AppHandle, status: ConnectStatus, address: &str, attempt: u32) {
   }
 }
 
-async fn is_game_running() -> Result<bool, Error> {
-  tokio::task::spawn_blocking(|| {
-    let mut manager = MANAGER
-      .lock()
-      .map_err(|_| Error::BackgroundTaskFailed("Mod manager lock poisoned".to_string()))?;
-    manager.is_game_running()
-  })
-  .await
-  .map_err(|e| Error::BackgroundTaskFailed(format!("Process check task failed: {e}")))?
-}
-
 fn open_steam_connect(address: &str, password: Option<&str>) -> Result<(), Error> {
   let uri = match password {
     Some(password) if !password.is_empty() => {
@@ -109,10 +97,14 @@ fn open_steam_connect(address: &str, password: Option<&str>) -> Result<(), Error
     _ => format!("steam://connect/{address}"),
   };
 
-  let manager = MANAGER
-    .lock()
-    .map_err(|_| Error::BackgroundTaskFailed("Mod manager lock poisoned".to_string()))?;
-  manager.get_steam_manager().open_steam_uri(&uri)
+  let request = {
+    let manager = MANAGER
+      .lock()
+      .map_err(|_| Error::BackgroundTaskFailed("Mod manager lock poisoned".to_string()))?;
+    manager.get_steam_manager().uri_launch_request(&uri)?
+  };
+  request.spawn()?;
+  Ok(())
 }
 
 /// Turn whatever the relay handed us into the literal `ip:port` Steam's
@@ -237,23 +229,20 @@ async fn run_watchdog(
 /// Waits for the Deadlock process to appear. Returns false if we gave up or
 /// were cancelled, having already emitted the terminal event in the former case.
 async fn await_game_start(app: &AppHandle, address: &str, cancel: &CancellationToken) -> bool {
-  let deadline = Instant::now() + GAME_START_TIMEOUT;
-
-  loop {
-    match is_game_running().await {
-      Ok(true) => return true,
-      Ok(false) => {}
-      Err(error) => log::warn!("Could not check whether Deadlock is running: {error}"),
-    }
-
-    if Instant::now() >= deadline {
+  match game_process::wait_for_game_start(GAME_START_TIMEOUT, LIVENESS_INTERVAL, cancel.cancelled())
+    .await
+  {
+    Ok(GameStartOutcome::Running) => true,
+    Ok(GameStartOutcome::Cancelled) => false,
+    Ok(GameStartOutcome::TimedOut) => {
       log::warn!("Deadlock never started; giving up on auto-connect to {address}");
       emit(app, ConnectStatus::TimedOut, address, 0);
-      return false;
+      false
     }
-
-    if sleep_or_cancel(LIVENESS_INTERVAL, cancel).await {
-      return false;
+    Err(error) => {
+      log::warn!("Could not check whether Deadlock is running: {error}");
+      emit(app, ConnectStatus::TimedOut, address, 0);
+      false
     }
   }
 }
@@ -284,7 +273,7 @@ async fn drive_connect(
 
     if last_liveness_check.elapsed() >= LIVENESS_INTERVAL {
       last_liveness_check = Instant::now();
-      match is_game_running().await {
+      match game_process::is_game_running().await {
         // Cold start already waited for the process, so a miss here means the
         // player quit — nothing left to connect.
         Ok(false) => {

--- a/apps/desktop/src-tauri/src/flatpak.rs
+++ b/apps/desktop/src-tauri/src/flatpak.rs
@@ -59,13 +59,18 @@ async fn cleanup_bundle(path: &PathBuf) {
 
 #[tauri::command]
 pub async fn is_flatpak() -> Result<bool, Error> {
-  Ok(std::env::var("FLATPAK_ID").is_ok())
+  Ok(running_in_flatpak())
+}
+
+pub fn running_in_flatpak() -> bool {
+  std::env::var_os("FLATPAK_ID").is_some()
 }
 
 #[tauri::command]
 pub async fn update_flatpak(app_handle: AppHandle, url: String) -> Result<(), Error> {
-  std::env::var("FLATPAK_ID")
-    .map_err(|_| Error::InvalidInput("Not running as a Flatpak".to_string()))?;
+  if !running_in_flatpak() {
+    return Err(Error::InvalidInput("Not running as a Flatpak".to_string()));
+  }
 
   let validated_url = validate_update_url(&url)?;
   let path = bundle_path();

--- a/apps/desktop/src-tauri/src/flatpak.rs
+++ b/apps/desktop/src-tauri/src/flatpak.rs
@@ -62,7 +62,7 @@ pub async fn is_flatpak() -> Result<bool, Error> {
   Ok(running_in_flatpak())
 }
 
-pub fn running_in_flatpak() -> bool {
+pub(crate) fn running_in_flatpak() -> bool {
   std::env::var_os("FLATPAK_ID").is_some()
 }
 

--- a/apps/desktop/src-tauri/src/mod_manager/game_process_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/game_process_manager.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::thread;
 use std::time::Duration;
 
@@ -6,6 +7,22 @@ use log;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System};
 
 const DEADLOCK_PROCESS_NAME: &str = "deadlock.exe";
+
+fn executable_name(value: &OsStr) -> Option<&str> {
+  value
+    .to_str()?
+    .rsplit(['/', '\\'])
+    .next()
+    .filter(|name| !name.is_empty())
+}
+
+fn is_deadlock_process(name: &OsStr, command: &[std::ffi::OsString]) -> bool {
+  executable_name(name).is_some_and(|name| name.eq_ignore_ascii_case(DEADLOCK_PROCESS_NAME))
+    || command
+      .first()
+      .and_then(|argument| executable_name(argument))
+      .is_some_and(|name| name.eq_ignore_ascii_case(DEADLOCK_PROCESS_NAME))
+}
 
 /// Manages game process lifecycle
 pub struct GameProcessManager {
@@ -29,7 +46,9 @@ impl GameProcessManager {
 
     let process_count = self
       .system
-      .processes_by_name(DEADLOCK_PROCESS_NAME.as_ref())
+      .processes()
+      .values()
+      .filter(|process| is_deadlock_process(process.name(), process.cmd()))
       .count();
 
     log::debug!("Found {process_count} game processes");
@@ -57,7 +76,9 @@ impl GameProcessManager {
     log::info!("Stopping game...");
     let processes: Vec<_> = self
       .system
-      .processes_by_name(DEADLOCK_PROCESS_NAME.as_ref())
+      .processes()
+      .values()
+      .filter(|process| is_deadlock_process(process.name(), process.cmd()))
       .collect();
 
     if processes.is_empty() {
@@ -91,5 +112,37 @@ impl GameProcessManager {
 impl Default for GameProcessManager {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::ffi::{OsStr, OsString};
+
+  use super::is_deadlock_process;
+
+  #[test]
+  fn detects_native_process_name() {
+    assert!(is_deadlock_process(OsStr::new("deadlock.exe"), &[]));
+  }
+
+  #[test]
+  fn detects_proton_process_by_windows_argv_zero() {
+    let command = [OsString::from(
+      r"S:\steamapps\common\Deadlock\game\bin\win64\deadlock.exe",
+    )];
+
+    assert!(is_deadlock_process(OsStr::new("MainThrd"), &command));
+  }
+
+  #[test]
+  fn ignores_wrapper_processes_that_only_reference_deadlock_later() {
+    let command = [
+      OsString::from("python3"),
+      OsString::from("/steam/Proton/proton"),
+      OsString::from("/steam/Deadlock/game/bin/win64/deadlock.exe"),
+    ];
+
+    assert!(!is_deadlock_process(OsStr::new("python3"), &command));
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -405,12 +405,12 @@ impl ModManager {
     Ok(())
   }
 
-  pub fn run_game(
+  pub fn prepare_game_launch(
     &mut self,
     vanilla: bool,
     additional_args: String,
     profile_folder: Option<String>,
-  ) -> Result<(), Error> {
+  ) -> Result<super::steam_uri_launcher::SteamUriLaunchRequest, Error> {
     // Ensure game path is found
     let game_path = self.find_game()?;
 
@@ -426,10 +426,7 @@ impl ModManager {
         .update_mod_path(&game_path, profile_folder)?;
     }
 
-    // Launch the game through Steam
-    self.steam_manager.launch_game(&additional_args)?;
-
-    Ok(())
+    self.steam_manager.game_launch_request(&additional_args)
   }
 
   pub fn get_mod_file_tree(&self, mod_path: &PathBuf) -> Result<ModFileTree, Error> {

--- a/apps/desktop/src-tauri/src/mod_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/mod.rs
@@ -12,6 +12,7 @@ pub mod game_process_manager;
 pub mod manager;
 pub mod mod_repository;
 pub mod steam_manager;
+pub(crate) mod steam_uri_launcher;
 pub mod vpk_manager;
 pub mod vpk_manifest;
 

--- a/apps/desktop/src-tauri/src/mod_manager/steam_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/steam_manager.rs
@@ -7,6 +7,23 @@ use std::path::PathBuf;
 
 const DEADLOCK_APP_ID: u32 = 1422450;
 
+#[cfg(target_os = "linux")]
+fn flatpak_game_launch_args(additional_args: &str) -> String {
+  let additional_args = additional_args.trim();
+  if additional_args
+    .split_ascii_whitespace()
+    .any(|argument| argument == "-condebug")
+  {
+    return additional_args.to_string();
+  }
+
+  if additional_args.is_empty() {
+    "-condebug".to_string()
+  } else {
+    format!("{additional_args} -condebug")
+  }
+}
+
 /// Manages Steam integration and game path detection
 pub struct SteamManager {
   steam_dir: Option<steamlocate::SteamDir>,
@@ -211,6 +228,18 @@ impl SteamManager {
 
   /// Prepare a request to launch Deadlock through Steam with optional arguments.
   pub fn game_launch_request(&self, additional_args: &str) -> Result<SteamUriLaunchRequest, Error> {
+    #[cfg(target_os = "linux")]
+    let additional_args = if crate::flatpak::running_in_flatpak() {
+      // Flatpak cannot see the host's process table, so console.log is the
+      // startup signal used to distinguish a running game from a false launch.
+      flatpak_game_launch_args(additional_args)
+    } else {
+      additional_args.to_string()
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let additional_args = additional_args.to_string();
+
     let steam_uri = format!("steam://run/{DEADLOCK_APP_ID}//{additional_args}");
     self.uri_launch_request(&steam_uri)
   }
@@ -449,5 +478,22 @@ mod tests {
     let request = manager.linux_uri_launch_request("steam://run/1422450//", true);
     assert_eq!(request.program(), Path::new("xdg-open"));
     assert!(request.uses_portal_timeout());
+  }
+
+  #[test]
+  fn flatpak_launch_args_include_console_logging_for_startup_confirmation() {
+    assert_eq!(flatpak_game_launch_args(""), "-condebug");
+    assert_eq!(
+      flatpak_game_launch_args("-novid +exec autoexec"),
+      "-novid +exec autoexec -condebug"
+    );
+    assert_eq!(
+      flatpak_game_launch_args("-novid -condebug"),
+      "-novid -condebug"
+    );
+    assert_eq!(
+      flatpak_game_launch_args("-condebuglog"),
+      "-condebuglog -condebug"
+    );
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/steam_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/steam_manager.rs
@@ -1,4 +1,5 @@
 use crate::errors::Error;
+use crate::mod_manager::steam_uri_launcher::{SteamUriLaunchRequest, redacted_steam_uri};
 use log;
 #[cfg(target_os = "linux")]
 use std::path::Path;
@@ -182,14 +183,36 @@ impl SteamManager {
     }
   }
 
-  /// Launch Deadlock through Steam with optional arguments
-  pub fn launch_game(&self, additional_args: &str) -> Result<(), Error> {
+  #[cfg(target_os = "linux")]
+  fn linux_uri_launch_request(
+    &self,
+    steam_uri: &str,
+    running_in_flatpak: bool,
+  ) -> SteamUriLaunchRequest {
+    if running_in_flatpak {
+      log::info!("Launching Steam URI through the Flatpak portal");
+      return SteamUriLaunchRequest::portal(PathBuf::from("xdg-open"), steam_uri.to_string());
+    }
+
+    match self.get_steam_executable() {
+      Ok(steam_exe) => {
+        log::info!(
+          "Launching via Steam executable directly: {}",
+          steam_exe.display()
+        );
+        SteamUriLaunchRequest::direct(steam_exe, steam_uri.to_string())
+      }
+      Err(_) => {
+        log::info!("No Steam executable found, falling back to xdg-open");
+        SteamUriLaunchRequest::portal(PathBuf::from("xdg-open"), steam_uri.to_string())
+      }
+    }
+  }
+
+  /// Prepare a request to launch Deadlock through Steam with optional arguments.
+  pub fn game_launch_request(&self, additional_args: &str) -> Result<SteamUriLaunchRequest, Error> {
     let steam_uri = format!("steam://run/{DEADLOCK_APP_ID}//{additional_args}");
-    log::info!(
-      "Launching game with URI: {}",
-      redacted_steam_uri(&steam_uri)
-    );
-    self.open_steam_uri(&steam_uri)
+    self.uri_launch_request(&steam_uri)
   }
 
   /// Hand a `steam://` URI to the Steam client.
@@ -198,37 +221,35 @@ impl SteamManager {
   /// first-class: it launches the game when it is closed and hands the
   /// address to an already running client, which `steam://run//+connect`
   /// cannot do.
-  pub fn open_steam_uri(&self, steam_uri: &str) -> Result<(), Error> {
+  pub fn uri_launch_request(&self, steam_uri: &str) -> Result<SteamUriLaunchRequest, Error> {
     log::info!("Opening Steam URI: {}", redacted_steam_uri(steam_uri));
 
     #[cfg(target_os = "windows")]
     {
       let steam_exe = self.get_steam_executable()?;
-      std::process::Command::new(steam_exe)
-        .arg(steam_uri)
-        .spawn()
-        .map_err(|e| Error::GameLaunchFailed(e.to_string()))?;
+      Ok(SteamUriLaunchRequest::direct(
+        steam_exe,
+        steam_uri.to_string(),
+      ))
     }
 
     #[cfg(target_os = "linux")]
     {
-      std::process::Command::new("xdg-open")
-        .arg(steam_uri)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| Error::GameLaunchFailed(e.to_string()))?;
+      Ok(self.linux_uri_launch_request(steam_uri, crate::flatpak::running_in_flatpak()))
     }
 
     #[cfg(target_os = "macos")]
     {
-      std::process::Command::new("open")
-        .arg(steam_uri)
-        .spawn()
-        .map_err(|e| Error::GameLaunchFailed(e.to_string()))?;
+      Ok(SteamUriLaunchRequest::direct(
+        PathBuf::from("open"),
+        steam_uri.to_string(),
+      ))
     }
 
-    Ok(())
+    #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+    Err(Error::GameLaunchFailed(
+      "Steam URI launching is unsupported on this platform".to_string(),
+    ))
   }
 
   fn candidate_steam_dirs(&self) -> Vec<steamlocate::SteamDir> {
@@ -263,63 +284,6 @@ impl SteamManager {
 impl Default for SteamManager {
   fn default() -> Self {
     Self::new()
-  }
-}
-
-/// Drop credentials from a Steam URI before it is written to the log file.
-fn redacted_steam_uri(uri: &str) -> String {
-  let without_connect_password = match uri.strip_prefix("steam://connect/") {
-    Some(rest) => {
-      let addr = rest.split('/').next().unwrap_or(rest);
-      format!("steam://connect/{addr}")
-    }
-    None => uri.to_string(),
-  };
-
-  redact_password_args(&without_connect_password)
-}
-
-fn redact_password_args(uri: &str) -> String {
-  let mut parts = uri.split(' ').peekable();
-  let mut out = Vec::new();
-  while let Some(part) = parts.next() {
-    out.push(part.to_string());
-    if part.eq_ignore_ascii_case("+password") && parts.peek().is_some() {
-      parts.next();
-      out.push("<redacted>".to_string());
-    }
-  }
-  out.join(" ")
-}
-
-#[cfg(test)]
-mod redaction_tests {
-  use super::*;
-
-  #[test]
-  fn drops_the_password_segment_from_a_connect_uri() {
-    assert_eq!(
-      redacted_steam_uri("steam://connect/203.0.113.10:27015/hunter2"),
-      "steam://connect/203.0.113.10:27015"
-    );
-  }
-
-  #[test]
-  fn leaves_a_connect_uri_without_a_password_unchanged() {
-    assert_eq!(
-      redacted_steam_uri("steam://connect/203.0.113.10:27015"),
-      "steam://connect/203.0.113.10:27015"
-    );
-  }
-
-  #[test]
-  fn redacts_a_password_launch_option() {
-    assert_eq!(
-      redacted_steam_uri(
-        "steam://run/1422450//+connect 203.0.113.10:27015 +password hunter2 -condebug"
-      ),
-      "steam://run/1422450//+connect 203.0.113.10:27015 +password <redacted> -condebug"
-    );
   }
 }
 
@@ -447,5 +411,43 @@ mod tests {
 
     let result = manager.set_steam_dir(temp_dir.path().to_path_buf());
     assert!(result.is_err());
+  }
+
+  #[test]
+  fn resolve_uri_launcher_prefers_the_steam_executable_on_native_linux() {
+    let (temp_dir, steam_dir) = temp_steam_dir("Steam", false);
+    let steam_sh = steam_dir.path().join("steam.sh");
+    fs::write(&steam_sh, "").unwrap();
+    let mut manager = SteamManager::new();
+    manager
+      .set_steam_dir(temp_dir.path().join("Steam"))
+      .unwrap();
+
+    let request = manager.linux_uri_launch_request("steam://run/1422450//", false);
+    assert_eq!(request.program(), steam_sh);
+    assert!(!request.uses_portal_timeout());
+  }
+
+  #[test]
+  fn resolve_uri_launcher_falls_back_to_xdg_open_without_a_steam_executable() {
+    let manager = SteamManager::new();
+
+    let request = manager.linux_uri_launch_request("steam://run/1422450//", false);
+    assert_eq!(request.program(), Path::new("xdg-open"));
+    assert!(request.uses_portal_timeout());
+  }
+
+  #[test]
+  fn resolve_uri_launcher_uses_xdg_open_inside_flatpak() {
+    let (temp_dir, steam_dir) = temp_steam_dir("Steam", false);
+    fs::write(steam_dir.path().join("steam.sh"), "").unwrap();
+    let mut manager = SteamManager::new();
+    manager
+      .set_steam_dir(temp_dir.path().join("Steam"))
+      .unwrap();
+
+    let request = manager.linux_uri_launch_request("steam://run/1422450//", true);
+    assert_eq!(request.program(), Path::new("xdg-open"));
+    assert!(request.uses_portal_timeout());
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/steam_uri_launcher.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/steam_uri_launcher.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::process::ExitStatus;
+use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -12,13 +12,11 @@ use crate::errors::Error;
 const PORTAL_TIMEOUT: Duration = Duration::from_secs(15);
 const CAPTURED_STDERR_LINES: usize = 20;
 
-#[derive(Debug, PartialEq, Eq)]
 enum CompletionPolicy {
   Observe,
   Timeout(Duration),
 }
 
-#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct SteamUriLaunchRequest {
   program: PathBuf,
   uri: String,
@@ -48,8 +46,6 @@ impl SteamUriLaunchRequest {
   }
 
   pub(crate) fn spawn(self) -> Result<SteamUriLaunchMonitor, Error> {
-    use std::process::Stdio;
-
     let mut child = Command::new(&self.program)
       .arg(&self.uri)
       .stdout(Stdio::null())
@@ -129,8 +125,9 @@ async fn monitor_child(
     return Ok(());
   }
 
-  let message = unsuccessful_exit_message(program, status, &stderr);
-  Err(Error::GameLaunchFailed(message))
+  Err(Error::GameLaunchFailed(unsuccessful_exit_message(
+    program, status, &stderr,
+  )))
 }
 
 async fn wait_with_timeout(

--- a/apps/desktop/src-tauri/src/mod_manager/steam_uri_launcher.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/steam_uri_launcher.rs
@@ -1,0 +1,327 @@
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, ChildStderr, Command};
+use tokio::task::JoinHandle;
+
+use crate::errors::Error;
+
+const PORTAL_TIMEOUT: Duration = Duration::from_secs(15);
+const CAPTURED_STDERR_LINES: usize = 20;
+
+#[derive(Debug, PartialEq, Eq)]
+enum CompletionPolicy {
+  Observe,
+  Timeout(Duration),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SteamUriLaunchRequest {
+  program: PathBuf,
+  uri: String,
+  completion: CompletionPolicy,
+}
+
+#[derive(Debug)]
+pub(crate) struct SteamUriLaunchMonitor {
+  task: JoinHandle<Result<(), Error>>,
+}
+
+impl SteamUriLaunchRequest {
+  pub(crate) fn direct(program: PathBuf, uri: String) -> Self {
+    Self {
+      program,
+      uri,
+      completion: CompletionPolicy::Observe,
+    }
+  }
+
+  pub(crate) fn portal(program: PathBuf, uri: String) -> Self {
+    Self {
+      program,
+      uri,
+      completion: CompletionPolicy::Timeout(PORTAL_TIMEOUT),
+    }
+  }
+
+  pub(crate) fn spawn(self) -> Result<SteamUriLaunchMonitor, Error> {
+    use std::process::Stdio;
+
+    let mut child = Command::new(&self.program)
+      .arg(&self.uri)
+      .stdout(Stdio::null())
+      .stderr(Stdio::piped())
+      .spawn()
+      .map_err(|error| {
+        Error::GameLaunchFailed(format!(
+          "failed to spawn {}: {error}",
+          self.program.display()
+        ))
+      })?;
+
+    let stderr = child.stderr.take().ok_or_else(|| {
+      Error::GameLaunchFailed(format!(
+        "failed to capture stderr from {}",
+        self.program.display()
+      ))
+    })?;
+
+    let task = tokio::spawn(async move {
+      let outcome = monitor_child(
+        &mut child,
+        stderr,
+        &self.program,
+        &self.uri,
+        self.completion,
+      )
+      .await;
+      if let Err(error) = &outcome {
+        log::error!("Steam URI launch failed: {error}");
+      }
+      outcome
+    });
+
+    Ok(SteamUriLaunchMonitor { task })
+  }
+
+  #[cfg(test)]
+  pub(crate) fn program(&self) -> &Path {
+    &self.program
+  }
+
+  #[cfg(test)]
+  pub(crate) fn uses_portal_timeout(&self) -> bool {
+    matches!(self.completion, CompletionPolicy::Timeout(_))
+  }
+}
+
+impl SteamUriLaunchMonitor {
+  pub(crate) async fn wait(self) -> Result<(), Error> {
+    self.task.await.map_err(|error| {
+      Error::BackgroundTaskFailed(format!("Steam URI launcher task failed: {error}"))
+    })?
+  }
+}
+
+async fn monitor_child(
+  child: &mut Child,
+  stderr: ChildStderr,
+  program: &Path,
+  uri: &str,
+  completion: CompletionPolicy,
+) -> Result<(), Error> {
+  let program_display = program.display().to_string();
+  let wait_for_exit = async {
+    match completion {
+      CompletionPolicy::Observe => child.wait().await.map_err(|error| {
+        Error::GameLaunchFailed(format!("failed to wait for {program_display}: {error}"))
+      }),
+      CompletionPolicy::Timeout(timeout) => wait_with_timeout(child, program, timeout).await,
+    }
+  };
+  let (status, stderr) =
+    tokio::try_join!(wait_for_exit, read_stderr(stderr, &program_display, uri))?;
+
+  if status.success() {
+    return Ok(());
+  }
+
+  let message = unsuccessful_exit_message(program, status, &stderr);
+  Err(Error::GameLaunchFailed(message))
+}
+
+async fn wait_with_timeout(
+  child: &mut Child,
+  program: &Path,
+  timeout: Duration,
+) -> Result<ExitStatus, Error> {
+  match tokio::time::timeout(timeout, child.wait()).await {
+    Ok(result) => result.map_err(|error| {
+      Error::GameLaunchFailed(format!(
+        "failed to wait for {} while handling the Steam URI: {error}",
+        program.display()
+      ))
+    }),
+    Err(_) => {
+      if let Err(error) = child.kill().await {
+        log::warn!(
+          "Failed to stop timed-out URI launcher {}: {error}",
+          program.display()
+        );
+      }
+      let _ = child.wait().await;
+      Err(Error::GameLaunchFailed(format!(
+        "{} did not finish handling the Steam URI within {} seconds",
+        program.display(),
+        timeout.as_secs()
+      )))
+    }
+  }
+}
+
+async fn read_stderr(stderr: ChildStderr, program: &str, uri: &str) -> Result<String, Error> {
+  let mut lines = BufReader::new(stderr).lines();
+  let mut captured = VecDeque::with_capacity(CAPTURED_STDERR_LINES);
+
+  while let Some(line) = lines.next_line().await.map_err(|error| {
+    Error::GameLaunchFailed(format!("failed to read output from {program}: {error}"))
+  })? {
+    let line = redact_launcher_output(&line, uri);
+    log::debug!("[{program}] {line}");
+    if captured.len() == CAPTURED_STDERR_LINES {
+      captured.pop_front();
+    }
+    captured.push_back(line);
+  }
+
+  Ok(captured.into_iter().collect::<Vec<_>>().join("\n"))
+}
+
+fn unsuccessful_exit_message(program: &Path, status: ExitStatus, stderr: &str) -> String {
+  if stderr.is_empty() {
+    format!(
+      "{} exited unsuccessfully while handling the Steam URI: {status}",
+      program.display()
+    )
+  } else {
+    format!(
+      "{} exited unsuccessfully while handling the Steam URI ({status}): {stderr}",
+      program.display()
+    )
+  }
+}
+
+fn redact_launcher_output(line: &str, uri: &str) -> String {
+  redact_password_args(&line.replace(uri, &redacted_steam_uri(uri)))
+}
+
+pub(super) fn redacted_steam_uri(uri: &str) -> String {
+  let without_connect_password = match uri.strip_prefix("steam://connect/") {
+    Some(rest) => {
+      let addr = rest.split('/').next().unwrap_or(rest);
+      format!("steam://connect/{addr}")
+    }
+    None => uri.to_string(),
+  };
+
+  redact_password_args(&without_connect_password)
+}
+
+fn redact_password_args(value: &str) -> String {
+  let mut parts = value.split(' ').peekable();
+  let mut out = Vec::new();
+  while let Some(part) = parts.next() {
+    out.push(part.to_string());
+    if part.eq_ignore_ascii_case("+password") && parts.peek().is_some() {
+      parts.next();
+      out.push("<redacted>".to_string());
+    }
+  }
+  out.join(" ")
+}
+
+#[cfg(test)]
+mod redaction_tests {
+  use super::*;
+
+  #[test]
+  fn redacts_connect_and_launch_passwords() {
+    assert_eq!(
+      redacted_steam_uri("steam://connect/203.0.113.10:27015/hunter2"),
+      "steam://connect/203.0.113.10:27015"
+    );
+    assert_eq!(
+      redacted_steam_uri(
+        "steam://run/1422450//+connect 203.0.113.10:27015 +password hunter2 -condebug"
+      ),
+      "steam://run/1422450//+connect 203.0.113.10:27015 +password <redacted> -condebug"
+    );
+  }
+}
+
+#[cfg(all(test, unix))]
+mod process_tests {
+  use std::fs;
+  use std::os::unix::fs::PermissionsExt;
+
+  use super::*;
+
+  fn fake_launcher(path: &Path, body: &str) -> PathBuf {
+    fs::write(path, format!("#!/bin/sh\n{body}\n")).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    path.to_path_buf()
+  }
+
+  #[tokio::test]
+  async fn reports_a_missing_program() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let request = SteamUriLaunchRequest::direct(
+      temp_dir.path().join("missing-launcher"),
+      "steam://run/1422450//".to_string(),
+    );
+
+    let result = request.spawn();
+
+    assert!(
+      matches!(result, Err(Error::GameLaunchFailed(ref message)) if message.contains("failed to spawn")),
+      "expected a spawn failure, got {result:?}"
+    );
+  }
+
+  #[tokio::test]
+  async fn reports_an_unsuccessful_exit_to_the_monitor() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let launcher = fake_launcher(
+      &temp_dir.path().join("fake-steam.sh"),
+      "echo 'no handler for Steam URI' >&2\nexit 3",
+    );
+    let request = SteamUriLaunchRequest::direct(launcher, "steam://run/1422450//".to_string());
+
+    let result = request.spawn().unwrap().wait().await;
+
+    assert!(
+      matches!(result, Err(Error::GameLaunchFailed(ref message)) if message.contains("no handler for Steam URI") && message.contains("exit status: 3")),
+      "expected stderr and exit status, got {result:?}"
+    );
+  }
+
+  #[tokio::test]
+  async fn hands_the_uri_to_the_program() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let recording_path = temp_dir.path().join("args.txt");
+    let launcher = fake_launcher(
+      &temp_dir.path().join("fake-steam.sh"),
+      &format!("printf '%s' \"$@\" > \"{}\"", recording_path.display()),
+    );
+    let request =
+      SteamUriLaunchRequest::direct(launcher, "steam://run/1422450//-condebug".to_string());
+
+    request.spawn().unwrap().wait().await.unwrap();
+
+    assert_eq!(
+      fs::read_to_string(recording_path).unwrap(),
+      "steam://run/1422450//-condebug"
+    );
+  }
+
+  #[tokio::test]
+  async fn reports_a_portal_timeout() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let launcher = fake_launcher(&temp_dir.path().join("fake-xdg-open"), "exec sleep 5");
+    let request = SteamUriLaunchRequest {
+      program: launcher,
+      uri: "steam://run/1422450//".to_string(),
+      completion: CompletionPolicy::Timeout(Duration::from_millis(20)),
+    };
+
+    let result = request.spawn().unwrap().wait().await;
+
+    assert!(
+      matches!(result, Err(Error::GameLaunchFailed(ref message)) if message.contains("did not finish")),
+      "expected a portal timeout, got {result:?}"
+    );
+  }
+}

--- a/apps/desktop/src/hooks/use-launch-map.ts
+++ b/apps/desktop/src/hooks/use-launch-map.ts
@@ -1,12 +1,15 @@
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
 import { enableAutoexecLaunchOptionIfDisabled } from "@/lib/autoexec/launch-option";
+import { getLaunchErrorMessage } from "@/lib/launch-error";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
 import { getAdditionalArgs } from "@/lib/utils";
 
 export const useLaunchMap = (onSuccess?: () => void) => {
+  const { t } = useTranslation();
   const getActiveProfile = usePersistedStore((state) => state.getActiveProfile);
   const queryClient = useQueryClient();
 
@@ -42,7 +45,11 @@ export const useLaunchMap = (onSuccess?: () => void) => {
     onError: (error) => {
       logger.errorOnly(error);
       toast.error(
-        error instanceof Error ? error.message : "An unexpected error occurred",
+        getLaunchErrorMessage(
+          error,
+          t("errors.gameLaunchFailed"),
+          t("errors.genericMessage"),
+        ),
       );
     },
   });

--- a/apps/desktop/src/hooks/use-launch.ts
+++ b/apps/desktop/src/hooks/use-launch.ts
@@ -6,11 +6,11 @@ import { useTranslation } from "react-i18next";
 import { useConfirm } from "@/components/providers/alert-dialog";
 import { stopHeroDetection } from "@/hooks/use-hero-detection";
 import { restoreProfileGameinfo } from "@/lib/gameinfo";
+import { getLaunchErrorMessage } from "@/lib/launch-error";
 import logger from "@/lib/logger";
 import { usePersistedStore } from "@/lib/store";
 import { getAdditionalArgs } from "@/lib/utils";
 import { ModStatus } from "@/types/mods";
-import type { ErrorKind } from "@/types/tauri";
 
 export const useLaunch = () => {
   const { t } = useTranslation();
@@ -128,7 +128,13 @@ export const useLaunch = () => {
     } catch (error) {
       console.error(error);
       logger.errorOnly(error);
-      toast.error((error as ErrorKind).message);
+      toast.error(
+        getLaunchErrorMessage(
+          error,
+          t("errors.gameLaunchFailed"),
+          t("errors.genericMessage"),
+        ),
+      );
     }
   };
 

--- a/apps/desktop/src/lib/launch-error.test.ts
+++ b/apps/desktop/src/lib/launch-error.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { getLaunchErrorMessage } from "./launch-error";
+
+describe("getLaunchErrorMessage", () => {
+  it("hides technical game launch details", () => {
+    const error = {
+      kind: "gameLaunchFailed",
+      message: "xdg-open exited with status 3: portal rejected request",
+    };
+
+    expect(getLaunchErrorMessage(error, "friendly message", "fallback")).toBe(
+      "friendly message",
+    );
+  });
+
+  it("preserves other Tauri error messages", () => {
+    const error = { kind: "gameNotFound", message: "Game not found" };
+
+    expect(getLaunchErrorMessage(error, "friendly message", "fallback")).toBe(
+      "Game not found",
+    );
+  });
+
+  it("uses the fallback for unrecognized errors", () => {
+    expect(getLaunchErrorMessage("failure", "friendly", "fallback")).toBe(
+      "fallback",
+    );
+  });
+});

--- a/apps/desktop/src/lib/launch-error.ts
+++ b/apps/desktop/src/lib/launch-error.ts
@@ -1,0 +1,15 @@
+import { isTauriError } from "@/types/tauri";
+
+export function getLaunchErrorMessage(
+  error: unknown,
+  gameLaunchFailedMessage: string,
+  fallbackMessage: string,
+): string {
+  if (isTauriError(error)) {
+    return error.kind === "gameLaunchFailed"
+      ? gameLaunchFailedMessage
+      : error.message;
+  }
+
+  return error instanceof Error ? error.message : fallbackMessage;
+}

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1960,6 +1960,7 @@
   },
   "errors": {
     "genericMessage": "Something went wrong.",
+    "gameLaunchFailed": "Deadlock couldn't be launched. Make sure Steam is running, then try again.",
     "errorCode": "Error code:",
     "tryAgain": "Try again",
     "goBack": "Go back",


### PR DESCRIPTION
## Description

Fix Linux game launches reporting success as soon as the launcher process is
spawned, even when Steam rejects the URI or Deadlock never starts.

- Monitor Steam URI launcher exit status and retain bounded, redacted stderr in
  the application log.
- Launch through `steam.sh` on native Linux and keep `xdg-open` for Flatpak.
- Confirm native launches from the Deadlock process and Flatpak launches from
  fresh `console.log` activity before returning success.
- Return launcher failures and game-start timeouts to the UI with a concise,
  actionable toast while keeping technical details in the log.
- Reuse the canonical game-start observer in the server connection flow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [x] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #570

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: OpenAI Codex, Used for: implementation, tests, code review, and Flatpak failure-injection verification

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes in both development and production-like environments

Manual verification:

- Built a Debian-compatible Wry package and isolated Flatpak bundle.
- Confirmed a real Flatpak Steam launch and observed
  `Confirmed Deadlock process started` after Deadlock wrote to `console.log`.
- Injected an `xdg-open` exit status of 3 and confirmed the failure returned to
  the UI while Deadlock remained closed.
- Left the installed Flatpak unchanged.

Automated verification:

- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib`
  (236 passed)
- `pnpm --filter @deadlock-mods/desktop test -- src/lib/launch-error.test.ts`
  (3 passed)
- `pnpm --filter @deadlock-mods/desktop check-types`
- `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --lib --tests`
- Targeted Oxlint checks for the changed frontend files

## Screenshots (if applicable)

Not applicable. The visible change is an error toast:
“Deadlock couldn't be launched. Make sure Steam is running, then try again.”

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested the changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

The missing `xdg-mime` executable used by Flatpak deep-link registration is
explicitly listed as adjacent scope in #570 and is unchanged by this PR.

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Affected package: `desktop`.
- Linux game launches now report Steam launcher failures and game-start timeouts instead of false success.
- Native Linux launches use `steam.sh` when available. Flatpak launches continue to use `xdg-open`.
- The desktop app monitors Steam exit status and Deadlock startup. It records bounded, redacted launcher stderr.
- The UI now shows localized, actionable launch error toasts.
- The server connection flow reuses the shared game-start observer.
- Process detection supports native and Proton-launched Deadlock processes.
- Added coverage for launcher selection, failures, timeouts, redaction, process detection, startup monitoring, cancellation, and UI error mapping.
- Added a changeset for `@deadlock-mods/desktop`.

No API, bot, www, docs, shared-package, database, Tauri plugin, or Rust FFI changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->