### PR TITLE
fix(desktop): remember selected mod variants on enable

### DIFF
--- a/.changeset/olive-moths-remember.md
+++ b/.changeset/olive-moths-remember.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Remember the variant picked at download when enabling a mod

--- a/apps/desktop/src/hooks/use-install-with-collection.ts
+++ b/apps/desktop/src/hooks/use-install-with-collection.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { appLocalDataDir, join } from "@tauri-apps/api/path";
 import { useState } from "react";
 import { createLogger } from "@/lib/logger";
+import { applyDownloadTimeSelection } from "@/lib/mods/mod-variants";
 import { usePersistedStore } from "@/lib/store";
 import type {
   InstallableMod,
@@ -236,6 +237,30 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
             return await performInstallation(mod, options, updatedFileTree);
           }
 
+          // The variant picked in the download dialog already answers this
+          // question, so don't ask it a second time on activation.
+          const downloadTimeSelection = applyDownloadTimeSelection(
+            mod,
+            mod.installedFileTree,
+          );
+          if (downloadTimeSelection) {
+            logger
+              .withMetadata({
+                modId: mod.remoteId,
+                selectedFiles: downloadTimeSelection.files.filter(
+                  (f) => f.is_selected,
+                ).length,
+                totalFiles: downloadTimeSelection.total_files,
+              })
+              .info("Using variant selected during download");
+
+            return await performInstallation(
+              mod,
+              options,
+              downloadTimeSelection,
+            );
+          }
+
           // No previous selection - show file selector dialog
           logger
             .withMetadata({
@@ -300,6 +325,31 @@ const useInstallWithCollection = (): UseInstallWithCollectionReturn => {
 
         // If mod has multiple files, show file selector dialog
         if (fileTree.has_multiple_files) {
+          // Same as above: a variant chosen at download time still counts here,
+          // where the tree was rebuilt from the archives left in the mod folder.
+          const downloadTimeSelection = applyDownloadTimeSelection(
+            mod,
+            fileTree,
+          );
+          if (downloadTimeSelection) {
+            logger
+              .withMetadata({
+                modId: mod.remoteId,
+                selectedFiles: downloadTimeSelection.files.filter(
+                  (f) => f.is_selected,
+                ).length,
+                totalFiles: downloadTimeSelection.total_files,
+              })
+              .info("Using variant selected during download");
+
+            setIsAnalyzing(false);
+            return await performInstallation(
+              mod,
+              options,
+              downloadTimeSelection,
+            );
+          }
+
           logger
             .withMetadata({
               modId: mod.remoteId,

--- a/apps/desktop/src/lib/mods/mod-variants.test.ts
+++ b/apps/desktop/src/lib/mods/mod-variants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyDownloadTimeSelection,
   deriveActiveArchiveNames,
   deriveActiveVariantCount,
 } from "@/lib/mods/mod-variants";
@@ -137,5 +138,103 @@ describe("deriveActiveVariantCount", () => {
 
   it("returns zero for mods with no variant information at all", () => {
     expect(deriveActiveVariantCount(mod({ installedVpks: [] }))).toBe(0);
+  });
+});
+
+const tree = (files: ModFile[]) => ({
+  files,
+  total_files: files.length,
+  has_multiple_files: files.length > 1,
+});
+
+const downloads = (...names: string[]) =>
+  names.map((name) => ({ name })) as LocalMod["downloads"];
+
+describe("applyDownloadTimeSelection", () => {
+  it("keeps only the files of the archive picked during download", () => {
+    const result = applyDownloadTimeSelection(
+      mod({
+        downloads: downloads("red.zip", "blue.zip"),
+        selectedDownloads: downloads("red.zip"),
+      }),
+      tree([
+        file("pak01_dir.vpk", true, "red.zip"),
+        file("pak02_dir.vpk", true, "blue.zip"),
+      ]),
+    );
+
+    expect(result?.files.map((f) => f.is_selected)).toEqual([true, false]);
+  });
+
+  it("selects every file of the picked archive", () => {
+    const result = applyDownloadTimeSelection(
+      mod({
+        downloads: downloads("red.zip", "blue.zip"),
+        selectedDownloads: downloads("red.zip"),
+      }),
+      tree([
+        file("pak01_dir.vpk", true, "red.zip"),
+        file("pak02_dir.vpk", true, "red.zip"),
+      ]),
+    );
+
+    expect(result?.files.map((f) => f.is_selected)).toEqual([true, true]);
+  });
+
+  it("falls back to the active variant archive", () => {
+    const result = applyDownloadTimeSelection(
+      mod({
+        downloads: downloads("red.zip", "blue.zip"),
+        activeVariantArchive: "blue.zip",
+      }),
+      tree([
+        file("pak01_dir.vpk", true, "red.zip"),
+        file("pak02_dir.vpk", true, "blue.zip"),
+      ]),
+    );
+
+    expect(result?.files.map((f) => f.is_selected)).toEqual([false, true]);
+  });
+
+  it("defers to the file selector when the mod only had one download", () => {
+    expect(
+      applyDownloadTimeSelection(
+        mod({
+          downloads: downloads("red.zip"),
+          selectedDownloads: downloads("red.zip"),
+        }),
+        tree([
+          file("pak01_dir.vpk", true, "red.zip"),
+          file("pak02_dir.vpk", true, "red.zip"),
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it("defers to the file selector when the stored archive is gone", () => {
+    expect(
+      applyDownloadTimeSelection(
+        mod({
+          downloads: downloads("red.zip", "blue.zip"),
+          selectedDownloads: downloads("green.zip"),
+        }),
+        tree([
+          file("pak01_dir.vpk", true, "red.zip"),
+          file("pak02_dir.vpk", true, "blue.zip"),
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it("defers to the file selector when the files carry no archive names", () => {
+    expect(
+      applyDownloadTimeSelection(
+        mod({
+          downloads: downloads("red.zip", "blue.zip"),
+          selectedDownloads: downloads("red.zip"),
+        }),
+        tree([file("pak01_dir.vpk", true), file("pak02_dir.vpk", true)]),
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/mods/mod-variants.ts
+++ b/apps/desktop/src/lib/mods/mod-variants.ts
@@ -1,4 +1,4 @@
-import type { LocalMod } from "@/types/mods";
+import type { LocalMod, ModFileTree } from "@/types/mods";
 
 export const deriveActiveArchiveNames = (mod: LocalMod | null): Set<string> => {
   const names = new Set<string>();
@@ -50,4 +50,58 @@ export const deriveActiveVariantCount = (mod: LocalMod | null): number => {
     return 0;
   }
   return mod?.installedVpks?.length ?? 0;
+};
+
+/**
+ * The archives the user picked in the download dialog. Empty when the mod only
+ * ever offered one download, because then nothing was chosen and there is no
+ * decision to carry over.
+ */
+export const deriveDownloadTimeArchiveNames = (
+  mod: LocalMod | null,
+): Set<string> => {
+  const names = new Set<string>();
+  if ((mod?.downloads?.length ?? 0) <= 1) {
+    return names;
+  }
+  for (const d of mod?.selectedDownloads ?? []) {
+    if (d.name) {
+      names.add(d.name);
+    }
+  }
+  if (names.size === 0 && mod?.activeVariantArchive) {
+    for (const part of mod.activeVariantArchive.split(",")) {
+      if (part) {
+        names.add(part);
+      }
+    }
+  }
+  return names;
+};
+
+/**
+ * Turns the variant picked during download into a file selection, so enabling a
+ * mod does not ask the same question twice. Returns null when the choice cannot
+ * be applied - no choice was ever made, or none of the files on disk belong to
+ * the chosen archives - and the file selector has to be shown after all.
+ */
+export const applyDownloadTimeSelection = (
+  mod: LocalMod | null,
+  fileTree: ModFileTree,
+): ModFileTree | null => {
+  const chosen = deriveDownloadTimeArchiveNames(mod);
+  if (chosen.size === 0) {
+    return null;
+  }
+
+  const files = fileTree.files.map((f) => ({
+    ...f,
+    is_selected: !!f.archive_name && chosen.has(f.archive_name),
+  }));
+
+  if (!files.some((f) => f.is_selected)) {
+    return null;
+  }
+
+  return { ...fileTree, files };
 };


### PR DESCRIPTION
- Reuse the archive choice made during download when activating mods
- Fall back to the file selector when the stored choice is unavailable
- Add coverage for variant selection and fallback behavior

## Description

Brief description of the changes introduced by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

- Closes #685 

## AI Disclosure

<!-- If AI tools were used significantly (beyond autocomplete), note the tool and what it helped with -->

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Claude Opus 5, Used for: implementation

## Testing

- [ ] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)


https://github.com/user-attachments/assets/94c610e0-f896-4667-8ab4-5fbaf55e122f

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

<!-- Any additional information that reviewers should know about this PR -->

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- The desktop app now remembers the archive variant selected during download.
- Activation reuses the stored variant automatically.
- The file selector appears only when no stored variant exists or the stored variant is no longer valid.
- Added tests for variant selection and fallback behavior.
- Added a patch changeset for `@deadlock-mods/desktop`.

No API, bot, www, docs, shared-package, database, Tauri plugin, or Rust FFI changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->