### PR TITLE
feat(vpkmanager): stamp mod identity into VPKs

### DIFF
--- a/.changeset/calm-stamps-ignore.md
+++ b/.changeset/calm-stamps-ignore.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/vpk-parser": patch
+---
+
+Ignore mod manager fingerprint stamps when hashing VPK content

--- a/packages/vpk-parser/Cargo.lock
+++ b/packages/vpk-parser/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bcdec_rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09c37bc0e9f0924b7dae9988265ef3c76c88538f41a3b06caf4bed07cee5226"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,15 +46,47 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -78,6 +128,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,10 +203,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.4"
+name = "either"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -126,10 +302,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.64"
+name = "half"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -150,6 +344,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "intel_tex_2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7980d359170e7da4bc2421aa74c49d338a3153313e006d732a3430f1af375a60"
+dependencies = [
+ "ispc_rt",
+]
+
+[[package]]
+name = "ispc_rt"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a396f76fd253fab9945bb4c6080f515d0c4036bc30219462d199b58886fd37b4"
+dependencies = [
+ "libc",
+ "num_cpus",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,31 +398,65 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
 
 [[package]]
 name = "num-traits"
@@ -193,10 +468,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "num_cpus"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -215,6 +519,27 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -261,10 +586,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -299,7 +666,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -328,9 +695,21 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -341,6 +720,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -369,7 +772,21 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -391,7 +808,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "termcolor",
 ]
 
@@ -431,25 +848,50 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "ts-rs",
  "twox-hash",
+ "vpkmanager",
+]
+
+[[package]]
+name = "vpkmanager"
+version = "0.1.0"
+dependencies = [
+ "bcdec_rs",
+ "bitflags",
+ "bytemuck",
+ "byteorder",
+ "crc",
+ "half",
+ "image",
+ "intel_tex_2",
+ "log",
+ "lz4_flex",
+ "rayon",
+ "ruzstd",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -460,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -470,25 +912,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi-util"
@@ -520,7 +968,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -531,7 +979,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -569,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
@@ -590,5 +1038,20 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/packages/vpk-parser/Cargo.toml
+++ b/packages/vpk-parser/Cargo.toml
@@ -21,6 +21,10 @@ ts-rs = { version = "11.1.0", features = ["serde-compat", "chrono-impl"] }
 
 libc = "0.2"
 
+[dev-dependencies]
+tempfile = "3"
+vpkmanager = { path = "../vpkmanager" }
+
 [profile.release]
 lto = true
 opt-level = "z" # Optimize for size

--- a/packages/vpk-parser/src-rs/parser.rs
+++ b/packages/vpk-parser/src-rs/parser.rs
@@ -244,6 +244,7 @@ impl VpkParser {
     fn generate_manifest_hash(&self, entries: &[VpkEntry]) -> String {
         let mut lines: Vec<String> = entries
             .iter()
+            .filter(|entry| !is_mod_manager_stamp(entry))
             .map(|entry| {
                 format!(
                     "{}\x00{}\n",
@@ -289,7 +290,10 @@ impl VpkParser {
             sha256,
             content_signature,
             vpk_version: self.get_vpk_version(),
-            file_count: entries.len(),
+            file_count: entries
+                .iter()
+                .filter(|entry| !is_mod_manager_stamp(entry))
+                .count(),
             has_multiparts,
             has_inline_data,
             merkle_root,
@@ -319,6 +323,9 @@ impl VpkParser {
         let filtered_entries: Vec<&VpkEntry> = entries
             .iter()
             .filter(|entry| {
+                if is_mod_manager_stamp(entry) {
+                    return false;
+                }
                 let filename = entry.filename.to_lowercase();
                 let full_path = entry.full_path.to_lowercase();
                 if junk_files.contains(filename.as_str()) {
@@ -350,6 +357,7 @@ impl VpkParser {
     fn generate_merkle_hash(&self, entries: &[VpkEntry]) -> MerkleData {
         let leaves: Vec<String> = entries
             .iter()
+            .filter(|entry| !is_mod_manager_stamp(entry))
             .map(|entry| {
                 let entry_data = format!(
                     "{}|{}|{}",
@@ -445,5 +453,70 @@ impl VpkParser {
             Ok(s) => Ok(s),
             Err(_) => Ok(string_bytes.iter().map(|&b| b as char).collect()),
         }
+    }
+}
+
+/// The desktop manager stamps `.dmm/fingerprint.dmm` into VPKs it owns.
+/// Those entries must not participate in lockdex content hashes: the stored
+/// `vpk` table is built from unstamped GameBanana downloads, so a stamp would
+/// miss every match tier that is derived from the entry list.
+fn is_mod_manager_stamp(entry: &VpkEntry) -> bool {
+    entry.ext.eq_ignore_ascii_case("dmm") && entry.path.eq_ignore_ascii_case(".dmm")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(full_path: &str, path: &str, filename: &str, ext: &str, length: u32) -> VpkEntry {
+        VpkEntry {
+            full_path: full_path.to_string(),
+            path: path.to_string(),
+            filename: filename.to_string(),
+            ext: ext.to_string(),
+            crc32_hex: "aabbccdd".to_string(),
+            preload_bytes: 0,
+            archive_index: 0x7fff,
+            entry_offset: 0,
+            entry_length: length,
+            terminator: 0xffff,
+        }
+    }
+
+    fn stamp_entry() -> VpkEntry {
+        entry(".dmm/fingerprint.dmm", ".dmm", "fingerprint", "dmm", 128)
+    }
+
+    fn skin_entry() -> VpkEntry {
+        entry("models/heroes/skin.vmdl_c", "models/heroes", "skin", "vmdl_c", 64)
+    }
+
+    #[test]
+    fn content_signature_and_merkle_ignore_mod_manager_stamps() {
+        let parser = VpkParser::new(Vec::new());
+        let without = [skin_entry()];
+        let with_stamp = [skin_entry(), stamp_entry()];
+
+        assert_eq!(
+            parser.generate_content_signature(&without),
+            parser.generate_content_signature(&with_stamp)
+        );
+        assert_eq!(
+            parser.generate_merkle_hash(&without).root,
+            parser.generate_merkle_hash(&with_stamp).root
+        );
+        assert_eq!(
+            parser.generate_manifest_hash(&without),
+            parser.generate_manifest_hash(&with_stamp)
+        );
+    }
+
+    #[test]
+    fn file_count_excludes_mod_manager_stamps() {
+        let parser = VpkParser::new(vec![0, 0, 0, 0, 2, 0, 0, 0]);
+        let fingerprint = parser
+            .generate_fingerprint(&[skin_entry(), stamp_entry()], "mod.vpk", None, true)
+            .unwrap();
+        assert_eq!(fingerprint.file_count, 1);
     }
 }

--- a/packages/vpk-parser/tests/stamp_hashes.rs
+++ b/packages/vpk-parser/tests/stamp_hashes.rs
@@ -1,0 +1,40 @@
+use std::fs;
+
+use vpk_parser::{VpkParseOptions, VpkParser};
+
+fn parse(path: &std::path::Path) -> vpk_parser::VpkParsed {
+    VpkParser::parse(
+        fs::read(path).expect("read VPK"),
+        VpkParseOptions {
+            include_full_file_hash: false,
+            file_path: path.to_string_lossy().to_string(),
+            last_modified: None,
+            include_merkle: true,
+            include_entries: true,
+        },
+    )
+    .expect("parse VPK")
+}
+
+#[test]
+fn stamping_does_not_change_lockdex_content_hashes() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("src");
+    fs::create_dir_all(source.join("models/heroes")).unwrap();
+    fs::write(source.join("models/heroes/skin.vmdl_c"), b"model bytes").unwrap();
+    let vpk = temp.path().join("mod.vpk");
+    vpkmanager::pack_directory(&source, &vpk).unwrap();
+
+    let before = parse(&vpk);
+    vpkmanager::fingerprint::stamp(&vpk, "650634", "cool_mod.vpk").unwrap();
+    let after = parse(&vpk);
+
+    assert_eq!(
+        before.fingerprint.content_signature,
+        after.fingerprint.content_signature
+    );
+    assert_eq!(before.fingerprint.merkle_root, after.fingerprint.merkle_root);
+    assert_eq!(before.fingerprint.file_count, after.fingerprint.file_count);
+    assert_eq!(before.manifest_sha256, after.manifest_sha256);
+    assert_eq!(after.entries.len(), before.entries.len() + 1);
+}

--- a/packages/vpkmanager/Cargo.lock
+++ b/packages/vpkmanager/Cargo.lock
@@ -27,6 +27,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +72,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -120,10 +138,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -148,6 +202,27 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -216,16 +291,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -265,6 +364,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "png"
@@ -319,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,12 +450,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ruzstd"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -373,6 +551,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -416,10 +607,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpkmanager"
@@ -433,9 +636,14 @@ dependencies = [
  "half",
  "image",
  "intel_tex_2",
+ "log",
  "lz4_flex",
  "rayon",
  "ruzstd",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror",
 ]
 
@@ -444,6 +652,21 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zerocopy"
@@ -464,6 +687,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/packages/vpkmanager/Cargo.toml
+++ b/packages/vpkmanager/Cargo.toml
@@ -14,6 +14,9 @@ path = "src/lib.rs"
 thiserror = "2.0"
 crc = "3.0"
 log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 # Vendored Source 2 codecs (see src/source2). These are their dependencies.
 bitflags = "2"
 byteorder = "1"

--- a/packages/vpkmanager/Cargo.toml
+++ b/packages/vpkmanager/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 thiserror = "2.0"
 crc = "3.0"
+log = "0.4"
 # Vendored Source 2 codecs (see src/source2). These are their dependencies.
 bitflags = "2"
 byteorder = "1"
@@ -41,3 +42,6 @@ image = { version = "0.25", default-features = false, features = [
   "tiff",
   "webp",
 ] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/packages/vpkmanager/README.md
+++ b/packages/vpkmanager/README.md
@@ -5,6 +5,13 @@ replacing compiled textures, swapping sounds, and packing a directory tree back
 into a loadable VPK. The read/render half — decoding models to glTF for the 3D
 preview — lives in `source2-model`.
 
+Each VPK the manager takes responsibility for is stamped with a fingerprint
+stored *inside* it, at `.dmm/fingerprint.dmm`. Stamping is additive: the entry
+is appended to the VPK's directory tree and its bytes to the end of the data
+section. VPK entry offsets are relative to the data section, so every existing
+file keeps its offset, and entries in `_NNN.vpk` companions are not touched at
+all. A stamped VPK loads exactly as the unstamped one did.
+
 ## Third-party code
 
 `src/source2/` is vendored from the `morphic` crate of

--- a/packages/vpkmanager/src/fingerprint.rs
+++ b/packages/vpkmanager/src/fingerprint.rs
@@ -1,0 +1,441 @@
+//! The identity a mod manager stamps into a VPK so it can always find it again.
+//!
+//! A profile's ledger records where every mod's VPKs are, but a filename is a
+//! weak key: users rename files, drag them between `addons` folders, restore an
+//! old backup, or copy a VPK in by hand. A fingerprint survives all of that. It
+//! is a small JSON document stored *inside* the VPK, at `.dmm/fingerprint.dmm`,
+//! so wherever the file ends up its owning mod can be read straight back out of
+//! it.
+//!
+//! Stamping is deliberately additive: [`crate::vpkdir`] appends the entry
+//! without moving any existing file's bytes, and the `dmm` extension is one no
+//! Source 2 asset uses, so the engine loads a stamped VPK exactly as it loaded
+//! the unstamped one.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::{Result, VpkManagerError};
+use crate::vpkdir::VpkDir;
+
+/// Where the stamp lives inside the VPK: `.dmm/fingerprint.dmm`.
+pub const FINGERPRINT_EXT: &str = "dmm";
+pub const FINGERPRINT_DIR: &str = ".dmm";
+pub const FINGERPRINT_NAME: &str = "fingerprint";
+
+/// Payload format version, bumped when the fields below change meaning.
+pub const FINGERPRINT_VERSION: u32 = 1;
+
+/// Distinguishes two stamps issued in the same second for identical content.
+///
+/// Seeded from the process id and start time: a plain counter would restart at
+/// zero, so two runs of the app stamping copies of one download within the same
+/// second would mint the same id and the ledger would lose one of the files.
+static ISSUE_COUNTER: LazyLock<AtomicU64> = LazyLock::new(|| {
+    let mut hasher = Sha256::new();
+    hasher.update(std::process::id().to_le_bytes());
+    hasher.update(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|since| since.as_nanos())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    let mut seed = [0u8; 8];
+    seed.copy_from_slice(&hasher.finalize()[..8]);
+    AtomicU64::new(u64::from_le_bytes(seed))
+});
+
+/// Keeps concurrent stamps of one VPK off each other's temp file. Process-local
+/// is enough because the process id goes into the name alongside it.
+static STAMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// The stamp carried by a VPK the mod manager has taken responsibility for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VpkFingerprint {
+    pub version: u32,
+    /// Unique per physical VPK file, even between two copies of one download.
+    pub id: String,
+    /// The mod this file belongs to, as the mod manager knows it.
+    pub mod_id: String,
+    /// The filename the mod shipped with, before any `pak##_dir.vpk` renaming.
+    pub original_name: String,
+    /// Unix seconds; when this stamp was issued.
+    pub issued_at: u64,
+    /// SHA-256 of the VPK's canonical unstamped form. Equal for two copies of
+    /// the same file, so it identifies *content* where `id` identifies a file.
+    pub content_hash: String,
+}
+
+impl VpkFingerprint {
+    fn new(mod_id: &str, original_name: &str, content_hash: String) -> Self {
+        let issued_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|since| since.as_secs())
+            .unwrap_or_default();
+        let nonce = ISSUE_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+        let mut hasher = Sha256::new();
+        hasher.update(content_hash.as_bytes());
+        hasher.update(mod_id.as_bytes());
+        hasher.update(original_name.as_bytes());
+        hasher.update(issued_at.to_le_bytes());
+        hasher.update(nonce.to_le_bytes());
+        let id = hasher
+            .finalize()
+            .iter()
+            .take(16)
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+
+        Self {
+            version: FINGERPRINT_VERSION,
+            id,
+            mod_id: mod_id.to_string(),
+            original_name: original_name.to_string(),
+            issued_at,
+            content_hash,
+        }
+    }
+}
+
+/// What [`inspect`] found inside a VPK.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StampInspect {
+    Present(VpkFingerprint),
+    Absent,
+    ForeignVersion,
+}
+
+/// Read the fingerprint of a VPK on disk.
+///
+/// Only the VPK's header, entry tree and the stamp itself are read, so this
+/// stays cheap enough to run over every file in a profile.
+///
+/// Returns `Ok(None)` for a VPK that has never been stamped, whose stamp is
+/// unreadable, or whose stamp was written by a newer version. Callers that
+/// must not overwrite a newer stamp should use [`inspect`].
+pub fn read(path: &Path) -> Result<Option<VpkFingerprint>> {
+    match inspect(path)? {
+        StampInspect::Present(fingerprint) => Ok(Some(fingerprint)),
+        StampInspect::Absent | StampInspect::ForeignVersion => Ok(None),
+    }
+}
+
+/// Classify the stamp on `path` without treating a newer-version stamp as
+/// missing.
+pub fn inspect(path: &Path) -> Result<StampInspect> {
+    let payload = crate::vpkdir::read_entry_from_file(
+        path,
+        FINGERPRINT_EXT,
+        FINGERPRINT_DIR,
+        FINGERPRINT_NAME,
+    )?;
+    Ok(payload
+        .as_deref()
+        .map(classify_payload)
+        .unwrap_or(StampInspect::Absent))
+}
+
+fn classify_payload(payload: &[u8]) -> StampInspect {
+    match serde_json::from_slice::<VpkFingerprint>(payload) {
+        Ok(fingerprint) if fingerprint.version <= FINGERPRINT_VERSION => {
+            StampInspect::Present(fingerprint)
+        }
+        Ok(fingerprint) => {
+            log::warn!(
+                "Ignoring VPK fingerprint written by a newer version ({})",
+                fingerprint.version
+            );
+            StampInspect::ForeignVersion
+        }
+        Err(error) => {
+            log::warn!("Ignoring unreadable VPK fingerprint: {error}");
+            StampInspect::Absent
+        }
+    }
+}
+
+/// Stamp `path` with a fingerprint for `mod_id`, replacing any stamp already
+/// there, and return it.
+///
+/// The file is rewritten through a sibling temp file and renamed into place, so
+/// an interrupted stamp leaves the original VPK untouched.
+pub fn stamp(path: &Path, mod_id: &str, original_name: &str) -> Result<VpkFingerprint> {
+    let mut dir = VpkDir::parse(fs::read(path)?)?;
+    let content_hash = content_hash(&mut dir)?;
+    let fingerprint = VpkFingerprint::new(mod_id, original_name, content_hash);
+    write_stamp(path, dir, &fingerprint)?;
+    Ok(fingerprint)
+}
+
+/// SHA-256 of the VPK with any existing stamp removed, so re-stamping the same
+/// file does not change its content hash.
+fn content_hash(dir: &mut VpkDir) -> Result<String> {
+    dir.remove(FINGERPRINT_EXT, FINGERPRINT_DIR, FINGERPRINT_NAME);
+    let mut hasher = Sha256::new();
+    hasher.update(dir.to_bytes()?);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+pub(crate) fn write_foreign_stamp(path: &Path, fingerprint: VpkFingerprint) -> Result<()> {
+    let mut foreign = fingerprint;
+    foreign.version = FINGERPRINT_VERSION + 1;
+    let dir = VpkDir::parse(fs::read(path)?)?;
+    write_stamp(path, dir, &foreign)
+}
+
+fn write_stamp(path: &Path, mut dir: VpkDir, fingerprint: &VpkFingerprint) -> Result<()> {
+    let payload = serde_json::to_vec(fingerprint)
+        .map_err(|error| VpkManagerError::Vpk(format!("failed to encode fingerprint: {error}")))?;
+    dir.upsert_inline(FINGERPRINT_EXT, FINGERPRINT_DIR, FINGERPRINT_NAME, &payload);
+    let bytes = dir.to_bytes()?;
+
+    let temp = temp_path(path);
+    // The rename below replaces the only copy of the original, so the new bytes
+    // have to reach the disk before it runs. Without the flush, losing power in
+    // that window leaves a VPK whose stamped directory has no data behind it.
+    let written = fs::File::create(&temp).and_then(|mut file| {
+        file.write_all(&bytes)?;
+        file.sync_all()
+    });
+    if let Err(error) = written {
+        let _ = fs::remove_file(&temp);
+        return Err(error.into());
+    }
+    if let Err(error) = fs::rename(&temp, path) {
+        let _ = fs::remove_file(&temp);
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+/// A temp name unique to this stamp, so a background backfill pass and a stamp
+/// the user triggered cannot land on the same path and truncate each other.
+fn temp_path(path: &Path) -> PathBuf {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "vpk".to_string());
+    let nonce = STAMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    path.with_file_name(format!(".{name}.{pid}-{nonce}.dmm-stamp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pack::pack_directory;
+
+    /// Build a VPK holding a couple of files, the way a packed mod looks.
+    fn sample_vpk(dir: &Path) -> PathBuf {
+        let source = dir.join("src");
+        fs::create_dir_all(source.join("models/heroes")).unwrap();
+        fs::write(source.join("models/heroes/skin.vmdl_c"), b"model bytes").unwrap();
+        fs::write(source.join("readme.txt"), b"hello").unwrap();
+        let vpk = dir.join("mod.vpk");
+        pack_directory(&source, &vpk).unwrap();
+        vpk
+    }
+
+    fn entry_bytes(path: &Path, full_path: &str) -> Vec<u8> {
+        let dir = VpkDir::parse(fs::read(path).unwrap()).unwrap();
+        let entry = dir
+            .entries()
+            .iter()
+            .find(|entry| entry.full_path() == full_path)
+            .expect("entry is missing");
+        dir.entry_data(entry).expect("entry has no data").to_vec()
+    }
+
+    #[test]
+    fn stamping_preserves_every_other_file_in_the_vpk() {
+        let temp = tempfile::tempdir().unwrap();
+        let vpk = sample_vpk(temp.path());
+        let before: Vec<_> = VpkDir::parse(fs::read(&vpk).unwrap())
+            .unwrap()
+            .entries()
+            .iter()
+            .map(|entry| (entry.full_path(), entry.crc32))
+            .collect();
+
+        stamp(&vpk, "650634", "cool_mod.vpk").unwrap();
+
+        let after = VpkDir::parse(fs::read(&vpk).unwrap()).unwrap();
+        for (full_path, crc32) in before {
+            let entry = after
+                .entries()
+                .iter()
+                .find(|entry| entry.full_path() == full_path)
+                .unwrap_or_else(|| panic!("{full_path} disappeared"));
+            assert_eq!(entry.crc32, crc32, "{full_path} changed");
+            assert_eq!(
+                crate::pack::checksum(after.entry_data(entry).unwrap()),
+                crc32,
+                "{full_path} no longer resolves to its own bytes"
+            );
+        }
+        assert_eq!(
+            entry_bytes(&vpk, "models/heroes/skin.vmdl_c"),
+            b"model bytes"
+        );
+    }
+
+    #[test]
+    fn a_stamp_round_trips_through_the_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let vpk = sample_vpk(temp.path());
+
+        let written = stamp(&vpk, "650634", "cool_mod.vpk").unwrap();
+        let read_back = read(&vpk).unwrap().unwrap();
+
+        assert_eq!(read_back, written);
+        assert_eq!(read_back.mod_id, "650634");
+        assert_eq!(read_back.original_name, "cool_mod.vpk");
+        assert_eq!(read_back.id.len(), 32);
+    }
+
+    #[test]
+    fn an_unstamped_vpk_reports_no_fingerprint() {
+        let temp = tempfile::tempdir().unwrap();
+        let vpk = sample_vpk(temp.path());
+
+        assert!(read(&vpk).unwrap().is_none());
+    }
+
+    /// Re-stamping must not pile up copies of the old payload, and must keep
+    /// the content hash — the identity of the *content* — stable.
+    #[test]
+    fn restamping_replaces_the_previous_stamp() {
+        let temp = tempfile::tempdir().unwrap();
+        let vpk = sample_vpk(temp.path());
+
+        let first = stamp(&vpk, "650634", "cool_mod.vpk").unwrap();
+        let size_after_first = fs::metadata(&vpk).unwrap().len();
+        let second = stamp(&vpk, "local-abc", "renamed.vpk").unwrap();
+        let size_after_second = fs::metadata(&vpk).unwrap().len();
+
+        assert_eq!(read(&vpk).unwrap().unwrap(), second);
+        assert_eq!(second.content_hash, first.content_hash);
+        assert_ne!(second.id, first.id);
+        assert!(
+            size_after_second <= size_after_first + 16,
+            "re-stamping grew the VPK by {} bytes",
+            size_after_second - size_after_first
+        );
+
+        let dir = VpkDir::parse(fs::read(&vpk).unwrap()).unwrap();
+        assert_eq!(
+            dir.entries()
+                .iter()
+                .filter(|entry| entry.ext == FINGERPRINT_EXT)
+                .count(),
+            1
+        );
+    }
+
+    /// Two copies of one download are different files that must stay tellable
+    /// apart, while still being recognizable as the same content.
+    #[test]
+    fn two_copies_of_one_vpk_get_different_ids_but_one_content_hash() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = sample_vpk(temp.path());
+        let second = temp.path().join("copy.vpk");
+        fs::copy(&first, &second).unwrap();
+
+        let left = stamp(&first, "650634", "cool_mod.vpk").unwrap();
+        let right = stamp(&second, "650634", "cool_mod.vpk").unwrap();
+
+        assert_ne!(left.id, right.id);
+        assert_eq!(left.content_hash, right.content_hash);
+    }
+
+    /// The synthetic VPKs above are all written by our own packer. This one is
+    /// a real Deadlock mod VPK, which is what stamping actually runs against.
+    #[test]
+    fn stamping_a_real_deadlock_vpk_keeps_every_entry_intact() {
+        let sample = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../vpk-parser/data/pak95_dir.vpk")
+            .canonicalize()
+            .expect("sample VPK is missing");
+        let temp = tempfile::tempdir().unwrap();
+        let vpk = temp.path().join("pak95_dir.vpk");
+        fs::copy(&sample, &vpk).unwrap();
+
+        let before = VpkDir::parse(fs::read(&vpk).unwrap()).unwrap();
+        let originals: Vec<_> = before
+            .entries()
+            .iter()
+            .map(|entry| {
+                (
+                    entry.full_path(),
+                    entry.crc32,
+                    entry.archive_index,
+                    entry.length,
+                    before.entry_data(entry).map(<[u8]>::to_vec),
+                )
+            })
+            .collect();
+        assert!(!originals.is_empty(), "sample VPK parsed as empty");
+
+        let fingerprint = stamp(&vpk, "650634", "cool_mod.vpk").unwrap();
+
+        assert_eq!(read(&vpk).unwrap().unwrap(), fingerprint);
+        let after = VpkDir::parse(fs::read(&vpk).unwrap()).unwrap();
+        assert_eq!(after.entries().len(), originals.len() + 1);
+        for (full_path, crc32, archive_index, length, data) in originals {
+            let entry = after
+                .entries()
+                .iter()
+                .find(|entry| entry.full_path() == full_path)
+                .unwrap_or_else(|| panic!("{full_path} disappeared"));
+            assert_eq!(entry.crc32, crc32, "{full_path}");
+            assert_eq!(entry.archive_index, archive_index, "{full_path}");
+            assert_eq!(entry.length, length, "{full_path}");
+            assert_eq!(
+                after.entry_data(entry).map(<[u8]>::to_vec),
+                data,
+                "{full_path}"
+            );
+            if let Some(bytes) = after.entry_data(entry) {
+                assert_eq!(crate::pack::checksum(bytes), crc32, "{full_path}");
+            }
+        }
+    }
+
+    /// Entries stored in `_NNN.vpk` companions are addressed by archive index,
+    /// so stamping the directory file must leave them pointing where they were.
+    #[test]
+    fn stamping_keeps_multipart_entries_addressable() {
+        let temp = tempfile::tempdir().unwrap();
+        let vpk = sample_vpk(temp.path());
+        let mut dir = VpkDir::parse(fs::read(&vpk).unwrap()).unwrap();
+        // Re-home one entry into a companion archive, as a split VPK would.
+        let entries = dir.entries().to_vec();
+        let mut external = entries[0].clone();
+        external.archive_index = 3;
+        external.offset = 4096;
+        dir.remove(&external.ext, &external.path, &external.filename);
+        dir.push(external.clone());
+        fs::write(&vpk, dir.to_bytes().unwrap()).unwrap();
+
+        stamp(&vpk, "650634", "cool_mod.vpk").unwrap();
+
+        let after = VpkDir::parse(fs::read(&vpk).unwrap()).unwrap();
+        let entry = after
+            .find(&external.ext, &external.path, &external.filename)
+            .unwrap();
+        assert_eq!(entry.archive_index, 3);
+        assert_eq!(entry.offset, 4096);
+        assert_eq!(entry.length, external.length);
+    }
+}

--- a/packages/vpkmanager/src/lib.rs
+++ b/packages/vpkmanager/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod audio;
 pub mod error;
+pub mod fingerprint;
 pub mod pack;
 pub mod particle_edit;
 pub mod pattern;
@@ -22,6 +23,7 @@ pub mod texture_edit;
 pub mod vpkdir;
 
 pub use error::{Result, VpkManagerError};
+pub use fingerprint::VpkFingerprint;
 pub use pack::pack_directory;
 pub use particle_edit::recolor_particle_colors;
 pub use pattern::{Pattern, PatternStyle, pattern_swatch, pattern_texture};

--- a/packages/vpkmanager/src/lib.rs
+++ b/packages/vpkmanager/src/lib.rs
@@ -19,6 +19,7 @@ pub mod pattern;
 pub mod sound_edit;
 pub mod source2;
 pub mod texture_edit;
+pub mod vpkdir;
 
 pub use error::{Result, VpkManagerError};
 pub use pack::pack_directory;
@@ -28,6 +29,7 @@ pub use sound_edit::{SoundInput, classify_sound_input, swap_sound};
 pub use texture_edit::{
     EditedTexture, Recolor, paint_texture, recolor_texture, replace_texture_image,
 };
+pub use vpkdir::VpkDir;
 
 /// Parse only a texture's header: its format, stored size and mip count.
 pub fn inspect_texture(bytes: &[u8]) -> Result<(u32, u32, String)> {

--- a/packages/vpkmanager/src/pack.rs
+++ b/packages/vpkmanager/src/pack.rs
@@ -20,6 +20,11 @@ const INLINE_ARCHIVE_INDEX: u16 = 0x7fff;
 const ENTRY_TERMINATOR: u16 = 0xffff;
 const CRC32: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
+/// The CRC-32 a VPK directory entry records for its file's bytes.
+pub(crate) fn checksum(bytes: &[u8]) -> u32 {
+    CRC32.checksum(bytes)
+}
+
 struct PackedEntry {
     filename: String,
     crc32: u32,

--- a/packages/vpkmanager/src/vpkdir.rs
+++ b/packages/vpkmanager/src/vpkdir.rs
@@ -1,0 +1,604 @@
+//! Reading and surgically rewriting a VPK directory file.
+//!
+//! [`pack`](crate::pack) writes a fresh VPK from a directory tree. This module
+//! is the other half: it opens a VPK that already exists — one downloaded from
+//! GameBanana, packed by an unknown tool, possibly split across `_NNN.vpk`
+//! companions — and lets a single inline entry be added or replaced without
+//! re-encoding a byte of anyone else's file data.
+//!
+//! That is what makes stamping a fingerprint into a third-party mod safe. Entry
+//! offsets in a VPK are relative to the start of the data section, not to the
+//! start of the file, so growing the entry tree leaves every existing offset
+//! valid. Entries stored in companion archives are referenced by archive index
+//! and are not touched at all.
+//!
+//! The one thing a rewrite does drop is the archive-MD5 / other-MD5 / signature
+//! sections of a v2 VPK. Those are integrity metadata over the exact bytes we
+//! are deliberately changing, they are absent from every mod VPK in practice,
+//! and the engine does not verify them for addons.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use crate::error::{Result, VpkManagerError};
+
+pub const VPK_SIGNATURE: u32 = 0x55aa1234;
+/// Archive index meaning "the data lives in this directory file".
+pub const INLINE_ARCHIVE_INDEX: u16 = 0x7fff;
+const ENTRY_TERMINATOR: u16 = 0xffff;
+const V1_HEADER_LEN: usize = 12;
+const V2_HEADER_LEN: usize = 28;
+/// Largest header-plus-tree buffer `read_entry_from_file` will allocate.
+/// Addon directory trees are metadata; this is thousands of files.
+const MAX_TREE_BYTES: usize = 16 * 1024 * 1024;
+/// Largest inline payload `read_entry_from_file` will copy into memory.
+/// Fingerprints are hundreds of bytes; this is a ceiling, not a target.
+const MAX_ENTRY_BYTES: usize = 16 * 1024 * 1024;
+
+/// One file inside a VPK, as described by the directory tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirEntry {
+    pub ext: String,
+    pub path: String,
+    pub filename: String,
+    pub crc32: u32,
+    pub archive_index: u16,
+    pub offset: u32,
+    pub length: u32,
+    /// Bytes stored inline in the tree itself, ahead of the entry's data.
+    pub preload: Vec<u8>,
+}
+
+impl DirEntry {
+    pub fn is_inline(&self) -> bool {
+        self.archive_index == INLINE_ARCHIVE_INDEX
+    }
+
+    /// `path/filename.ext`, with the VPK's `" "` root spelling normalized away.
+    pub fn full_path(&self) -> String {
+        let name = format!("{}.{}", self.filename, self.ext);
+        if self.path.is_empty() || self.path == " " {
+            name
+        } else {
+            format!("{}/{name}", self.path)
+        }
+    }
+}
+
+/// A parsed VPK directory file, held in memory together with its data section.
+pub struct VpkDir {
+    version: u32,
+    header_len: usize,
+    /// Offset of the data section within `bytes`.
+    data_start: usize,
+    /// Length of the data section, which may be shortened by an edit.
+    data_len: usize,
+    entries: Vec<DirEntry>,
+    bytes: Vec<u8>,
+    /// Data appended past the original section by [`Self::upsert_inline`].
+    appended: Vec<u8>,
+}
+
+impl VpkDir {
+    pub fn parse(bytes: Vec<u8>) -> Result<Self> {
+        let mut cursor = Cursor::new(&bytes);
+        let signature = cursor.u32()?;
+        if signature != VPK_SIGNATURE {
+            return Err(VpkManagerError::Vpk(format!(
+                "not a VPK file: signature {signature:#010x}"
+            )));
+        }
+        let version = cursor.u32()?;
+        let tree_len = cursor.u32()? as usize;
+
+        let (header_len, declared_data_len, trailing) = if version >= 2 {
+            let data_size = cursor.u32()? as usize;
+            let archive_md5 = cursor.u32()? as usize;
+            let other_md5 = cursor.u32()? as usize;
+            let signature_size = cursor.u32()? as usize;
+            (
+                V2_HEADER_LEN,
+                data_size,
+                archive_md5 + other_md5 + signature_size,
+            )
+        } else if version == 1 {
+            (V1_HEADER_LEN, 0, 0)
+        } else {
+            return Err(VpkManagerError::Vpk(format!(
+                "unsupported VPK version {version}"
+            )));
+        };
+
+        let data_start = header_len
+            .checked_add(tree_len)
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(|| VpkManagerError::Vpk("VPK tree runs past the end of the file".into()))?;
+
+        // A v2 writer that leaves the data-section size at zero while storing
+        // inline data is common enough that the field cannot be trusted on its
+        // own; fall back to "everything after the tree" when nothing else
+        // claims those bytes.
+        let data_len = if declared_data_len > 0 {
+            declared_data_len
+        } else if trailing == 0 {
+            bytes.len() - data_start
+        } else {
+            0
+        };
+        if data_start + data_len > bytes.len() {
+            return Err(VpkManagerError::Vpk(
+                "VPK data section runs past the end of the file".into(),
+            ));
+        }
+
+        let entries = cursor.tree(header_len, tree_len)?;
+
+        Ok(Self {
+            version,
+            header_len,
+            data_start,
+            data_len,
+            entries,
+            bytes,
+            appended: Vec::new(),
+        })
+    }
+
+    pub fn entries(&self) -> &[DirEntry] {
+        &self.entries
+    }
+
+    pub fn find(&self, ext: &str, path: &str, filename: &str) -> Option<&DirEntry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.ext == ext && entry.path == path && entry.filename == filename)
+    }
+
+    /// The bytes of an entry stored in this directory file. `None` for entries
+    /// that live in a `_NNN.vpk` companion.
+    pub fn entry_data(&self, entry: &DirEntry) -> Option<&[u8]> {
+        if !entry.is_inline() {
+            return None;
+        }
+        let start = entry.offset as usize;
+        let end = start.checked_add(entry.length as usize)?;
+        if end <= self.data_len {
+            self.bytes
+                .get(self.data_start + start..self.data_start + end)
+        } else if start >= self.data_len {
+            self.appended
+                .get(start - self.data_len..end - self.data_len)
+        } else {
+            None
+        }
+    }
+
+    /// Drop an entry from the tree, reclaiming its bytes when they are the tail
+    /// of the data section. Returns the entry if it was there.
+    pub fn remove(&mut self, ext: &str, path: &str, filename: &str) -> Option<DirEntry> {
+        let index = self.entries.iter().position(|entry| {
+            entry.ext == ext && entry.path == path && entry.filename == filename
+        })?;
+        let removed = self.entries.remove(index);
+
+        let end = removed.offset as usize + removed.length as usize;
+        if removed.is_inline() && end == self.data_len + self.appended.len() {
+            let reclaimed = (removed.length as usize).min(self.appended.len());
+            self.appended.truncate(self.appended.len() - reclaimed);
+            self.data_len -= removed.length as usize - reclaimed;
+        }
+        Some(removed)
+    }
+
+    /// Add an entry whose data already lives wherever its offset and archive
+    /// index say it does.
+    pub fn push(&mut self, entry: DirEntry) {
+        self.entries.push(entry);
+    }
+
+    /// Add `payload` as an inline entry, replacing any entry already at that
+    /// key. Existing entries keep their data bytes and their offsets.
+    pub fn upsert_inline(&mut self, ext: &str, path: &str, filename: &str, payload: &[u8]) {
+        // Entries added here always go last, so replacing one usually reclaims
+        // its bytes rather than orphaning them.
+        self.remove(ext, path, filename);
+
+        let offset = self.data_len + self.appended.len();
+        self.entries.push(DirEntry {
+            ext: ext.to_string(),
+            path: path.to_string(),
+            filename: filename.to_string(),
+            crc32: crate::pack::checksum(payload),
+            archive_index: INLINE_ARCHIVE_INDEX,
+            offset: offset as u32,
+            length: payload.len() as u32,
+            preload: Vec::new(),
+        });
+        self.appended.extend_from_slice(payload);
+    }
+
+    /// Serialize back to a complete VPK directory file.
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let tree = self.build_tree();
+        let data = &self.bytes[self.data_start..self.data_start + self.data_len];
+        let data_len = data.len() + self.appended.len();
+
+        let mut out = Vec::with_capacity(self.header_len + tree.len() + data_len);
+        write_u32(&mut out, VPK_SIGNATURE);
+        write_u32(&mut out, self.version);
+        write_u32(
+            &mut out,
+            u32::try_from(tree.len())
+                .map_err(|_| VpkManagerError::Vpk("VPK tree is too large".into()))?,
+        );
+        if self.version >= 2 {
+            write_u32(
+                &mut out,
+                u32::try_from(data_len)
+                    .map_err(|_| VpkManagerError::Vpk("VPK data section is too large".into()))?,
+            );
+            // Integrity sections cannot survive a rewrite of the bytes they
+            // cover; see the module docs.
+            write_u32(&mut out, 0);
+            write_u32(&mut out, 0);
+            write_u32(&mut out, 0);
+        }
+        out.extend_from_slice(&tree);
+        out.extend_from_slice(data);
+        out.extend_from_slice(&self.appended);
+        Ok(out)
+    }
+
+    fn build_tree(&self) -> Vec<u8> {
+        let mut grouped: BTreeMap<&str, BTreeMap<&str, Vec<&DirEntry>>> = BTreeMap::new();
+        for entry in &self.entries {
+            grouped
+                .entry(entry.ext.as_str())
+                .or_default()
+                .entry(entry.path.as_str())
+                .or_default()
+                .push(entry);
+        }
+
+        let mut out = Vec::new();
+        for (ext, paths) in grouped {
+            write_cstring(&mut out, ext);
+            for (path, entries) in paths {
+                write_cstring(&mut out, path);
+                for entry in entries {
+                    write_cstring(&mut out, &entry.filename);
+                    write_u32(&mut out, entry.crc32);
+                    write_u16(&mut out, entry.preload.len() as u16);
+                    write_u16(&mut out, entry.archive_index);
+                    write_u32(&mut out, entry.offset);
+                    write_u32(&mut out, entry.length);
+                    write_u16(&mut out, ENTRY_TERMINATOR);
+                    out.extend_from_slice(&entry.preload);
+                }
+                out.push(0);
+            }
+            out.push(0);
+        }
+        out.push(0);
+        out
+    }
+}
+
+/// Read one inline entry out of a VPK on disk without loading the whole file.
+///
+/// Reconciliation asks every VPK in a profile for its fingerprint, and a profile
+/// can hold gigabytes; only the header, the entry tree and the entry's own bytes
+/// are read. Returns `None` if the entry is absent or lives in a companion
+/// archive.
+pub fn read_entry_from_file(
+    path: &Path,
+    ext: &str,
+    dir_path: &str,
+    filename: &str,
+) -> Result<Option<Vec<u8>>> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = fs::File::open(path)?;
+    let mut header = [0u8; V2_HEADER_LEN];
+    file.read_exact(&mut header[..V1_HEADER_LEN])?;
+
+    let signature = u32::from_le_bytes(header[0..4].try_into().unwrap());
+    if signature != VPK_SIGNATURE {
+        return Err(VpkManagerError::Vpk(format!(
+            "not a VPK file: signature {signature:#010x}"
+        )));
+    }
+    let version = u32::from_le_bytes(header[4..8].try_into().unwrap());
+    let tree_len = u32::from_le_bytes(header[8..12].try_into().unwrap()) as usize;
+    let header_len = match version {
+        1 => V1_HEADER_LEN,
+        2.. => V2_HEADER_LEN,
+        0 => {
+            return Err(VpkManagerError::Vpk("unsupported VPK version 0".into()));
+        }
+    };
+
+    // `tree_len` and entry lengths are u32 values from the file. Measuring only
+    // against `file_len` is not enough: a sparse VPK can have a huge logical
+    // size, so a 4 GiB tree would still "fit". Cap the allocation first, then
+    // require that it also lies inside the file.
+    let prefix_len = header_len
+        .checked_add(tree_len)
+        .filter(|len| *len <= MAX_TREE_BYTES)
+        .ok_or_else(|| VpkManagerError::Vpk("VPK entry tree is too large".into()))?;
+    let file_len = file.metadata()?.len();
+    if prefix_len as u64 > file_len {
+        return Err(VpkManagerError::Vpk(
+            "VPK entry tree runs past the end of the file".into(),
+        ));
+    }
+
+    // The tree is parsed from a buffer that starts at the file's start, because
+    // that is what `Cursor::tree` addresses against.
+    let mut prefix = vec![0u8; prefix_len];
+    file.seek(SeekFrom::Start(0))?;
+    file.read_exact(&mut prefix)?;
+    let entries = Cursor::new(&prefix).tree(header_len, tree_len)?;
+
+    let Some(entry) = entries
+        .iter()
+        .find(|entry| entry.ext == ext && entry.path == dir_path && entry.filename == filename)
+    else {
+        return Ok(None);
+    };
+    if !entry.is_inline() {
+        return Ok(None);
+    }
+
+    let payload_len = entry.length as usize;
+    if payload_len > MAX_ENTRY_BYTES {
+        return Err(VpkManagerError::Vpk("VPK entry is too large".into()));
+    }
+
+    let data_start = prefix_len as u64;
+    let entry_start = data_start + u64::from(entry.offset);
+    if entry_start + u64::from(entry.length) > file_len {
+        return Err(VpkManagerError::Vpk(
+            "VPK entry runs past the end of the file".into(),
+        ));
+    }
+
+    file.seek(SeekFrom::Start(entry_start))?;
+    let mut payload = vec![0u8; payload_len];
+    file.read_exact(&mut payload)?;
+    Ok(Some(payload))
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn take(&mut self, count: usize) -> Result<&'a [u8]> {
+        let end = self
+            .position
+            .checked_add(count)
+            .filter(|end| *end <= self.bytes.len())
+            .ok_or_else(|| VpkManagerError::Vpk("VPK ended mid-structure".into()))?;
+        let slice = &self.bytes[self.position..end];
+        self.position = end;
+        Ok(slice)
+    }
+
+    fn u16(&mut self) -> Result<u16> {
+        let bytes = self.take(2)?;
+        Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn u32(&mut self) -> Result<u32> {
+        let bytes = self.take(4)?;
+        Ok(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn cstring(&mut self) -> Result<String> {
+        let start = self.position;
+        while self.position < self.bytes.len() && self.bytes[self.position] != 0 {
+            self.position += 1;
+        }
+        if self.position >= self.bytes.len() {
+            return Err(VpkManagerError::Vpk(
+                "unterminated string in VPK tree".into(),
+            ));
+        }
+        let raw = &self.bytes[start..self.position];
+        self.position += 1;
+        // VPK paths are ASCII in practice; a stray byte must not abort a parse
+        // whose only job is to locate entries.
+        Ok(String::from_utf8_lossy(raw).into_owned())
+    }
+
+    fn tree(&mut self, tree_start: usize, tree_len: usize) -> Result<Vec<DirEntry>> {
+        self.position = tree_start;
+        let tree_end = tree_start + tree_len;
+        let mut entries = Vec::new();
+
+        while self.position < tree_end {
+            let ext = self.cstring()?;
+            if ext.is_empty() {
+                break;
+            }
+            loop {
+                if self.position >= tree_end {
+                    return Err(VpkManagerError::Vpk("VPK tree ended inside a path".into()));
+                }
+                let path = self.cstring()?;
+                if path.is_empty() {
+                    break;
+                }
+                loop {
+                    if self.position >= tree_end {
+                        return Err(VpkManagerError::Vpk(
+                            "VPK tree ended inside a directory".into(),
+                        ));
+                    }
+                    let filename = self.cstring()?;
+                    if filename.is_empty() {
+                        break;
+                    }
+                    let crc32 = self.u32()?;
+                    let preload_len = self.u16()? as usize;
+                    let archive_index = self.u16()?;
+                    let offset = self.u32()?;
+                    let length = self.u32()?;
+                    let _terminator = self.u16()?;
+                    let preload = self.take(preload_len)?.to_vec();
+
+                    entries.push(DirEntry {
+                        ext: ext.clone(),
+                        path: path.clone(),
+                        filename,
+                        crc32,
+                        archive_index,
+                        offset,
+                        length,
+                        preload,
+                    });
+                }
+            }
+        }
+
+        Ok(entries)
+    }
+}
+
+fn write_cstring(out: &mut Vec<u8>, value: &str) {
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+}
+
+fn write_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn write_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_inline_tree(tree: &mut Vec<u8>, offset: u32, length: u32) {
+        write_cstring(tree, "dmm");
+        write_cstring(tree, ".dmm");
+        write_cstring(tree, "fingerprint");
+        write_u32(tree, 0);
+        write_u16(tree, 0);
+        write_u16(tree, INLINE_ARCHIVE_INDEX);
+        write_u32(tree, offset);
+        write_u32(tree, length);
+        write_u16(tree, ENTRY_TERMINATOR);
+        tree.push(0);
+        tree.push(0);
+        tree.push(0);
+    }
+
+    fn write_v1_header(out: &mut Vec<u8>, tree_len: u32) {
+        write_u32(out, VPK_SIGNATURE);
+        write_u32(out, 1);
+        write_u32(out, tree_len);
+    }
+
+    /// A header claiming a 4 GiB entry tree used to size the read buffer before
+    /// anything checked the file was that big.
+    #[test]
+    fn a_tree_length_larger_than_the_file_is_rejected_without_allocating() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("truncated.vpk");
+        let mut header = Vec::new();
+        write_v1_header(&mut header, u32::MAX);
+        fs::write(&path, &header).unwrap();
+
+        let err = read_entry_from_file(&path, "json", "dmm", "fingerprint").unwrap_err();
+
+        assert!(
+            err.to_string().contains("too large")
+                || err.to_string().contains("past the end of the file"),
+            "{err}"
+        );
+    }
+
+    /// A sparse file can be many gigabytes logically while storing only a
+    /// header. The tree still "fits"; the allocation cap has to reject it.
+    #[test]
+    fn an_oversized_tree_that_fits_the_file_is_rejected_without_allocating() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("huge-tree.vpk");
+        let tree_len = (MAX_TREE_BYTES + 1 - V1_HEADER_LEN) as u32;
+        let mut header = Vec::new();
+        write_v1_header(&mut header, tree_len);
+        fs::write(&path, &header).unwrap();
+        {
+            let file = fs::OpenOptions::new().write(true).open(&path).unwrap();
+            file.set_len(V1_HEADER_LEN as u64 + u64::from(tree_len))
+                .unwrap();
+        }
+
+        let err = read_entry_from_file(&path, "dmm", ".dmm", "fingerprint").unwrap_err();
+
+        assert!(err.to_string().contains("too large"), "{err}");
+    }
+
+    /// A VPK whose data section is a hole past a small inline entry. The tree
+    /// and payload are within the caps; a large logical size must not reject it.
+    #[test]
+    fn a_valid_length_sparse_vpk_is_readable() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("sparse.vpk");
+        let payload = b"{\"ok\":true}";
+
+        let mut tree = Vec::new();
+        write_inline_tree(&mut tree, 0, payload.len() as u32);
+        let mut bytes = Vec::new();
+        write_v1_header(&mut bytes, tree.len() as u32);
+        bytes.extend_from_slice(&tree);
+        bytes.extend_from_slice(payload);
+
+        {
+            let mut file = fs::File::create(&path).unwrap();
+            file.write_all(&bytes).unwrap();
+            file.set_len(8 * 1024 * 1024).unwrap();
+        }
+
+        let read = read_entry_from_file(&path, "dmm", ".dmm", "fingerprint")
+            .unwrap()
+            .expect("entry is present");
+        assert_eq!(read, payload);
+    }
+
+    #[test]
+    fn an_oversized_entry_that_fits_the_file_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("huge-entry.vpk");
+        let length = (MAX_ENTRY_BYTES + 1) as u32;
+
+        let mut tree = Vec::new();
+        write_inline_tree(&mut tree, 0, length);
+        let mut bytes = Vec::new();
+        write_v1_header(&mut bytes, tree.len() as u32);
+        bytes.extend_from_slice(&tree);
+
+        {
+            let mut file = fs::File::create(&path).unwrap();
+            file.write_all(&bytes).unwrap();
+            file.set_len(bytes.len() as u64 + u64::from(length))
+                .unwrap();
+        }
+
+        let err = read_entry_from_file(&path, "dmm", ".dmm", "fingerprint").unwrap_err();
+
+        assert!(err.to_string().contains("too large"), "{err}");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `VpkDir` so vpkmanager can read and rewrite a VPK directory tree without moving existing file bytes.
- Stamp a `.dmm/fingerprint.dmm` payload into VPKs the manager owns, with a stable content hash and a unique per-file id.
- Teach `vpk-parser` to ignore those stamps in content signature, merkle root, manifest hash, and file count so lockdex matching still hits the unstamped GameBanana copies in the `vpk` table.

This is the first of two stacked PRs. The desktop migration lives in #611 and targets this branch.

## Test plan
- [ ] `cargo test --manifest-path packages/vpkmanager/Cargo.toml`
- [ ] `cargo test --manifest-path packages/vpk-parser/Cargo.toml` (includes `stamping_does_not_change_lockdex_content_hashes`)
- [ ] Confirm a stamped VPK still loads in-game (additive `.dmm` entry, inline archive index)
- [ ] Confirm lockdex / `ModAnalyserService` still matches a stamped local VPK on content signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added VPK directory parsing and rewriting in `vpkmanager` without moving existing file bytes.
- Added `.dmm/fingerprint.dmm` stamps for managed VPKs. Each stamp stores a stable content hash, mod ID, original filename, and unique file ID.
- Added safe stamp rewriting with temporary files and atomic replacement.
- Updated `vpk-parser` to ignore manager stamps in content signatures, Merkle roots, manifest hashes, and file counts.
- Added coverage for VPK rewriting, fingerprint handling, multipart archives, malformed inputs, and hash stability.

## Affected packages

- `vpkmanager`: New `VpkDir` and fingerprint APIs.
- `vpk-parser`: Stamp-aware hash and file-count calculations.
- Desktop migration is not included in this PR.
- No changes affect `api`, `bot`, `www`, `docs`, or shared application packages.

## Dependencies and integration

- Added `vpkmanager` as a development dependency of `vpk-parser`.
- Added `log`, `serde`, `serde_json`, and `sha2` to `vpkmanager`.
- No database migrations, Tauri plugin changes, or Rust FFI boundary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->