### PR TITLE
feat(www): add DeadlockSkins.gg to footer partners

### DIFF
--- a/.changeset/olive-moths-arrive.md
+++ b/.changeset/olive-moths-arrive.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/www": patch
+---
+
+Add DeadlockSkins.gg to the website footer partners list

--- a/apps/www/src/components/footer.tsx
+++ b/apps/www/src/components/footer.tsx
@@ -89,6 +89,13 @@ export const Footer = () => {
                 target='_blank'>
                 Deadlock API
               </a>
+              <a
+                className='text-sm opacity-60 hover:opacity-100 transition-opacity'
+                href='https://deadlockskins.gg/?utm_source=deadlock-modmanager&utm_medium=footer&utm_campaign=partners'
+                rel='noopener noreferrer'
+                target='_blank'>
+                DeadlockSkins.gg
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Adds [DeadlockSkins.gg](https://deadlockskins.gg/) to the Partners column in the
website footer, alongside the existing partners. It is a free catalog of Deadlock
skins and community mods with a real-time 3D viewer for every item. The listing
was agreed with the maintainer beforehand.

The entry copies the existing partner pattern exactly: same classes, same
`rel`/`target`, and the same
`utm_source=deadlock-modmanager&utm_medium=footer&utm_campaign=partners`
attribution parameters, so the referral shows up in analytics the way the
other partners' do.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [ ] 🧪 Tests (adding or updating tests)
- [ ] 🔨 Chore (maintenance, dependency updates, etc.)

## Related Issues

None.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted — Tool: Qwen3.8-27B, via the omp harness, Used for: drafting the footer entry and checking it against the existing partner markup and repo conventions

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

`oxfmt` 0.50.0 and `oxlint` 1.65.0 (the versions pinned in the repo) are clean on
the changed file, and `oxfmt --write` is a no-op on it. Verified in the www dev
server (`vite dev --port 3003`) at 1440px and 390px: the Partners column renders
four links, the new one carrying the same class string, `rel` and `target` as its
siblings, and clicking it opens the expected URL in a new tab. `tsc --noEmit` on
`apps/www` reports nothing for the changed file.

## Screenshots (if applicable)

The entry renders as a fourth text link in the Partners column with styling
identical to its siblings, at both desktop and mobile widths.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

`apps/www/src/components/footer.tsx` is the only place partner links live, so
this is a one-file change plus a `patch` changeset for `@deadlock-mods/www`.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `DeadlockSkins.gg` to the `www` footer Partners column.
- Preserved the existing link classes, analytics parameters, `target`, and `rel` attributes.
- Added a patch changeset for `@deadlock-mods/www`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->