### PR TITLE
fix(desktop): mods enabled counter

### DIFF
--- a/.changeset/brisk-owls-count.md
+++ b/.changeset/brisk-owls-count.md
@@ -2,4 +2,4 @@
 "@deadlock-mods/desktop": patch
 ---
 
-Fix the profile manager counting mods that were deleted or cleared under "Enabled mods", and show each profile's own mod names when expanding its list
+Fix enabled mod counts and profile mod names

--- a/.changeset/brisk-owls-count.md
+++ b/.changeset/brisk-owls-count.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix the profile manager counting mods that were deleted or cleared under "Enabled mods", and show each profile's own mod names when expanding its list

--- a/apps/desktop/src/components/profiles/profile-manager-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-manager-dialog.tsx
@@ -166,12 +166,10 @@ export const ProfileManagerDialog = ({
 
     const enabledMods: ModInfo[] = enabledEntries
       .map((entry) => {
-        const localMod = localMods.find(
-          (mod) => mod.remoteId === entry.remoteId,
-        );
-        return localMod
-          ? { name: localMod.name, remoteId: entry.remoteId }
-          : null;
+        const mod =
+          (profile.mods ?? []).find((m) => m.remoteId === entry.remoteId) ??
+          localMods.find((m) => m.remoteId === entry.remoteId);
+        return mod ? { name: mod.name, remoteId: entry.remoteId } : null;
       })
       .filter((mod): mod is ModInfo => mod !== null);
 
@@ -299,7 +297,7 @@ export const ProfileManagerDialog = ({
                           {getEnabledModsInfo(profile).count}
                         </Badge>
                       </div>
-                      {getEnabledModsInfo(profile).count > 0 && (
+                      {getEnabledModsInfo(profile).mods.length > 0 && (
                         <button
                           onClick={() => toggleProfileExpanded(profile.id)}
                           className='flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors cursor-pointer'>

--- a/apps/desktop/src/lib/store/slices/mods.test.ts
+++ b/apps/desktop/src/lib/store/slices/mods.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { create } from "zustand";
+
+const noop = () => {};
+const loggerMock: Record<string, unknown> = {
+  withMetadata: () => loggerMock,
+  withError: () => loggerMock,
+  warn: noop,
+  error: noop,
+  info: noop,
+};
+
+mock.module("@/lib/logger", () => ({
+  createLogger: () => loggerMock,
+  default: loggerMock,
+}));
+
+import type { LocalMod } from "@/types/mods";
+import { ModStatus } from "@/types/mods";
+import type { ModProfile, ProfileId } from "@/types/profiles";
+import { createProfileId } from "@/types/profiles";
+import { createModsSlice, type ModsState } from "./mods";
+
+type TestState = ModsState & {
+  profiles: Record<string, ModProfile>;
+  activeProfileId: ProfileId;
+};
+
+const modFor = (remoteId: string): LocalMod =>
+  ({
+    id: `mod_${remoteId}`,
+    remoteId,
+    name: `Mod ${remoteId}`,
+    status: ModStatus.Installed,
+    installedVpks: [`pak0${remoteId}_dir.vpk`],
+  }) as LocalMod;
+
+const profileFor = (id: string, remoteIds: string[]): ModProfile => ({
+  id: createProfileId(id),
+  name: id,
+  createdAt: new Date(),
+  enabledMods: Object.fromEntries(
+    remoteIds.map((remoteId) => [
+      remoteId,
+      { remoteId, enabled: true, lastModified: new Date() },
+    ]),
+  ),
+  isDefault: id === "default",
+  folderName: id === "default" ? null : `profile_1_${id}`,
+  mods: remoteIds.map(modFor),
+});
+
+const createTestStore = () =>
+  create<TestState>()((set, get, store) => ({
+    ...createModsSlice(
+      set as Parameters<typeof createModsSlice>[0],
+      get as Parameters<typeof createModsSlice>[1],
+      store as Parameters<typeof createModsSlice>[2],
+    ),
+    profiles: {},
+    activeProfileId: createProfileId("default"),
+  }));
+
+let store: ReturnType<typeof createTestStore>;
+
+beforeEach(() => {
+  store = createTestStore();
+  store.setState({
+    localMods: [modFor("1"), modFor("2")],
+    modProgress: { "1": { percentage: 100 } },
+    profiles: {
+      default: profileFor("default", ["1", "2"]),
+      secondary: profileFor("secondary", ["1"]),
+    },
+    activeProfileId: createProfileId("default"),
+  });
+});
+
+describe("removeMod", () => {
+  it("clears the mod from the active profile's enabled mods", () => {
+    store.getState().removeMod("1");
+
+    const active = store.getState().profiles.default;
+    expect(active.enabledMods["1"]).toBeUndefined();
+    expect(Object.keys(active.enabledMods)).toEqual(["2"]);
+    expect(active.mods.map((mod) => mod.remoteId)).toEqual(["2"]);
+    expect(store.getState().localMods.map((mod) => mod.remoteId)).toEqual([
+      "2",
+    ]);
+    expect(store.getState().modProgress["1"]).toBeUndefined();
+  });
+
+  it("leaves other profiles alone, since their copy is still installed", () => {
+    store.getState().removeMod("1");
+
+    const secondary = store.getState().profiles.secondary;
+    expect(secondary.enabledMods["1"]?.enabled).toBe(true);
+    expect(secondary.mods.map((mod) => mod.remoteId)).toEqual(["1"]);
+  });
+
+  it("is a no-op on profiles that never had the mod enabled", () => {
+    store.setState({
+      profiles: {
+        default: profileFor("default", ["2"]),
+      },
+    });
+
+    store.getState().removeMod("1");
+
+    expect(Object.keys(store.getState().profiles.default.enabledMods)).toEqual([
+      "2",
+    ]);
+  });
+});
+
+describe("clearMods", () => {
+  it("empties the active profile's snapshot along with the library", () => {
+    store.getState().clearMods();
+
+    const active = store.getState().profiles.default;
+    expect(store.getState().localMods).toEqual([]);
+    expect(store.getState().modProgress).toEqual({});
+    expect(active.mods).toEqual([]);
+    expect(active.enabledMods).toEqual({});
+  });
+
+  it("leaves other profiles alone, since their copy is still installed", () => {
+    store.getState().clearMods();
+
+    const secondary = store.getState().profiles.secondary;
+    expect(secondary.mods.map((mod) => mod.remoteId)).toEqual(["1"]);
+    expect(secondary.enabledMods["1"]?.enabled).toBe(true);
+  });
+
+  it("still clears the library when there is no active profile", () => {
+    store.setState({ profiles: {} });
+
+    store.getState().clearMods();
+
+    expect(store.getState().localMods).toEqual([]);
+    expect(store.getState().profiles).toEqual({});
+  });
+});

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -283,9 +283,13 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       const currentProfile = profiles[activeProfileId];
 
       if (currentProfile) {
+        const { [remoteId]: _removed, ...remainingEnabledMods } =
+          currentProfile.enabledMods ?? {};
+
         const updatedProfile = {
           ...currentProfile,
           mods: currentProfile.mods.filter((mod) => mod.remoteId !== remoteId),
+          enabledMods: remainingEnabledMods,
         };
 
         return {
@@ -306,7 +310,25 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   setMods: (mods) => set({ localMods: mods }),
 
-  clearMods: () => set({ localMods: [], modProgress: {} }),
+  clearMods: () =>
+    set((state) => {
+      const currentProfile = state.profiles[state.activeProfileId];
+
+      return {
+        localMods: [],
+        modProgress: {},
+        profiles: currentProfile
+          ? {
+              ...state.profiles,
+              [state.activeProfileId]: {
+                ...currentProfile,
+                mods: [],
+                enabledMods: {},
+              },
+            }
+          : state.profiles,
+      };
+    }),
 
   setModProgress: (remoteId, progress) =>
     set((state) => ({


### PR DESCRIPTION
## Description

Fixes the "Enabled mods" counter in the profile manager reporting mods that no
longer exist, and the expanded mod list rendering empty for inactive profiles.

Three changes, all in the desktop app:

- **`removeMod`** (`slices/mods.ts`) — deleting a mod filtered it out of
  `localMods`, `modProgress`, and `profile.mods`, but left its
  `profile.enabledMods[remoteId]` entry behind. The profile manager badge counts
  `enabledMods`, so a deleted mod kept being counted with no way to clear it.
  The entry is now dropped alongside the others.
- **`clearMods`** (`slices/mods.ts`) — only reset `localMods` and `modProgress`,
  never the active profile's snapshot. The badge kept counting mods that had just
  been cleared, and the next profile switch reloaded `localMods` from the stale
  snapshot, undoing the clear. It now empties the active profile's `mods` and
  `enabledMods` in the same update.
- **`getEnabledModsInfo`** (`profile-manager-dialog.tsx`) — resolved mod names
  against `localMods`, which only holds the *active* profile's mods, so every
  other profile expanded to a blank list. It now resolves against the profile's
  own `mods` snapshot first, falling back to `localMods`. The "Show" toggle is
  gated on resolved names rather than the raw count so it can't open onto nothing.

Other profiles are deliberately left untouched on delete and clear — their VPKs
are still in their own addons folders (`purge_mod` only strips the active
profile's), so their counts stay truthful.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Fixes #622 

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code (Opus 5) and GPT-5.6 Terra. Used for: tracing the counter
      through the profile/store slices, implementing the three fixes, and reviewing the change.

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Added `apps/desktop/src/lib/store/slices/mods.test.ts` — six tests covering both
store fixes: `removeMod` drops the `enabledMods` entry and leaves other profiles
alone; `clearMods` empties the active profile's snapshot, leaves other profiles
alone, and still clears the library when there is no active profile.

Desktop suite: 220 pass / 0 fail across 25 files. `pnpm lint` and
`pnpm check-types` clean.

## Screenshots (if applicable)

Before:

https://github.com/user-attachments/assets/990012da-84d9-4978-b62d-ea0663b74c2b

After:

https://github.com/user-attachments/assets/b377c595-dc29-4b18-a631-161f0a5fdf96



## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed the desktop profile manager’s `Enabled mods` count after mod deletion or clearing.
- Kept the active profile’s `mods` and `enabledMods` snapshots in sync.
- Resolved displayed mod names from profile snapshots, with fallback to `localMods`.
- Showed the `Show` control only when resolved mod names are available.
- Added six store tests covering active and unaffected profiles.

No API, bot, www, docs, shared-package, database, Tauri plugin, or Rust FFI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->