### PR TITLE
fix(desktop): stop hero conflict dialog clicks from opening the mod page

### DIFF
--- a/.changeset/swift-skins-swap.md
+++ b/.changeset/swift-skins-swap.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix hero mod swaps from the mod store not applying

--- a/apps/desktop/src/components/mod-browsing/hero-conflict-dialog.tsx
+++ b/apps/desktop/src/components/mod-browsing/hero-conflict-dialog.tsx
@@ -85,7 +85,9 @@ export const HeroConflictDialog = ({
 
   return (
     <AlertDialog onOpenChange={handleOpenChange} open={open}>
-      <AlertDialogContent className='gap-0 overflow-hidden p-0 sm:max-w-2xl'>
+      <AlertDialogContent
+        className='gap-0 overflow-hidden p-0 sm:max-w-2xl'
+        onClick={(e) => e.stopPropagation()}>
         <div className='flex items-start gap-3 border-b border-border/60 bg-muted/30 px-6 pt-5 pb-4'>
           <Avatar className='size-10 ring-1 ring-border/60'>
             {heroImage && <AvatarImage alt={heroName} src={heroImage} />}


### PR DESCRIPTION
Portalled dialog clicks bubbled into ModCard's card onClick and navigated away, unmounting the dialog before the swap animation resolved it.

## Description

In the Mods Store, resolving a hero conflict did nothing: clicking **Swap** sent
you to the mod's detail page with neither mod changed, so you had to enable it
there and answer the same dialog a second time. The same flow worked correctly in
the Mods Library.

`HeroConflictDialog` renders through a Radix portal, but React synthetic events
still bubble along the *React* tree, not the DOM tree. In the store that path
leads into `ModCard`'s card-level `onClick`, the only `navigate()` call in the
`mod-browsing` tree, which opens `/mods/:remoteId`. Every button in the dialog
left the page — Cancel and Keep both included.

Swap was the one that lost data. It resolves from the swap animation's
`onAnimationEnd` rather than from the click, so navigating unmounted the dialog
before that fired: the pending `askHeroConflict` promise never settled, and
neither the uninstall of the active mod nor the install of the new one ran.

The Mods Library was unaffected only because it binds navigation to the card
image and title rather than to the whole card — it runs the identical
`ModButton` swap code.

The fix stops propagation at the dialog content, matching the guard
`FileSelectorDialog` and `MultiFileDownloadDialog` already carry.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Fixes #541 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Code (Opus 5), Used for: tracing the store vs.
      library difference to the portal event path, and writing the one-line fix.

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

`pnpm lint` — 0 errors (96 pre-existing warnings, none in the changed file)
`pnpm check-types` — 11/11 tasks pass
`pnpm --filter desktop test` — 217 pass, 0 fail

## Screenshots (if applicable)

Before:

https://github.com/user-attachments/assets/13890302-f7c5-4bfd-8989-33d0408e4e9b

After:

https://github.com/user-attachments/assets/af06d1a6-6402-4cd6-b3b4-526d963e05d1

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed hero mod swaps in the desktop Mods Store.
- Stopped clicks in `HeroConflictDialog` from bubbling to `ModCard` navigation.
- Kept the dialog mounted so the swap animation can uninstall the active mod and install the new mod.
- Added a patch changeset for `@deadlock-mods/desktop`.
- No API, bot, web, docs, shared-package, database, Tauri, or Rust FFI changes.
- Local lint, type-check, and desktop tests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->