### PR TITLE
fix(desktop): make the VPK manifest the single owner of installed files

### DIFF
--- a/.changeset/steady-owls-reconcile.md
+++ b/.changeset/steady-owls-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Fix VPK state drift during deletes, batch updates, profile switches, and restore

--- a/.changeset/steady-vpks-recover.md
+++ b/.changeset/steady-vpks-recover.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Preserve mod metadata during VPK replacement, clean up failed update extractions, and recognize uppercase VPK downloads. Reconcile profiles without overwriting concurrent changes, verify restored files on disk, and retry unavailable mod metadata. Keep inactive-profile cleanup from clearing active-profile progress and visibility.

--- a/apps/desktop/src-tauri/src/commands/archive.rs
+++ b/apps/desktop/src-tauri/src/commands/archive.rs
@@ -57,7 +57,6 @@ pub async fn copy_selected_vpks_from_archive(
   _is_map: bool,
 ) -> Result<(), Error> {
   use crate::mod_manager::archive_extractor::ArchiveExtractor;
-  use crate::mod_manager::vpk_manager::VpkManager;
 
   log::info!(
     "Copying selected VPKs from extracted directory for mod: {} (profile: {profile_folder:?})",
@@ -115,13 +114,14 @@ pub async fn copy_selected_vpks_from_archive(
 
   drop(mod_manager);
 
-  let vpk_manager = VpkManager::new();
-  vpk_manager.copy_selected_vpks_with_prefix(
+  let vpk_manager = crate::mod_manager::vpk_manager::VpkManager::new();
+  let prefixed_vpks = vpk_manager.copy_selected_vpks_with_prefix(
     &extracted_dir,
     &destination_path,
     &mod_id,
     &file_tree,
   )?;
+  persist_prefixed_import(&destination_path, &mod_id, prefixed_vpks)?;
 
   log::info!("Removing extracted directory: {extracted_dir:?}");
   std::fs::remove_dir_all(&extracted_dir)?;
@@ -195,12 +195,35 @@ pub async fn copy_local_mod_vpks(
     ));
   }
 
+  persist_prefixed_import(&destination_path, &mod_id, prefixed_vpks.clone())?;
+
   log::info!(
     "Successfully copied {} VPKs for local mod: {}",
     prefixed_vpks.len(),
     mod_id
   );
   Ok(prefixed_vpks)
+}
+
+fn persist_prefixed_import(
+  destination_path: &std::path::Path,
+  mod_id: &str,
+  prefixed_vpks: Vec<String>,
+) -> Result<(), Error> {
+  let mut manifest = crate::mod_manager::vpk_manifest::ProfileVpkManifest::open_for_write(
+    destination_path,
+  )?;
+  let original_names: Vec<String> = prefixed_vpks
+    .iter()
+    .map(|name| {
+      name
+        .strip_prefix(&format!("{mod_id}_"))
+        .unwrap_or(name)
+        .to_string()
+    })
+    .collect();
+  manifest.mark_disabled(mod_id, prefixed_vpks, original_names);
+  manifest.save(destination_path)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod logs;
 pub mod match_sync;
 pub mod mods;
 pub mod policy;
+pub mod profile_snapshot;
 pub mod profiles;
 pub mod reports;
 pub mod server_browser;

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -192,6 +192,8 @@ pub struct BatchUpdateResult {
   pub succeeded: Vec<String>,
   pub failed: Vec<(String, String)>,
   pub installed_mods: Vec<InstalledModInfo>,
+  #[serde(default)]
+  pub vpk_mappings: Vec<(String, Vec<String>)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -436,6 +438,35 @@ pub async fn batch_update_mods(
     )
     .ok();
 
+  let profile_folder_option = if profile_folder.is_empty() {
+    None
+  } else {
+    Some(profile_folder.clone())
+  };
+  let mut vpk_mappings = Vec::new();
+  if !succeeded.is_empty() {
+    let mut mod_manager = MANAGER.lock().unwrap();
+    if let Err(error) = mod_manager.reorder_all_mods_for_profile(profile_folder_option.clone())
+    {
+      log::warn!("Post-batch reorder failed: {error}");
+    }
+    if let Ok(addons_path) = mod_manager.get_addons_path(profile_folder_option.as_deref())
+      && let Ok(manifest) = ProfileVpkManifest::load(&addons_path)
+    {
+      for info in &mut installed_mods {
+        if let Some(entry) = manifest.mods.get(&info.mod_id) {
+          info.installed_vpks = entry.current_vpks.clone();
+        }
+      }
+      vpk_mappings = manifest
+        .mods
+        .iter()
+        .filter(|(_, entry)| entry.enabled && !entry.current_vpks.is_empty())
+        .map(|(mod_id, entry)| (mod_id.clone(), entry.current_vpks.clone()))
+        .collect();
+    }
+  }
+
   log::info!(
     "Batch mod update completed: {} succeeded, {} failed",
     succeeded.len(),
@@ -447,6 +478,7 @@ pub async fn batch_update_mods(
     succeeded,
     failed,
     installed_mods,
+    vpk_mappings,
   })
 }
 

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -333,60 +333,11 @@ pub async fn batch_update_mods(
       }
     };
     let progress_pct = (index as f64 / total_mods as f64) * 100.0;
-
-    app_handle
-      .emit(
-        "batch-update-progress",
-        BatchUpdateProgressEvent {
-          current_step: "cleaning".to_string(),
-          current_mod_index: index,
-          total_mods,
-          current_mod_name: mod_data.mod_name.clone(),
-          overall_progress: progress_pct,
-        },
-      )
-      .ok();
-
-    let addons_path_for_profile = if profile_folder.is_empty() {
-      addons_path.clone()
-    } else {
-      addons_path.join(&profile_folder)
-    };
-
-    let vpk_manager = crate::mod_manager::vpk_manager::VpkManager::new();
     let profile_folder_option = if profile_folder.is_empty() {
       None
     } else {
       Some(profile_folder.clone())
     };
-    let removed = {
-      let mut mod_manager = MANAGER.lock().unwrap();
-      match mod_manager.remove_mod_vpks(
-        &mod_data.mod_id,
-        &mod_data.installed_vpks,
-        profile_folder_option.clone(),
-      ) {
-        Ok(result) => result,
-        Err(error) => {
-          log::error!(
-            "Failed to prepare mod {} for update: {:?}",
-            mod_data.mod_id,
-            error
-          );
-          failed.push((
-            mod_data.mod_id.clone(),
-            format!("Failed to remove old VPKs: {error:?}"),
-          ));
-          continue;
-        }
-      }
-    };
-    log::info!(
-      "Removed {} old VPKs for mod {} before update",
-      removed.count,
-      mod_data.mod_id
-    );
-    let install_order = removed.install_order;
 
     app_handle
       .emit(
@@ -396,7 +347,7 @@ pub async fn batch_update_mods(
           current_mod_index: index,
           total_mods,
           current_mod_name: mod_data.mod_name.clone(),
-          overall_progress: progress_pct + (1.0 / total_mods as f64) * 30.0,
+          overall_progress: progress_pct,
         },
       )
       .ok();
@@ -417,94 +368,17 @@ pub async fn batch_update_mods(
     };
 
     let manager = get_download_manager(app_handle.clone()).await;
-    manager.queue_download(task).await?;
-
-    let mut download_complete = false;
-    let mut download_error: Option<String> = None;
-    let start_time = std::time::Instant::now();
-    let timeout_duration = std::time::Duration::from_secs(600);
-
-    while !download_complete && start_time.elapsed() < timeout_duration {
-      tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-      match manager.get_download_status(&mod_data.mod_id).await {
-        Ok(Some(status)) => {
-          if status.status == "downloading" {
-            continue;
-          }
-          download_complete = true;
-        }
-        Ok(None) => {
-          download_complete = true;
-        }
-        Err(e) => {
-          download_error = Some(format!("Failed to check download status: {:?}", e));
-          break;
-        }
-      }
-    }
-
-    if !download_complete || download_error.is_some() {
-      let err_msg = download_error.unwrap_or_else(|| "Download timeout".to_string());
-      log::error!("Download failed for mod {}: {}", mod_data.mod_id, err_msg);
-      failed.push((mod_data.mod_id.clone(), err_msg));
-      continue;
-    }
-
-    let mut vpks_found = false;
-    let max_retries = 10;
-    let mut retry_delay_ms = 100;
-
-    for attempt in 0..max_retries {
-      match vpk_manager.find_prefixed_vpks(&addons_path_for_profile, &mod_data.mod_id) {
-        Ok(vpks) if !vpks.is_empty() => {
-          log::info!(
-            "Download completed for mod: {} (found {} VPKs after {} attempts)",
-            mod_data.mod_id,
-            vpks.len(),
-            attempt + 1
-          );
-          vpks_found = true;
-          break;
-        }
-        Ok(_) => {
-          if attempt < max_retries - 1 {
-            log::debug!(
-              "VPKs not found yet for mod {} (attempt {}/{}), waiting {}ms",
-              mod_data.mod_id,
-              attempt + 1,
-              max_retries,
-              retry_delay_ms
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(retry_delay_ms)).await;
-            retry_delay_ms = std::cmp::min(retry_delay_ms * 2, 1000);
-          }
-        }
-        Err(e) => {
-          log::error!("Failed to check VPKs for mod {}: {:?}", mod_data.mod_id, e);
-          failed.push((
-            mod_data.mod_id.clone(),
-            format!("Failed to verify download: {:?}", e),
-          ));
-          break;
-        }
-      }
-    }
-
-    if !vpks_found {
-      if !failed.iter().any(|(id, _)| id == &mod_data.mod_id) {
+    let prepared = match manager.queue_download_and_prepare(task).await {
+      Ok(prepared) => prepared,
+      Err(error) => {
         log::error!(
-          "Download completed but no VPKs found for mod: {} after {} retries",
-          mod_data.mod_id,
-          max_retries
+          "Failed to prepare update for mod {}: {error}",
+          mod_data.mod_id
         );
-        failed.push((
-          mod_data.mod_id.clone(),
-          "Download completed but no VPKs found".to_string(),
-        ));
+        failed.push((mod_data.mod_id.clone(), error.to_string()));
+        continue;
       }
-      continue;
-    }
+    };
 
     app_handle
       .emit(
@@ -521,17 +395,13 @@ pub async fn batch_update_mods(
 
     let install_result = {
       let mut mod_manager = MANAGER.lock().unwrap();
-      let deadlock_mod = Mod {
-        id: mod_data.mod_id.clone(),
-        name: mod_data.mod_name.clone(),
-        is_map: mod_data.is_map,
-        installed_vpks: Vec::new(),
-        file_tree: mod_data.file_tree.clone(),
-        install_order,
-        original_vpk_names: Vec::new(),
-      };
-
-      mod_manager.install_mod(deadlock_mod, profile_folder_option)
+      mod_manager.update_mod_from_prepared(
+        &mod_data.mod_id,
+        &mod_data.mod_name,
+        &prepared.vpk_paths,
+        mod_data.file_tree.clone(),
+        profile_folder_option,
+      )
     };
 
     match install_result {

--- a/apps/desktop/src-tauri/src/commands/profile_snapshot.rs
+++ b/apps/desktop/src-tauri/src/commands/profile_snapshot.rs
@@ -1,0 +1,83 @@
+use crate::errors::Error;
+use crate::mod_manager::shard::{ProfileBase, ShardIndex, ShardLocator};
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
+use serde::Serialize;
+
+use super::state::MANAGER;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileVpkSnapshot {
+  manifest: ProfileVpkManifest,
+  files: Vec<SnapshotVpkFile>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SnapshotVpkFile {
+  shard: ShardIndex,
+  filename: String,
+  locator: String,
+}
+
+impl ProfileVpkSnapshot {
+  fn read(base: &ProfileBase) -> Result<Self, Error> {
+    let manifest = ProfileVpkManifest::load(base)?;
+    let mut files = Vec::new();
+    for (shard, dir) in base.existing_shards() {
+      for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file()
+          && let Some(filename) = path.file_name().and_then(|name| name.to_str())
+          && filename.to_ascii_lowercase().ends_with(".vpk")
+        {
+          files.push(SnapshotVpkFile {
+            shard,
+            filename: filename.to_string(),
+            locator: ShardLocator::new(shard, filename).to_wire(),
+          });
+        }
+      }
+    }
+    files.sort_by(|a, b| (a.shard, &a.filename).cmp(&(b.shard, &b.filename)));
+    Ok(Self { manifest, files })
+  }
+}
+
+#[tauri::command]
+pub async fn get_profile_vpk_snapshot(
+  profile_folder: Option<String>,
+) -> Result<ProfileVpkSnapshot, Error> {
+  // Keep the filesystem listing and manifest in the same critical section:
+  // a reorder between separate IPC reads would compare two different layouts.
+  let mut manager = MANAGER.lock().unwrap();
+  manager.migrate_profile_to_shards(profile_folder.clone())?;
+  let base = manager.get_addons_path(profile_folder.as_deref())?;
+  ProfileVpkSnapshot::read(&base)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn snapshot_distinguishes_same_filename_in_different_shards() {
+    let temp = tempfile::tempdir().unwrap();
+    let base = ProfileBase::new(temp.path().join("citadel/addons")).unwrap();
+    let shard_two = ShardIndex::new(2).unwrap();
+    for shard in [ShardIndex::FIRST, shard_two] {
+      std::fs::create_dir_all(base.shard_dir(shard)).unwrap();
+      std::fs::write(base.shard_dir(shard).join("pak01_dir.vpk"), b"fixture").unwrap();
+    }
+    let mut manifest = ProfileVpkManifest::default();
+    manifest.mark_enabled("mod", vec!["pak01_dir.vpk".into()], vec![], Some(0), shard_two);
+    manifest.save(&base).unwrap();
+
+    let snapshot = ProfileVpkSnapshot::read(&base).unwrap();
+    assert_eq!(snapshot.manifest, manifest);
+    assert_eq!(snapshot.files.len(), 2);
+    assert_eq!(snapshot.files[0].locator, "pak01_dir.vpk");
+    assert_eq!(snapshot.files[1].locator, "addons2/pak01_dir.vpk");
+  }
+}

--- a/apps/desktop/src-tauri/src/commands/profile_snapshot.rs
+++ b/apps/desktop/src-tauri/src/commands/profile_snapshot.rs
@@ -51,7 +51,9 @@ pub async fn get_profile_vpk_snapshot(
 ) -> Result<ProfileVpkSnapshot, Error> {
   // Keep the filesystem listing and manifest in the same critical section:
   // a reorder between separate IPC reads would compare two different layouts.
-  let mut manager = MANAGER.lock().unwrap();
+  let mut manager = MANAGER
+    .lock()
+    .map_err(|_| Error::BackgroundTaskFailed("Mod manager lock poisoned".to_string()))?;
   manager.migrate_profile_to_shards(profile_folder.clone())?;
   let base = manager.get_addons_path(profile_folder.as_deref())?;
   ProfileVpkSnapshot::read(&base)
@@ -71,7 +73,13 @@ mod tests {
       std::fs::write(base.shard_dir(shard).join("pak01_dir.vpk"), b"fixture").unwrap();
     }
     let mut manifest = ProfileVpkManifest::default();
-    manifest.mark_enabled("mod", vec!["pak01_dir.vpk".into()], vec![], Some(0), shard_two);
+    manifest.mark_enabled(
+      "mod",
+      vec!["pak01_dir.vpk".into()],
+      vec![],
+      Some(0),
+      shard_two,
+    );
     manifest.save(&base).unwrap();
 
     let snapshot = ProfileVpkSnapshot::read(&base).unwrap();

--- a/apps/desktop/src-tauri/src/download_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/download_manager/mod.rs
@@ -6,9 +6,12 @@ use downloader::{DownloadProgress as FileProgress, PauseHandle, download_file_re
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{
+  Arc,
+  atomic::{AtomicU64, Ordering},
+};
 use tauri::Emitter;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -112,11 +115,33 @@ struct ActiveDownload {
   speed: f64,
 }
 
+#[derive(Clone, Debug)]
+pub struct PreparedDownload {
+  pub operation_id: u64,
+  pub mod_id: String,
+  pub profile_folder: Option<String>,
+  pub vpk_paths: Vec<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DownloadPurpose {
+  Install,
+  PrepareUpdate,
+}
+
+struct QueuedDownload {
+  operation_id: u64,
+  task: DownloadTask,
+  purpose: DownloadPurpose,
+  completion: Option<oneshot::Sender<Result<PreparedDownload, String>>>,
+}
+
 pub struct DownloadManager {
-  queue: Arc<Mutex<VecDeque<DownloadTask>>>,
+  queue: Arc<Mutex<VecDeque<QueuedDownload>>>,
   active_downloads: Arc<Mutex<HashMap<String, ActiveDownload>>>,
   app_handle: AppHandle,
   processing: Arc<Mutex<bool>>,
+  next_operation_id: AtomicU64,
 }
 
 impl DownloadManager {
@@ -126,19 +151,54 @@ impl DownloadManager {
       active_downloads: Arc::new(Mutex::new(HashMap::new())),
       app_handle,
       processing: Arc::new(Mutex::new(false)),
+      next_operation_id: AtomicU64::new(1),
     }
   }
 
   pub async fn queue_download(&self, task: DownloadTask) -> Result<(), Error> {
-    log::info!("Queueing download for mod: {}", task.mod_id);
+    self.queue(task, DownloadPurpose::Install, None).await;
+    Ok(())
+  }
+
+  pub async fn queue_download_and_prepare(
+    &self,
+    task: DownloadTask,
+  ) -> Result<PreparedDownload, Error> {
+    let (sender, receiver) = oneshot::channel();
+    self
+      .queue(task, DownloadPurpose::PrepareUpdate, Some(sender))
+      .await;
+
+    receiver
+      .await
+      .map_err(|_| Error::BackgroundTaskFailed("Download worker stopped unexpectedly".to_string()))?
+      .map_err(Error::DownloadFailed)
+  }
+
+  async fn queue(
+    &self,
+    task: DownloadTask,
+    purpose: DownloadPurpose,
+    completion: Option<oneshot::Sender<Result<PreparedDownload, String>>>,
+  ) {
+    let operation_id = self.next_operation_id.fetch_add(1, Ordering::Relaxed);
+    log::info!(
+      "Queueing download operation {operation_id} for mod {} (profile: {:?})",
+      task.mod_id,
+      task.profile_folder
+    );
 
     {
       let mut queue = self.queue.lock().await;
-      queue.push_back(task);
+      queue.push_back(QueuedDownload {
+        operation_id,
+        task,
+        purpose,
+        completion,
+      });
     }
 
     self.process_queue().await;
-    Ok(())
   }
 
   async fn process_queue(&self) {
@@ -163,11 +223,55 @@ impl DownloadManager {
         };
 
         match task {
-          Some(task) => {
-            if let Err(e) =
-              Self::download_mod(task, Arc::clone(&active_clone), app_handle.clone()).await
-            {
-              log::error!("Failed to download mod: {e}");
+          Some(queued) => {
+            let mod_id = queued.task.mod_id.clone();
+            let profile_folder = queued.task.profile_folder.clone();
+            let task_path = queued.task.target_dir.to_string_lossy().to_string();
+            let result = Self::download_mod(
+              queued.operation_id,
+              queued.task,
+              queued.purpose,
+              Arc::clone(&active_clone),
+              app_handle.clone(),
+            )
+            .await;
+
+            active_clone.lock().await.remove(&mod_id);
+
+            match &result {
+              Ok(_) => {
+                app_handle
+                  .emit(
+                    "download-completed",
+                    DownloadCompletedEvent {
+                      mod_id: mod_id.clone(),
+                      path: task_path,
+                    },
+                  )
+                  .ok();
+              }
+              Err(error) => {
+                log::error!(
+                  "Download operation {} failed for mod {} (profile: {:?}): {}",
+                  queued.operation_id,
+                  mod_id,
+                  profile_folder,
+                  error
+                );
+                app_handle
+                  .emit(
+                    "download-error",
+                    DownloadErrorEvent {
+                      mod_id: mod_id.clone(),
+                      error: error.to_string(),
+                    },
+                  )
+                  .ok();
+              }
+            }
+
+            if let Some(completion) = queued.completion {
+              completion.send(result.map_err(|error| error.to_string())).ok();
             }
           }
           None => break,
@@ -180,10 +284,12 @@ impl DownloadManager {
   }
 
   async fn download_mod(
+    operation_id: u64,
     task: DownloadTask,
+    purpose: DownloadPurpose,
     active_downloads: Arc<Mutex<HashMap<String, ActiveDownload>>>,
     app_handle: AppHandle,
-  ) -> Result<(), Error> {
+  ) -> Result<PreparedDownload, Error> {
     let mod_id = task.mod_id.clone();
     let cancel_token = CancellationToken::new();
     let pause = PauseHandle::new();
@@ -333,25 +439,8 @@ impl DownloadManager {
       }
     }
 
-    {
-      let mut active = active_downloads.lock().await;
-      active.remove(&mod_id);
-    }
-
     if !errors.is_empty() {
       let error_message = errors.join("; ");
-      log::error!("Download failed for mod {mod_id}: {error_message}");
-
-      app_handle
-        .emit(
-          "download-error",
-          DownloadErrorEvent {
-            mod_id: mod_id.clone(),
-            error: error_message.clone(),
-          },
-        )
-        .ok();
-
       return Err(Error::DownloadFailed(error_message));
     }
 
@@ -360,36 +449,206 @@ impl DownloadManager {
       downloaded_files.len()
     );
 
-    // Spawn extraction as a detached task so it doesn't block subsequent downloads
-    let task_path = task.target_dir.to_string_lossy().to_string();
-    tokio::spawn(async move {
-      if let Err(e) = Self::process_downloaded_files(&task, &downloaded_files, &app_handle).await {
-        log::error!("Failed to process downloaded files for mod {mod_id}: {e}");
+    {
+      let mut active = active_downloads.lock().await;
+      if let Some(download) = active.get_mut(&mod_id) {
+        download.status = "processing".to_string();
+      }
+    }
+
+    let vpk_paths = match purpose {
+      DownloadPurpose::Install => {
+        Self::process_downloaded_files(&task, &downloaded_files, &app_handle).await?;
+        Vec::new()
+      }
+      DownloadPurpose::PrepareUpdate => {
+        Self::prepare_downloaded_vpks(operation_id, &task, &downloaded_files, &app_handle).await?
+      }
+    };
+
+    Ok(PreparedDownload {
+      operation_id,
+      mod_id,
+      profile_folder: task.profile_folder,
+      vpk_paths,
+    })
+  }
+
+  async fn prepare_downloaded_vpks(
+    operation_id: u64,
+    task: &DownloadTask,
+    downloaded_files: &[PathBuf],
+    app_handle: &AppHandle,
+  ) -> Result<Vec<PathBuf>, Error> {
+    use crate::mod_manager::archive_extractor::ArchiveExtractor;
+    use crate::mod_manager::file_tree::FileTreeAnalyzer;
+
+    let prepared_dir = task.target_dir.join(format!("prepared-{operation_id}"));
+    if prepared_dir.exists() {
+      std::fs::remove_dir_all(&prepared_dir)?;
+    }
+    std::fs::create_dir_all(&prepared_dir)?;
+
+    let prepare_result = async {
+      let extractor = ArchiveExtractor::new();
+      let analyzer = FileTreeAnalyzer::new();
+      let mut prepared_paths = Vec::new();
+
+      for (archive_index, downloaded_file) in downloaded_files.iter().enumerate() {
+        if !extractor.is_supported_archive(downloaded_file) {
+          if downloaded_file.extension().and_then(|extension| extension.to_str()) == Some("vpk")
+            && Self::downloaded_vpk_is_selected(downloaded_file, task.file_tree.as_ref())
+          {
+            Self::copy_prepared_vpk(downloaded_file, &prepared_dir, &mut prepared_paths)?;
+          }
+          continue;
+        }
 
         app_handle
           .emit(
-            "download-error",
-            DownloadErrorEvent {
-              mod_id: mod_id.clone(),
-              error: format!("Failed to process files: {e}"),
+            "download-extracting",
+            DownloadExtractingEvent {
+              mod_id: task.mod_id.clone(),
             },
           )
           .ok();
 
-        return;
+        let extracted_dir = task
+          .target_dir
+          .join(format!("prepared-extracted-{operation_id}-{archive_index}"));
+        if extracted_dir.exists() {
+          std::fs::remove_dir_all(&extracted_dir)?;
+        }
+        std::fs::create_dir_all(&extracted_dir)?;
+
+        let archive_path = downloaded_file.clone();
+        let extract_target = extracted_dir.clone();
+        const EXTRACTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+        let extraction_result = tokio::time::timeout(
+          EXTRACTION_TIMEOUT,
+          tokio::task::spawn_blocking(move || {
+            ArchiveExtractor::new().extract_archive(&archive_path, &extract_target)
+          }),
+        )
+        .await;
+
+        match extraction_result {
+          Ok(Ok(Ok(()))) => {}
+          Ok(Ok(Err(error))) => return Err(error),
+          Ok(Err(error)) => {
+            return Err(Error::ModExtractionFailed(format!(
+              "Extraction task panicked: {error}"
+            )));
+          }
+          Err(_) => {
+            return Err(Error::ModExtractionFailed(format!(
+              "Extraction timed out after {} seconds for mod {}",
+              EXTRACTION_TIMEOUT.as_secs(),
+              task.mod_id
+            )));
+          }
+        }
+
+        let archive_name = downloaded_file
+          .file_name()
+          .and_then(|name| name.to_str())
+          .unwrap_or_default();
+        let extracted_tree = analyzer.get_file_tree_from_extracted(&extracted_dir, archive_name)?;
+        let selected_paths =
+          Self::selected_extracted_vpks(&extracted_dir, &extracted_tree, task.file_tree.as_ref());
+
+        if extracted_tree.has_multiple_files && task.file_tree.is_none() {
+          return Err(Error::InvalidInput(format!(
+            "A VPK selection is required to update mod {}",
+            task.mod_id
+          )));
+        }
+
+        for selected_path in selected_paths {
+          Self::copy_prepared_vpk(&selected_path, &prepared_dir, &mut prepared_paths)?;
+        }
+
+        std::fs::remove_dir_all(&extracted_dir)?;
       }
 
-      app_handle
-        .emit(
-          "download-completed",
-          DownloadCompletedEvent {
-            mod_id: mod_id.clone(),
-            path: task_path,
-          },
-        )
-        .ok();
-    });
+      if prepared_paths.is_empty() {
+        return Err(Error::InvalidInput(
+          "No VPKs matched the update selection".to_string(),
+        ));
+      }
 
+      Ok(prepared_paths)
+    }
+    .await;
+
+    if prepare_result.is_err() && prepared_dir.exists()
+      && let Err(error) = std::fs::remove_dir_all(&prepared_dir) {
+        log::warn!(
+          "Failed to remove incomplete prepared update directory {}: {}",
+          prepared_dir.display(),
+          error
+        );
+      }
+
+    prepare_result
+  }
+
+  fn selected_extracted_vpks(
+    extracted_dir: &std::path::Path,
+    extracted_tree: &crate::mod_manager::file_tree::ModFileTree,
+    selection: Option<&crate::mod_manager::file_tree::ModFileTree>,
+  ) -> Vec<PathBuf> {
+    extracted_tree
+      .files
+      .iter()
+      .filter(|candidate| {
+        selection.is_none_or(|selection| {
+          selection.files.iter().any(|selected| {
+            selected.is_selected
+              && (selected.archive_name.is_empty()
+                || selected.archive_name == candidate.archive_name)
+              && selected.path.replace('\\', "/") == candidate.path.replace('\\', "/")
+          })
+        })
+      })
+      .map(|file| extracted_dir.join(&file.path))
+      .collect()
+  }
+
+  fn downloaded_vpk_is_selected(
+    path: &std::path::Path,
+    selection: Option<&crate::mod_manager::file_tree::ModFileTree>,
+  ) -> bool {
+    let Some(selection) = selection else {
+      return true;
+    };
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+      return false;
+    };
+
+    selection
+      .files
+      .iter()
+      .any(|file| file.is_selected && file.name == file_name)
+  }
+
+  fn copy_prepared_vpk(
+    source: &std::path::Path,
+    prepared_dir: &std::path::Path,
+    prepared_paths: &mut Vec<PathBuf>,
+  ) -> Result<(), Error> {
+    let file_name = source.file_name().ok_or_else(|| {
+      Error::InvalidInput(format!("VPK source has no filename: {}", source.display()))
+    })?;
+    let destination = prepared_dir.join(file_name);
+    if destination.exists() {
+      return Err(Error::InvalidInput(format!(
+        "Update contains duplicate VPK filename: {}",
+        file_name.to_string_lossy()
+      )));
+    }
+    std::fs::copy(source, &destination)?;
+    prepared_paths.push(destination);
     Ok(())
   }
 
@@ -855,5 +1114,67 @@ impl DownloadManager {
     app_handle: AppHandle,
   ) -> Result<(), Error> {
     Self::process_downloaded_files(&task, &[file_path], &app_handle).await
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::mod_manager::file_tree::{ModFile, ModFileTree};
+
+  fn tree(files: Vec<ModFile>) -> ModFileTree {
+    let total_files = files.len();
+    ModFileTree {
+      files,
+      total_files,
+      has_multiple_files: total_files > 1,
+    }
+  }
+
+  fn file(archive_name: &str, path: &str, is_selected: bool) -> ModFile {
+    ModFile {
+      name: PathBuf::from(path)
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string(),
+      path: path.to_string(),
+      size: 1,
+      is_selected,
+      archive_name: archive_name.to_string(),
+    }
+  }
+
+  #[test]
+  fn update_selection_distinguishes_identical_paths_from_multiple_archives() {
+    let extracted = tree(vec![file("second.zip", "variants/main.vpk", true)]);
+    let selection = tree(vec![
+      file("first.zip", "variants/main.vpk", true),
+      file("second.zip", "variants/main.vpk", false),
+    ]);
+
+    assert!(
+      DownloadManager::selected_extracted_vpks(
+        std::path::Path::new("extracted"),
+        &extracted,
+        Some(&selection),
+      )
+      .is_empty()
+    );
+  }
+
+  #[test]
+  fn update_selection_accepts_normalized_windows_paths() {
+    let extracted = tree(vec![file("mod.zip", "variants/main.vpk", true)]);
+    let selection = tree(vec![file("mod.zip", "variants\\main.vpk", true)]);
+
+    assert_eq!(
+      DownloadManager::selected_extracted_vpks(
+        std::path::Path::new("extracted"),
+        &extracted,
+        Some(&selection),
+      ),
+      vec![std::path::Path::new("extracted").join("variants/main.vpk")]
+    );
   }
 }

--- a/apps/desktop/src-tauri/src/download_manager/mod.rs
+++ b/apps/desktop/src-tauri/src/download_manager/mod.rs
@@ -271,7 +271,9 @@ impl DownloadManager {
             }
 
             if let Some(completion) = queued.completion {
-              completion.send(result.map_err(|error| error.to_string())).ok();
+              completion
+                .send(result.map_err(|error| error.to_string()))
+                .ok();
             }
           }
           None => break,
@@ -496,7 +498,7 @@ impl DownloadManager {
 
       for (archive_index, downloaded_file) in downloaded_files.iter().enumerate() {
         if !extractor.is_supported_archive(downloaded_file) {
-          if downloaded_file.extension().and_then(|extension| extension.to_str()) == Some("vpk")
+          if Self::is_vpk_path(downloaded_file)
             && Self::downloaded_vpk_is_selected(downloaded_file, task.file_tree.as_ref())
           {
             Self::copy_prepared_vpk(downloaded_file, &prepared_dir, &mut prepared_paths)?;
@@ -513,27 +515,20 @@ impl DownloadManager {
           )
           .ok();
 
-        let extracted_dir = task
-          .target_dir
-          .join(format!("prepared-extracted-{operation_id}-{archive_index}"));
-        if extracted_dir.exists() {
-          std::fs::remove_dir_all(&extracted_dir)?;
-        }
-        std::fs::create_dir_all(&extracted_dir)?;
-
         let archive_path = downloaded_file.clone();
-        let extract_target = extracted_dir.clone();
+        let extract_target = task.target_dir.clone();
+        let extract_prefix = format!("prepared-extracted-{operation_id}-{archive_index}-");
         const EXTRACTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
         let extraction_result = tokio::time::timeout(
           EXTRACTION_TIMEOUT,
           tokio::task::spawn_blocking(move || {
-            ArchiveExtractor::new().extract_archive(&archive_path, &extract_target)
+            Self::extract_prepared_archive(&archive_path, &extract_target, &extract_prefix)
           }),
         )
         .await;
 
-        match extraction_result {
-          Ok(Ok(Ok(()))) => {}
+        let extracted_dir = match extraction_result {
+          Ok(Ok(Ok(directory))) => directory,
           Ok(Ok(Err(error))) => return Err(error),
           Ok(Err(error)) => {
             return Err(Error::ModExtractionFailed(format!(
@@ -547,15 +542,19 @@ impl DownloadManager {
               task.mod_id
             )));
           }
-        }
+        };
 
         let archive_name = downloaded_file
           .file_name()
           .and_then(|name| name.to_str())
           .unwrap_or_default();
-        let extracted_tree = analyzer.get_file_tree_from_extracted(&extracted_dir, archive_name)?;
-        let selected_paths =
-          Self::selected_extracted_vpks(&extracted_dir, &extracted_tree, task.file_tree.as_ref());
+        let extracted_tree =
+          analyzer.get_file_tree_from_extracted(extracted_dir.path(), archive_name)?;
+        let selected_paths = Self::selected_extracted_vpks(
+          extracted_dir.path(),
+          &extracted_tree,
+          task.file_tree.as_ref(),
+        );
 
         if extracted_tree.has_multiple_files && task.file_tree.is_none() {
           return Err(Error::InvalidInput(format!(
@@ -568,7 +567,7 @@ impl DownloadManager {
           Self::copy_prepared_vpk(&selected_path, &prepared_dir, &mut prepared_paths)?;
         }
 
-        std::fs::remove_dir_all(&extracted_dir)?;
+        extracted_dir.close()?;
       }
 
       if prepared_paths.is_empty() {
@@ -581,16 +580,38 @@ impl DownloadManager {
     }
     .await;
 
-    if prepare_result.is_err() && prepared_dir.exists()
-      && let Err(error) = std::fs::remove_dir_all(&prepared_dir) {
-        log::warn!(
-          "Failed to remove incomplete prepared update directory {}: {}",
-          prepared_dir.display(),
-          error
-        );
-      }
+    if prepare_result.is_err()
+      && prepared_dir.exists()
+      && let Err(error) = std::fs::remove_dir_all(&prepared_dir)
+    {
+      log::warn!(
+        "Failed to remove incomplete prepared update directory {}: {}",
+        prepared_dir.display(),
+        error
+      );
+    }
 
     prepare_result
+  }
+
+  fn is_vpk_path(path: &std::path::Path) -> bool {
+    path
+      .extension()
+      .and_then(|extension| extension.to_str())
+      .is_some_and(|extension| extension.eq_ignore_ascii_case("vpk"))
+  }
+
+  // The blocking worker owns cleanup until extraction finishes, including when
+  // its async caller times out and drops the receiver.
+  fn extract_prepared_archive(
+    archive: &std::path::Path,
+    target: &std::path::Path,
+    prefix: &str,
+  ) -> Result<tempfile::TempDir, Error> {
+    let directory = tempfile::Builder::new().prefix(prefix).tempdir_in(target)?;
+    crate::mod_manager::archive_extractor::ArchiveExtractor::new()
+      .extract_archive(archive, directory.path())?;
+    Ok(directory)
   }
 
   fn selected_extracted_vpks(
@@ -1122,6 +1143,54 @@ mod tests {
   use super::*;
   use crate::mod_manager::file_tree::{ModFile, ModFileTree};
 
+  #[test]
+  fn direct_vpk_downloads_accept_mixed_case_extensions() {
+    assert!(DownloadManager::is_vpk_path(std::path::Path::new(
+      "MOD.VPK"
+    )));
+    assert!(DownloadManager::is_vpk_path(std::path::Path::new(
+      "mod.VpK"
+    )));
+    assert!(!DownloadManager::is_vpk_path(std::path::Path::new(
+      "mod.vpk.zip"
+    )));
+  }
+
+  #[test]
+  fn failed_prepared_extraction_removes_partial_directory() {
+    let root = tempfile::tempdir().unwrap();
+    let archive = root.path().join("broken.zip");
+    std::fs::write(&archive, b"invalid archive").unwrap();
+    assert!(
+      DownloadManager::extract_prepared_archive(&archive, root.path(), "prepared-extracted-")
+        .is_err()
+    );
+    let remaining = std::fs::read_dir(root.path())
+      .unwrap()
+      .map(|entry| entry.unwrap().file_name())
+      .collect::<Vec<_>>();
+    assert_eq!(remaining, vec![std::ffi::OsString::from("broken.zip")]);
+  }
+
+  #[test]
+  fn prepared_extraction_is_cleaned_when_its_consumer_exits() {
+    use std::io::Write;
+    let root = tempfile::tempdir().unwrap();
+    let archive = root.path().join("mod.zip");
+    let mut zip = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+    zip
+      .start_file("mod.vpk", zip::write::SimpleFileOptions::default())
+      .unwrap();
+    zip.write_all(b"fixture").unwrap();
+    zip.finish().unwrap();
+    let directory =
+      DownloadManager::extract_prepared_archive(&archive, root.path(), "prepared-extracted-")
+        .unwrap();
+    let path = directory.path().to_path_buf();
+    assert_eq!(std::fs::read(path.join("mod.vpk")).unwrap(), b"fixture");
+    drop(directory);
+    assert!(!path.exists());
+  }
   fn tree(files: Vec<ModFile>) -> ModFileTree {
     let total_files = files.len();
     ModFileTree {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -268,6 +268,7 @@ pub fn run() {
       commands::downloads::download_custom_provider_mod,
       commands::profiles::get_profile_installed_vpks,
       commands::profiles::get_profile_vpk_manifest,
+      commands::profile_snapshot::get_profile_vpk_snapshot,
       commands::profiles::hydrate_mods_from_manifest,
       commands::shards::get_shard_diagnostics,
       commands::shards::resync_profile_shards,

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -10,7 +10,7 @@ use crate::mod_manager::{
   mod_repository::{Mod, ModRepository},
   shard::{self, ProfileBase, ShardIndex, ShardLocator},
   steam_manager::SteamManager,
-  vpk_manager::staging::VpkStaging,
+  vpk_manager::staging::{PendingVpkOperation, VpkStaging},
   vpk_manager::{MissingVpkPolicy, ShardAssignment, ShardPlacement, SwapRequest, VpkManager},
   vpk_manifest::{ProfileVpkManifest, ProfileVpkManifestEntry},
 };
@@ -1151,5 +1151,51 @@ mod tests {
     let after = ProfileVpkManifest::load(&base).unwrap();
     assert!(after.mods.contains_key("other"));
     assert!(!after.mods.contains_key("target"));
+  }
+
+  #[test]
+  fn update_mod_from_prepared_replaces_files_without_touching_other_mods() {
+    let game = game_dir();
+    let addons_path = game.path().join("game").join("citadel").join("addons");
+    fs::create_dir_all(&addons_path).unwrap();
+    let base = crate::mod_manager::shard::ProfileBase::new(&addons_path).unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "target",
+      ShardIndex::FIRST,
+      "pak01_dir.vpk",
+      b"old-target",
+    );
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "other",
+      ShardIndex::FIRST,
+      "pak02_dir.vpk",
+      b"other",
+    );
+    manifest.save(&base).unwrap();
+
+    let prepared_dir = game.path().join("prepared");
+    fs::create_dir_all(&prepared_dir).unwrap();
+    let prepared = prepared_dir.join("replacement.vpk");
+    fs::write(&prepared, b"new-target").unwrap();
+
+    let mut manager = test_manager(game.path());
+    let updated = manager
+      .update_mod_from_prepared("target", "Target", &[prepared], None, None)
+      .unwrap();
+
+    assert_eq!(updated.installed_vpks, vec!["pak01_dir.vpk".to_string()]);
+    assert_eq!(fs::read(base.join("pak01_dir.vpk")).unwrap(), b"new-target");
+    assert_eq!(fs::read(base.join("pak02_dir.vpk")).unwrap(), b"other");
+    let after = ProfileVpkManifest::load(&base).unwrap();
+    assert_eq!(
+      after.mods["target"].original_vpk_names,
+      vec!["replacement.vpk".to_string()]
+    );
+    assert!(after.mods.contains_key("other"));
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -1001,4 +1001,155 @@ mod tests {
       assert!(matches!(result, Err(Error::InvalidInput(_))), "{mod_id}");
     }
   }
+
+  fn write_owned_mod(
+    addons_path: &crate::mod_manager::shard::ProfileBase,
+    manifest: &mut ProfileVpkManifest,
+    mod_id: &str,
+    shard: ShardIndex,
+    filename: &str,
+    contents: &[u8],
+  ) {
+    let dir = addons_path.shard_dir(shard);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join(filename), contents).unwrap();
+    manifest.mark_enabled(
+      mod_id,
+      vec![filename.to_string()],
+      vec![format!("{mod_id}.vpk")],
+      None,
+      shard,
+    );
+  }
+
+  /// A stale frontend `pak01_dir.vpk` used to resolve to shard 1 even when the
+  /// target lived in shard 2, deleting another mod's file.
+  #[test]
+  fn remove_mod_vpks_ignores_stale_filename_when_manifest_owns_the_mod() {
+    let game = game_dir();
+    let addons_path = game.path().join("game").join("citadel").join("addons");
+    fs::create_dir_all(&addons_path).unwrap();
+    let base = crate::mod_manager::shard::ProfileBase::new(&addons_path).unwrap();
+    let shard_two = ShardIndex::new(2).unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "target",
+      shard_two,
+      "pak01_dir.vpk",
+      b"target",
+    );
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "other",
+      ShardIndex::FIRST,
+      "pak01_dir.vpk",
+      b"other",
+    );
+    manifest.save(&base).unwrap();
+
+    let mut manager = test_manager(game.path());
+    manager.mod_repository.add_mod(Mod {
+      id: "target".into(),
+      name: "target".into(),
+      is_map: false,
+      installed_vpks: vec!["pak01_dir.vpk".into()],
+      file_tree: None,
+      install_order: None,
+      original_vpk_names: vec!["target.vpk".into()],
+    });
+
+    let result = manager
+      .remove_mod_vpks("target", &["pak01_dir.vpk".into()], None)
+      .unwrap();
+
+    assert_eq!(result.count, 1);
+    assert!(!base.shard_dir(shard_two).join("pak01_dir.vpk").exists());
+    assert_eq!(
+      fs::read(base.join("pak01_dir.vpk")).unwrap(),
+      b"other"
+    );
+    let after = ProfileVpkManifest::load(&base).unwrap();
+    assert!(!after.mods.contains_key("target"));
+    assert!(after.mods.contains_key("other"));
+  }
+
+  #[test]
+  fn remove_mod_vpks_does_not_cross_shards_for_identical_filenames() {
+    let game = game_dir();
+    let addons_path = game.path().join("game").join("citadel").join("addons");
+    fs::create_dir_all(&addons_path).unwrap();
+    let base = crate::mod_manager::shard::ProfileBase::new(&addons_path).unwrap();
+    let shard_two = ShardIndex::new(2).unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "target",
+      shard_two,
+      "pak01_dir.vpk",
+      b"target",
+    );
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "other",
+      ShardIndex::FIRST,
+      "pak01_dir.vpk",
+      b"other",
+    );
+    manifest.save(&base).unwrap();
+
+    let mut manager = test_manager(game.path());
+    let result = manager.remove_mod_vpks("target", &[], None).unwrap();
+
+    assert_eq!(result.count, 1);
+    assert!(!base.shard_dir(shard_two).join("pak01_dir.vpk").exists());
+    assert_eq!(
+      fs::read(base.join("pak01_dir.vpk")).unwrap(),
+      b"other"
+    );
+  }
+
+  /// Without a manifest entry, fallback names are still shard-1-resolved, but
+  /// they must not delete a file another entry already claims.
+  #[test]
+  fn remove_mod_vpks_skips_fallback_paths_claimed_by_another_mod() {
+    let game = game_dir();
+    let addons_path = game.path().join("game").join("citadel").join("addons");
+    fs::create_dir_all(&addons_path).unwrap();
+    let base = crate::mod_manager::shard::ProfileBase::new(&addons_path).unwrap();
+    let mut manifest = ProfileVpkManifest::default();
+    write_owned_mod(
+      &base,
+      &mut manifest,
+      "other",
+      ShardIndex::FIRST,
+      "pak01_dir.vpk",
+      b"other",
+    );
+    fs::write(base.join("pak02_dir.vpk"), b"orphan").unwrap();
+    manifest.save(&base).unwrap();
+
+    let mut manager = test_manager(game.path());
+    let result = manager
+      .remove_mod_vpks(
+        "target",
+        &["pak01_dir.vpk".into(), "pak02_dir.vpk".into()],
+        None,
+      )
+      .unwrap();
+
+    assert_eq!(result.count, 1);
+    assert_eq!(
+      fs::read(base.join("pak01_dir.vpk")).unwrap(),
+      b"other"
+    );
+    assert!(!base.join("pak02_dir.vpk").exists());
+    let after = ProfileVpkManifest::load(&base).unwrap();
+    assert!(after.mods.contains_key("other"));
+    assert!(!after.mods.contains_key("target"));
+  }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -1067,10 +1067,7 @@ mod tests {
 
     assert_eq!(result.count, 1);
     assert!(!base.shard_dir(shard_two).join("pak01_dir.vpk").exists());
-    assert_eq!(
-      fs::read(base.join("pak01_dir.vpk")).unwrap(),
-      b"other"
-    );
+    assert_eq!(fs::read(base.join("pak01_dir.vpk")).unwrap(), b"other");
     let after = ProfileVpkManifest::load(&base).unwrap();
     assert!(!after.mods.contains_key("target"));
     assert!(after.mods.contains_key("other"));
@@ -1107,10 +1104,7 @@ mod tests {
 
     assert_eq!(result.count, 1);
     assert!(!base.shard_dir(shard_two).join("pak01_dir.vpk").exists());
-    assert_eq!(
-      fs::read(base.join("pak01_dir.vpk")).unwrap(),
-      b"other"
-    );
+    assert_eq!(fs::read(base.join("pak01_dir.vpk")).unwrap(), b"other");
   }
 
   /// Without a manifest entry, fallback names are still shard-1-resolved, but
@@ -1143,10 +1137,7 @@ mod tests {
       .unwrap();
 
     assert_eq!(result.count, 1);
-    assert_eq!(
-      fs::read(base.join("pak01_dir.vpk")).unwrap(),
-      b"other"
-    );
+    assert_eq!(fs::read(base.join("pak01_dir.vpk")).unwrap(), b"other");
     assert!(!base.join("pak02_dir.vpk").exists());
     let after = ProfileVpkManifest::load(&base).unwrap();
     assert!(after.mods.contains_key("other"));
@@ -1184,9 +1175,36 @@ mod tests {
     fs::write(&prepared, b"new-target").unwrap();
 
     let mut manager = test_manager(game.path());
+    let preserved_tree = crate::mod_manager::file_tree::ModFileTree {
+      files: vec![],
+      total_files: 0,
+      has_multiple_files: false,
+    };
+    manager.mod_repository.add_mod(Mod {
+      id: "target".into(),
+      name: "Original map".into(),
+      is_map: true,
+      installed_vpks: vec!["pak01_dir.vpk".into()],
+      file_tree: Some(preserved_tree.clone()),
+      install_order: Some(0),
+      original_vpk_names: vec!["original.vpk".into()],
+    });
     let updated = manager
-      .update_mod_from_prepared("target", "Target", &[prepared], None, None)
+      .update_mod_from_prepared(
+        "target",
+        "Target",
+        std::slice::from_ref(&prepared),
+        None,
+        None,
+      )
       .unwrap();
+
+    assert!(updated.is_map);
+    assert_eq!(
+      updated.file_tree.as_ref().unwrap().total_files,
+      preserved_tree.total_files
+    );
+    assert_eq!(updated.name, "Target");
 
     assert_eq!(updated.installed_vpks, vec!["pak01_dir.vpk".to_string()]);
     assert_eq!(fs::read(base.join("pak01_dir.vpk")).unwrap(), b"new-target");
@@ -1197,5 +1215,12 @@ mod tests {
       vec!["replacement.vpk".to_string()]
     );
     assert!(after.mods.contains_key("other"));
+    manager
+      .replace_mod_vpks("target".into(), vec![prepared], vec![], None)
+      .unwrap();
+    let replaced = manager.mod_repository.get_mod("target").unwrap();
+    assert_eq!(replaced.name, "Target");
+    assert!(replaced.is_map);
+    assert!(replaced.file_tree.is_some());
   }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
@@ -528,4 +528,117 @@ impl ModManager {
     log::info!("Successfully replaced VPK files for mod: {mod_id}");
     Ok(())
   }
+
+  /// Replace a working install with already-extracted VPKs without deleting the
+  /// old files first. Old paths are staged, new files are written, and the
+  /// manifest is committed in one journaled operation.
+  pub fn update_mod_from_prepared(
+    &mut self,
+    mod_id: &str,
+    mod_name: &str,
+    prepared_vpks: &[PathBuf],
+    file_tree: Option<ModFileTree>,
+    profile_folder: Option<String>,
+  ) -> Result<Mod, Error> {
+    Self::ensure_safe_mod_id(mod_id)?;
+    if prepared_vpks.is_empty() {
+      return Err(Error::InvalidInput(
+        "No prepared VPKs provided for update".to_string(),
+      ));
+    }
+
+    let addons_path = self.get_addons_path(profile_folder.as_deref())?;
+    let mut manifest = ProfileVpkManifest::open_for_write(&addons_path)?;
+    let existing = manifest.mods.get(mod_id).cloned();
+    let install_order = existing.as_ref().and_then(|entry| entry.order);
+    let old_count = existing
+      .as_ref()
+      .filter(|entry| entry.enabled)
+      .map(|entry| entry.current_vpks.len() as u32)
+      .unwrap_or(0);
+    let target_shard = Self::choose_shard_for(
+      &addons_path,
+      existing
+        .as_ref()
+        .map(|entry| (entry.shard, old_count)),
+      prepared_vpks.len() as u32,
+    )?;
+    let enabled_dir = addons_path.shard_dir(target_shard);
+    std::fs::create_dir_all(&enabled_dir)?;
+
+    let reuse_names = existing.as_ref().is_some_and(|entry| {
+      entry.enabled
+        && entry.shard == target_shard
+        && entry.current_vpks.len() == prepared_vpks.len()
+    });
+    let staging_name = format!("{}{mod_id}", shard::UPDATE_STAGING_PREFIX);
+    let mut staging = VpkStaging::claim(&addons_path, &staging_name)?;
+
+    if let Some(entry) = &existing {
+      for path in entry.file_paths(&addons_path) {
+        if path.is_file()
+          && let Err(error) = staging.stage(&addons_path, &path)
+        {
+          return Err(staging.rollback(error));
+        }
+      }
+    }
+
+    let dest_names = if reuse_names {
+      existing
+        .as_ref()
+        .map(|entry| entry.current_vpks.clone())
+        .unwrap_or_default()
+    } else {
+      match crate::mod_manager::vpk_manager::allocate_enabled_vpk_names(
+        &enabled_dir,
+        prepared_vpks.len(),
+      ) {
+        Ok(names) => names,
+        Err(error) => return Err(staging.rollback(error)),
+      }
+    };
+
+    for (source, dest_name) in prepared_vpks.iter().zip(dest_names.iter()) {
+      let dest = enabled_dir.join(dest_name);
+      if let Err(error) = staging.track_created(&dest) {
+        return Err(staging.rollback(error));
+      }
+      if let Err(error) = std::fs::copy(source, &dest).map_err(Error::from) {
+        return Err(staging.rollback(error));
+      }
+    }
+
+    let original_vpk_names: Vec<String> = prepared_vpks
+      .iter()
+      .filter_map(|path| {
+        path
+          .file_name()
+          .map(|name| name.to_string_lossy().into_owned())
+      })
+      .collect();
+
+    manifest.mark_enabled(
+      mod_id,
+      dest_names.clone(),
+      original_vpk_names.clone(),
+      install_order,
+      target_shard,
+    );
+
+    let pending = PendingVpkOperation::with_staging((), staging);
+    pending.commit_manifest(&manifest, &addons_path)?;
+
+    let updated = Mod {
+      id: mod_id.to_string(),
+      name: mod_name.to_string(),
+      is_map: false,
+      installed_vpks: dest_names,
+      file_tree,
+      install_order,
+      original_vpk_names,
+    };
+    self.mod_repository.add_mod(updated.clone());
+    Ok(updated)
+  }
 }

--- a/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
@@ -496,7 +496,18 @@ impl ModManager {
       Vec::new()
     };
 
-    // Use VpkManager to replace the files
+    if !installed_vpks.is_empty() {
+      self.update_mod_from_prepared(
+        &mod_id,
+        &mod_id,
+        &source_vpk_paths,
+        None,
+        profile_folder,
+      )?;
+      log::info!("Successfully replaced VPK files for mod: {mod_id}");
+      return Ok(());
+    }
+
     self.vpk_manager.replace_vpks(
       &addons_path,
       &enabled_dir,
@@ -511,18 +522,8 @@ impl ModManager {
       .collect();
 
     let mut manifest = ProfileVpkManifest::load(&addons_path)?;
-    if installed_vpks.is_empty() {
-      let prefixed_vpks = self.vpk_manager.find_prefixed_vpks(&addons_path, &mod_id)?;
-      manifest.mark_disabled(&mod_id, prefixed_vpks, new_original_names);
-    } else {
-      manifest.mark_enabled(
-        &mod_id,
-        installed_vpks,
-        new_original_names,
-        None,
-        target_shard,
-      );
-    }
+    let prefixed_vpks = self.vpk_manager.find_prefixed_vpks(&addons_path, &mod_id)?;
+    manifest.mark_disabled(&mod_id, prefixed_vpks, new_original_names);
     manifest.save(&addons_path)?;
 
     log::info!("Successfully replaced VPK files for mod: {mod_id}");

--- a/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
@@ -331,34 +331,15 @@ impl ModManager {
     let mut manifest = ProfileVpkManifest::open_for_write(&addons_path)?;
     let manifest_entry = manifest.mods.get(mod_id).cloned();
     let install_order = manifest_entry.as_ref().and_then(|entry| entry.order);
-    let mut sources = HashSet::new();
-
-    if let Some(entry) = &manifest_entry {
-      for path in entry.file_paths(&addons_path) {
-        if path.is_file() {
-          sources.insert(path);
-        }
-      }
-    }
-
-    for prefixed_vpk in self.vpk_manager.find_prefixed_vpks(&addons_path, mod_id)? {
-      let path = addons_path.join(prefixed_vpk);
-      if path.is_file() {
-        sources.insert(path);
-      }
-    }
-
-    let mut fallback_names = fallback_vpks.to_vec();
-    if let Some(repository_mod) = self.mod_repository.get_mod(mod_id) {
-      fallback_names.extend(repository_mod.installed_vpks.clone());
-    }
-    for fallback in fallback_names {
-      let locator = ShardLocator::from_legacy_name(&fallback);
-      let path = addons_path.locator_path(&locator);
-      if path.is_file() {
-        sources.insert(path);
-      }
-    }
+    let sources = if let Some(entry) = &manifest_entry {
+      entry
+        .file_paths(&addons_path)
+        .into_iter()
+        .filter(|path| path.is_file())
+        .collect::<HashSet<_>>()
+    } else {
+      self.discover_unowned_mod_vpks(mod_id, fallback_vpks, &addons_path, &manifest)?
+    };
 
     if sources.is_empty() && manifest_entry.is_none() {
       self.mod_repository.remove_mod(mod_id);
@@ -392,6 +373,46 @@ impl ModManager {
       count: removed_count,
       install_order,
     })
+  }
+
+  /// Discover VPKs for a mod that has no manifest entry, without touching
+  /// files another entry already claims. Bare fallback names resolve to shard 1,
+  /// so this filter is what stops a stale `pak01_dir.vpk` from deleting a
+  /// different mod's file.
+  fn discover_unowned_mod_vpks(
+    &self,
+    mod_id: &str,
+    fallback_vpks: &[String],
+    addons_path: &ProfileBase,
+    manifest: &ProfileVpkManifest,
+  ) -> Result<HashSet<PathBuf>, Error> {
+    let claimed: HashSet<PathBuf> = manifest
+      .mods
+      .values()
+      .flat_map(|entry| entry.file_paths(addons_path))
+      .collect();
+    let mut sources = HashSet::new();
+
+    for prefixed_vpk in self.vpk_manager.find_prefixed_vpks(addons_path, mod_id)? {
+      let path = addons_path.join(prefixed_vpk);
+      if path.is_file() && !claimed.contains(&path) {
+        sources.insert(path);
+      }
+    }
+
+    let mut fallback_names = fallback_vpks.to_vec();
+    if let Some(repository_mod) = self.mod_repository.get_mod(mod_id) {
+      fallback_names.extend(repository_mod.installed_vpks.clone());
+    }
+    for fallback in fallback_names {
+      let locator = ShardLocator::from_legacy_name(&fallback);
+      let path = addons_path.locator_path(&locator);
+      if path.is_file() && !claimed.contains(&path) {
+        sources.insert(path);
+      }
+    }
+
+    Ok(sources)
   }
 
   pub fn hydrate_mods_from_manifest(

--- a/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager/lifecycle.rs
@@ -497,11 +497,18 @@ impl ModManager {
     };
 
     if !installed_vpks.is_empty() {
+      let existing_mod = self.mod_repository.get_mod(&mod_id).cloned();
+      let mod_name = existing_mod
+        .as_ref()
+        .map(|mod_info| mod_info.name.as_str())
+        .unwrap_or(&mod_id);
       self.update_mod_from_prepared(
         &mod_id,
-        &mod_id,
+        mod_name,
         &source_vpk_paths,
-        None,
+        existing_mod
+          .as_ref()
+          .and_then(|mod_info| mod_info.file_tree.clone()),
         profile_folder,
       )?;
       log::info!("Successfully replaced VPK files for mod: {mod_id}");
@@ -559,9 +566,7 @@ impl ModManager {
       .unwrap_or(0);
     let target_shard = Self::choose_shard_for(
       &addons_path,
-      existing
-        .as_ref()
-        .map(|entry| (entry.shard, old_count)),
+      existing.as_ref().map(|entry| (entry.shard, old_count)),
       prepared_vpks.len() as u32,
     )?;
     let enabled_dir = addons_path.shard_dir(target_shard);
@@ -630,12 +635,13 @@ impl ModManager {
     let pending = PendingVpkOperation::with_staging((), staging);
     pending.commit_manifest(&manifest, &addons_path)?;
 
+    let previous_mod = self.mod_repository.get_mod(mod_id);
     let updated = Mod {
       id: mod_id.to_string(),
       name: mod_name.to_string(),
-      is_map: false,
+      is_map: previous_mod.is_some_and(|mod_info| mod_info.is_map),
       installed_vpks: dest_names,
-      file_tree,
+      file_tree: file_tree.or_else(|| previous_mod.and_then(|mod_info| mod_info.file_tree.clone())),
       install_order,
       original_vpk_names,
     };

--- a/apps/desktop/src-tauri/src/mod_manager/manager/reorder.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager/reorder.rs
@@ -424,7 +424,7 @@ impl ModManager {
     })
   }
 
-  pub(super) fn reorder_all_mods_for_profile(
+  pub fn reorder_all_mods_for_profile(
     &mut self,
     profile_folder: Option<String>,
   ) -> Result<(), Error> {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -18,6 +18,8 @@ mod operations;
 mod reorder;
 pub(crate) mod staging;
 
+pub(crate) use naming::allocate_enabled_vpk_names;
+
 /// Final placement of a mod's enabled VPKs after a sharded reorder.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShardPlacement {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager.rs
@@ -440,7 +440,13 @@ mod tests {
     fs::create_dir_all(&reorder).unwrap();
     fs::write(reorder.join("s1__pak01_dir.vpk"), b"staged").unwrap();
 
-    recover_staging_directory(&base, &reorder, RecoveryMode::AvoidEnabledCollisions).unwrap();
+    recover_staging_directory(
+      &base,
+      &reorder,
+      RecoveryMode::AvoidEnabledCollisions,
+      &crate::mod_manager::vpk_manifest::ProfileVpkManifest::default(),
+    )
+    .unwrap();
 
     // Neither file is lost: the placed file keeps its slot, the staged file is
     // recovered into a free one.

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/naming.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/naming.rs
@@ -78,6 +78,40 @@ pub(super) fn enabled_vpk_name(number: u32) -> String {
   format!("pak{number:02}_dir.vpk")
 }
 
+/// Lowest unused `pak##_dir.vpk` names in `dir`, filling gaps left by disabled mods.
+pub(crate) fn allocate_enabled_vpk_names(dir: &Path, count: usize) -> Result<Vec<String>, Error> {
+  let mut used = std::collections::HashSet::new();
+  if dir.exists() {
+    for entry in fs::read_dir(dir)? {
+      let path = entry?.path();
+      if path.is_file()
+        && let Some(name) = path.file_name().and_then(|name| name.to_str())
+        && let Some(number) = VpkManager::enabled_vpk_number(name)
+      {
+        used.insert(number);
+      }
+    }
+  }
+
+  let mut names = Vec::with_capacity(count);
+  let mut number = 1u32;
+  while names.len() < count {
+    if number > shard::SHARD_CAPACITY {
+      return Err(Error::ModInvalid(format!(
+        "Cannot allocate {count} enabled VPK names in {}; shard capacity is {}",
+        dir.display(),
+        shard::SHARD_CAPACITY
+      )));
+    }
+    if !used.contains(&number) {
+      names.push(enabled_vpk_name(number));
+      used.insert(number);
+    }
+    number += 1;
+  }
+  Ok(names)
+}
+
 /// Lowest `pak##_dir.vpk` name not yet taken in `dir`, filling gaps left by
 /// disabled mods.
 pub(super) fn next_free_enabled_vpk_name(dir: &Path) -> Result<String, Error> {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/reorder.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/reorder.rs
@@ -39,7 +39,13 @@ impl VpkManager {
     let temp_dir = base.join(shard::REORDER_STAGING_DIR);
     if temp_dir.exists() {
       log::warn!("Recovering VPK files left by an interrupted reorder");
-      recover_staging_directory(&base, &temp_dir, RecoveryMode::AvoidEnabledCollisions)?;
+      let manifest = crate::mod_manager::vpk_manifest::ProfileVpkManifest::load(&base)?;
+      recover_staging_directory(
+        &base,
+        &temp_dir,
+        RecoveryMode::AvoidEnabledCollisions,
+        &manifest,
+      )?;
     }
 
     let duplicate_assignments = Self::duplicate_sharded_assignments(ordered_mods);

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
@@ -1,10 +1,33 @@
 use super::naming;
 use crate::errors::Error;
 use crate::mod_manager::fs_retry;
-use crate::mod_manager::shard::{ProfileBase, StagedName};
+use crate::mod_manager::shard::{ProfileBase, ShardLocator, StagedName};
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+
+const JOURNAL_FILENAME: &str = ".transaction.jsonl";
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "camelCase")]
+enum JournalEvent {
+  Stage {
+    original: String,
+  },
+  Place {
+    original: String,
+    destination: String,
+  },
+  Create {
+    path: String,
+  },
+  Manifest {
+    manifest: ProfileVpkManifest,
+  },
+}
 
 pub enum RecoveryMode {
   /// Fail if a staged file's original slot is occupied. Used where the caller
@@ -20,9 +43,15 @@ pub fn recover_staging_directory(
   base: &ProfileBase,
   staging_dir: &Path,
   mode: RecoveryMode,
+  manifest: &ProfileVpkManifest,
 ) -> Result<(), Error> {
   if !staging_dir.is_dir() {
     return Ok(());
+  }
+
+  let journal_path = staging_dir.join(JOURNAL_FILENAME);
+  if journal_path.is_file() {
+    return recover_journaled_staging(base, staging_dir, &journal_path, manifest);
   }
 
   for entry in fs::read_dir(staging_dir)? {
@@ -54,7 +83,118 @@ pub fn recover_staging_directory(
   Ok(())
 }
 
+fn recover_journaled_staging(
+  base: &ProfileBase,
+  staging_dir: &Path,
+  journal_path: &Path,
+  manifest: &ProfileVpkManifest,
+) -> Result<(), Error> {
+  let contents = fs::read_to_string(journal_path)?;
+  let lines: Vec<&str> = contents.lines().collect();
+  let mut originals = Vec::new();
+  let mut placements = std::collections::BTreeMap::new();
+  let mut created = BTreeSet::new();
+  let mut expected_manifest = None;
+
+  for (index, line) in lines.iter().enumerate() {
+    if line.trim().is_empty() {
+      continue;
+    }
+    let event = match serde_json::from_str::<JournalEvent>(line) {
+      Ok(event) => event,
+      Err(error) if index + 1 == lines.len() && !contents.ends_with('\n') => {
+        log::warn!(
+          "Ignoring incomplete final VPK transaction journal record at {}: {error}",
+          journal_path.display()
+        );
+        break;
+      }
+      Err(error) => {
+        return Err(Error::ModInvalid(format!(
+          "Invalid VPK transaction journal at {}: {error}",
+          journal_path.display()
+        )));
+      }
+    };
+    match event {
+      JournalEvent::Stage { original } => {
+        if !originals.contains(&original) {
+          originals.push(original);
+        }
+      }
+      JournalEvent::Place {
+        original,
+        destination,
+      } => {
+        placements.insert(original, destination);
+      }
+      JournalEvent::Create { path } => {
+        created.insert(path);
+      }
+      JournalEvent::Manifest {
+        manifest: expected,
+      } => expected_manifest = Some(expected),
+    }
+  }
+
+  if expected_manifest.as_ref() == Some(manifest) {
+    fs::remove_dir_all(staging_dir)?;
+    return Ok(());
+  }
+
+  let mut files = Vec::new();
+  for original in originals {
+    let locator = ShardLocator::parse(&original)?;
+    let parked = staging_dir.join(StagedName::new(locator.shard, &locator.filename).encode());
+    let current = placements
+      .get(&original)
+      .map(|path| ShardLocator::parse(path))
+      .transpose()?
+      .map(|path| base.locator_path(&path))
+      .unwrap_or_else(|| parked.clone());
+    files.push((base.locator_path(&locator), parked, current));
+  }
+
+  for (_, parked, current) in &files {
+    if current == parked || !current.exists() {
+      continue;
+    }
+    if parked.exists() {
+      return Err(Error::ModInvalid(format!(
+        "Cannot recover VPK transaction because both {} and {} exist",
+        current.display(),
+        parked.display()
+      )));
+    }
+    fs::rename(current, parked)?;
+  }
+
+  for path in created {
+    let locator = ShardLocator::parse(&path)?;
+    let path = base.locator_path(&locator);
+    if path.is_file() {
+      fs::remove_file(path)?;
+    }
+  }
+
+  for (original, parked, _) in files.into_iter().rev() {
+    if !parked.exists() {
+      continue;
+    }
+    if original.is_file() {
+      fs::remove_file(&original)?;
+    }
+    if let Some(parent) = original.parent() {
+      fs::create_dir_all(parent)?;
+    }
+    fs::rename(parked, original)?;
+  }
+  fs::remove_dir_all(staging_dir)?;
+  Ok(())
+}
+
 struct StagedFile {
+  original_locator: String,
   original: PathBuf,
   current: PathBuf,
   /// Where this file sits while parked in the staging directory. Always a
@@ -67,8 +207,10 @@ struct StagedFile {
 /// committed, including on an unwind. Files parked here survive a crash: the
 /// next manifest load recovers them via [`recover_staging_directory`].
 pub struct VpkStaging {
+  base: ProfileBase,
   dir: PathBuf,
   files: Vec<StagedFile>,
+  created: BTreeSet<PathBuf>,
   finalized: bool,
 }
 
@@ -87,11 +229,47 @@ impl VpkStaging {
       }
     })?;
 
+    OpenOptions::new()
+      .create_new(true)
+      .write(true)
+      .open(dir.join(JOURNAL_FILENAME))?
+      .sync_all()?;
+
     Ok(Self {
+      base: base.clone(),
       dir,
       files: Vec::new(),
+      created: BTreeSet::new(),
       finalized: false,
     })
+  }
+
+  fn append_journal(&self, event: &JournalEvent) -> Result<(), Error> {
+    let mut journal = OpenOptions::new()
+      .append(true)
+      .open(self.dir.join(JOURNAL_FILENAME))?;
+    serde_json::to_writer(&mut journal, event)
+      .map_err(|error| Error::ModInvalid(format!("Failed to write VPK journal: {error}")))?;
+    journal.write_all(b"\n")?;
+    journal.sync_all()?;
+    Ok(())
+  }
+
+  fn locator_for(&self, path: &Path) -> Result<String, Error> {
+    let shard = path
+      .parent()
+      .and_then(|parent| self.base.shard_of_dir(parent))
+      .ok_or_else(|| {
+        Error::ModInvalid(format!(
+          "Cannot journal VPK outside profile shards: {}",
+          path.display()
+        ))
+      })?;
+    let filename = path
+      .file_name()
+      .and_then(|name| name.to_str())
+      .ok_or_else(|| Error::ModInvalid("VPK filename is not valid UTF-8".to_string()))?;
+    Ok(ShardLocator::new(shard, filename).to_wire())
   }
 
   pub fn stage(&mut self, base: &ProfileBase, source: &Path) -> Result<PathBuf, Error> {
@@ -109,12 +287,17 @@ impl VpkStaging {
       .and_then(|name| name.to_str())
       .ok_or_else(|| Error::ModInvalid("VPK filename is not valid UTF-8".to_string()))?;
     let staged = self.dir.join(StagedName::new(shard, filename).encode());
-    fs::rename(source, &staged)?;
+    let original_locator = ShardLocator::new(shard, filename).to_wire();
+    self.append_journal(&JournalEvent::Stage {
+      original: original_locator.clone(),
+    })?;
     self.files.push(StagedFile {
+      original_locator,
       original: source.to_path_buf(),
       current: staged.clone(),
       parked: staged.clone(),
     });
+    fs::rename(source, &staged)?;
     Ok(staged)
   }
 
@@ -128,14 +311,32 @@ impl VpkStaging {
     if let Some(parent) = destination.parent() {
       fs::create_dir_all(parent)?;
     }
-    fs::rename(staged, destination)?;
-    let file = self
+    let index = self
       .files
-      .iter_mut()
-      .find(|file| file.current == staged)
+      .iter()
+      .position(|file| file.current == staged)
       .ok_or_else(|| Error::ModInvalid(format!("Untracked staged VPK: {}", staged.display())))?;
-    file.current = destination.to_path_buf();
+    self.append_journal(&JournalEvent::Place {
+      original: self.files[index].original_locator.clone(),
+      destination: self.locator_for(destination)?,
+    })?;
+    fs::rename(staged, destination)?;
+    self.files[index].current = destination.to_path_buf();
     Ok(())
+  }
+
+  pub fn track_created(&mut self, path: &Path) -> Result<(), Error> {
+    let locator = self.locator_for(path)?;
+    if self.created.insert(path.to_path_buf()) {
+      self.append_journal(&JournalEvent::Create { path: locator })?;
+    }
+    Ok(())
+  }
+
+  fn prepare_manifest_commit(&self, manifest: &ProfileVpkManifest) -> Result<(), Error> {
+    self.append_journal(&JournalEvent::Manifest {
+      manifest: manifest.clone(),
+    })
   }
 
   pub fn commit(mut self) {
@@ -182,8 +383,16 @@ impl VpkStaging {
       file.current = file.parked.clone();
     }
 
+    for path in &self.created {
+      if path.is_file()
+        && let Err(error) = fs::remove_file(path)
+      {
+        failures.push(format!("failed to remove {}: {error}", path.display()));
+      }
+    }
+
     for file in self.files.iter().rev() {
-      if !file.current.exists() || file.current == file.original {
+      if !file.parked.exists() {
         continue;
       }
       if let Some(parent) = file.original.parent()
@@ -192,10 +401,16 @@ impl VpkStaging {
         failures.push(format!("failed to create {}: {error}", parent.display()));
         continue;
       }
-      if let Err(error) = fs::rename(&file.current, &file.original) {
+      if file.original.is_file()
+        && let Err(error) = fs::remove_file(&file.original)
+      {
+        failures.push(format!("failed to remove {}: {error}", file.original.display()));
+        continue;
+      }
+      if let Err(error) = fs::rename(&file.parked, &file.original) {
         failures.push(format!(
           "{} -> {}: {error}",
-          file.current.display(),
+          file.parked.display(),
           file.original.display()
         ));
       }
@@ -251,6 +466,20 @@ impl<T> PendingVpkOperation<T> {
       PendingGuard::Snapshot(snapshot) => snapshot.commit(),
     }
     self.value
+  }
+
+  pub fn commit_manifest(
+    mut self,
+    manifest: &ProfileVpkManifest,
+    addons_path: &Path,
+  ) -> Result<T, Error> {
+    if let PendingGuard::Staging(staging) = &mut self.guard {
+      staging.prepare_manifest_commit(manifest)?;
+    }
+    if let Err(error) = manifest.save(addons_path) {
+      return Err(self.rollback(error));
+    }
+    Ok(self.commit())
   }
 
   pub fn rollback(self, original_error: Error) -> Error {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
@@ -442,7 +442,7 @@ pub struct PendingVpkOperation<T> {
 }
 
 impl<T> PendingVpkOperation<T> {
-  pub(super) fn with_staging(value: T, staging: VpkStaging) -> Self {
+  pub(crate) fn with_staging(value: T, staging: VpkStaging) -> Self {
     Self {
       value,
       guard: PendingGuard::Staging(staging),

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
@@ -131,9 +131,7 @@ fn recover_journaled_staging(
       JournalEvent::Create { path } => {
         created.insert(path);
       }
-      JournalEvent::Manifest {
-        manifest: expected,
-      } => expected_manifest = Some(expected),
+      JournalEvent::Manifest { manifest: expected } => expected_manifest = Some(expected),
     }
   }
 
@@ -350,9 +348,8 @@ impl VpkStaging {
   }
 
   pub fn rollback(mut self, original_error: Error) -> Error {
-    let failures = self.restore_files();
+    let failures = self.restore_and_clean_up();
     self.finalized = true;
-    let _ = fs::remove_dir(&self.dir);
     if failures.is_empty() {
       original_error
     } else {
@@ -361,6 +358,23 @@ impl VpkStaging {
         failures.join("; ")
       ))
     }
+  }
+
+  fn restore_and_clean_up(&mut self) -> Vec<String> {
+    let mut failures = self.restore_files();
+    // Keep the journal and parked payloads when restoration is incomplete.
+    // A completed rollback must discard its journal before the next mutation
+    // can mistake the old placements for an interrupted transaction.
+    if failures.is_empty() {
+      if let Err(error) = fs::remove_file(self.dir.join(JOURNAL_FILENAME)) {
+        failures.push(format!("failed to remove rolled-back journal: {error}"));
+      } else if let Err(error) = fs::remove_dir(&self.dir) {
+        failures.push(format!(
+          "failed to remove rolled-back staging directory: {error}"
+        ));
+      }
+    }
+    failures
   }
 
   fn restore_files(&mut self) -> Vec<String> {
@@ -404,7 +418,10 @@ impl VpkStaging {
       if file.original.is_file()
         && let Err(error) = fs::remove_file(&file.original)
       {
-        failures.push(format!("failed to remove {}: {error}", file.original.display()));
+        failures.push(format!(
+          "failed to remove {}: {error}",
+          file.original.display()
+        ));
         continue;
       }
       if let Err(error) = fs::rename(&file.parked, &file.original) {
@@ -661,10 +678,9 @@ impl Drop for VpkStaging {
     if self.finalized {
       return;
     }
-    for failure in self.restore_files() {
+    for failure in self.restore_and_clean_up() {
       log::error!("Failed to roll back dropped VPK staging transaction: {failure}");
     }
-    let _ = fs::remove_dir(&self.dir);
   }
 }
 
@@ -697,6 +713,24 @@ mod tests {
     assert!(matches!(error, Error::InvalidInput(_)));
     assert_eq!(fs::read(original).unwrap(), b"vpk");
     assert!(!placed.exists());
+  }
+
+  #[test]
+  fn incomplete_rollback_retains_journal_and_payload_for_recovery() {
+    let temp = tempfile::tempdir().unwrap();
+    let base = base(&temp);
+    let original = base.join("pak01_dir.vpk");
+    fs::write(&original, b"retained").unwrap();
+    let mut staging = VpkStaging::claim(&base, ".test-staging").unwrap();
+    let parked = staging.stage(&base, &original).unwrap();
+    fs::create_dir(&original).unwrap();
+    fs::write(original.join("blocker"), b"protected").unwrap();
+
+    let error = staging.rollback(Error::InvalidInput("interrupted".into()));
+    assert!(matches!(error, Error::RollbackFailed(_)));
+    assert_eq!(fs::read(&parked).unwrap(), b"retained");
+    assert!(base.join(".test-staging").join(JOURNAL_FILENAME).is_file());
+    assert_eq!(fs::read(original.join("blocker")).unwrap(), b"protected");
   }
 
   /// A reorder routinely gives file A the slot file B came from. Rolling that

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -243,7 +243,7 @@ impl ProfileVpkManifest {
       if manifest.mods.is_empty() {
         fs::remove_dir_all(&clear_staging)?;
       } else {
-        recover_staging_directory(&base, &clear_staging, RecoveryMode::Strict)?;
+        recover_staging_directory(&base, &clear_staging, RecoveryMode::Strict, manifest)?;
       }
     }
 
@@ -253,6 +253,7 @@ impl ProfileVpkManifest {
         &base,
         &reorder_staging,
         RecoveryMode::AvoidEnabledCollisions,
+        manifest,
       )?;
     }
 
@@ -271,7 +272,7 @@ impl ProfileVpkManifest {
         continue;
       };
       if manifest.mods.contains_key(mod_id) {
-        recover_staging_directory(&base, &path, RecoveryMode::Strict)?;
+        recover_staging_directory(&base, &path, RecoveryMode::Strict, manifest)?;
       } else {
         fs::remove_dir_all(path)?;
       }

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -116,7 +116,8 @@ impl ProfileVpkManifest {
       }
       let base = ProfileBase::from_snapshot(&profile_path)?;
       let manifest = Self::load(&profile_path)?;
-      for (mod_id, entry) in manifest.mods {
+      let mut claimed = std::collections::BTreeMap::<String, String>::new();
+      for (mod_id, entry) in &manifest.mods {
         let missing: Vec<String> = entry
           .file_paths(&base)
           .into_iter()
@@ -128,6 +129,14 @@ impl ProfileVpkManifest {
             "Manifest entry {mod_id} references missing VPKs: {}",
             missing.join(", ")
           )));
+        }
+        for path in entry.file_paths(&base) {
+          let key = path.display().to_string();
+          if let Some(owner) = claimed.insert(key.clone(), mod_id.clone()) {
+            return Err(Error::ModInvalid(format!(
+              "Manifest entries {owner} and {mod_id} both claim {key}"
+            )));
+          }
         }
       }
     }

--- a/apps/desktop/src/components/settings/addons-backup-management.tsx
+++ b/apps/desktop/src/components/settings/addons-backup-management.tsx
@@ -82,6 +82,13 @@ export const AddonsBackupManagement = () => {
   const setMaxBackupCount = usePersistedStore(
     (state) => state.setMaxBackupCount,
   );
+  const restoreModsFromManifest = usePersistedStore(
+    (state) => state.restoreModsFromManifest,
+  );
+  const syncProfileEnabledMods = usePersistedStore(
+    (state) => state.syncProfileEnabledMods,
+  );
+  const getActiveProfile = usePersistedStore((state) => state.getActiveProfile);
 
   const loadBackups = useCallback(async () => {
     try {
@@ -167,6 +174,11 @@ export const AddonsBackupManagement = () => {
         fileName: selectedBackup,
         strategy,
       });
+      const activeProfile = getActiveProfile();
+      if (activeProfile) {
+        await restoreModsFromManifest();
+        await syncProfileEnabledMods(activeProfile.id);
+      }
       toast.dismiss();
       toast.success(t("settings.backupRestored"));
       logger

--- a/apps/desktop/src/hooks/use-batch-update.ts
+++ b/apps/desktop/src/hooks/use-batch-update.ts
@@ -27,6 +27,7 @@ export const useBatchUpdate = () => {
     getActiveProfile,
     setInstalledVpks,
     setSelectedDownloads: setStoreSelectedDownloads,
+    updateModVpksAfterReorder,
     localMods,
     backupEnabled,
     maxBackupCount,
@@ -181,6 +182,11 @@ export const useBatchUpdate = () => {
       });
 
       const result = BatchUpdateResultSchema.parse(rawResult);
+      const activeProfileId = activeProfile?.id;
+
+      if (result.vpkMappings && result.vpkMappings.length > 0) {
+        updateModVpksAfterReorder(result.vpkMappings, activeProfileId);
+      }
 
       for (const installedModInfo of result.installedMods) {
         const updatableMod = updatableMods.find(

--- a/apps/desktop/src/lib/store/index.ts
+++ b/apps/desktop/src/lib/store/index.ts
@@ -120,6 +120,7 @@ export const usePersistedStore = create<State>()(
         const {
           modProgress: _modProgress,
           isSwitching: _isSwitching,
+          profileSyncRevision: _profileSyncRevision,
           showWhatsNew: _showWhatsNew,
           lastSeenVersion: _lastSeenVersion,
           forceShowWhatsNew: _forceShowWhatsNew,

--- a/apps/desktop/src/lib/store/index.ts
+++ b/apps/desktop/src/lib/store/index.ts
@@ -120,7 +120,7 @@ export const usePersistedStore = create<State>()(
         const {
           modProgress: _modProgress,
           isSwitching: _isSwitching,
-          profileSyncRevision: _profileSyncRevision,
+          profileSyncRevisions: _profileSyncRevisions,
           showWhatsNew: _showWhatsNew,
           lastSeenVersion: _lastSeenVersion,
           forceShowWhatsNew: _forceShowWhatsNew,

--- a/apps/desktop/src/lib/store/slices/mods.test.ts
+++ b/apps/desktop/src/lib/store/slices/mods.test.ts
@@ -24,6 +24,8 @@ import { createModsSlice, type ModsState } from "./mods";
 type TestState = ModsState & {
   profiles: Record<string, ModProfile>;
   activeProfileId: ProfileId;
+  profileSyncRevision: number;
+  bumpProfileSyncRevision: () => number;
 };
 
 const modFor = (remoteId: string): LocalMod =>
@@ -59,6 +61,12 @@ const createTestStore = () =>
     ),
     profiles: {},
     activeProfileId: createProfileId("default"),
+    profileSyncRevision: 0,
+    bumpProfileSyncRevision: () => {
+      const next = (get().profileSyncRevision ?? 0) + 1;
+      set({ profileSyncRevision: next });
+      return next;
+    },
   }));
 
 let store: ReturnType<typeof createTestStore>;

--- a/apps/desktop/src/lib/store/slices/mods.test.ts
+++ b/apps/desktop/src/lib/store/slices/mods.test.ts
@@ -24,8 +24,8 @@ import { createModsSlice, type ModsState } from "./mods";
 type TestState = ModsState & {
   profiles: Record<string, ModProfile>;
   activeProfileId: ProfileId;
-  profileSyncRevision: number;
-  bumpProfileSyncRevision: () => number;
+  profileSyncRevisions: Record<ProfileId, number>;
+  bumpProfileSyncRevision: (profileId: ProfileId) => number;
 };
 
 const modFor = (remoteId: string): LocalMod =>
@@ -61,10 +61,11 @@ const createTestStore = () =>
     ),
     profiles: {},
     activeProfileId: createProfileId("default"),
-    profileSyncRevision: 0,
-    bumpProfileSyncRevision: () => {
-      const next = (get().profileSyncRevision ?? 0) + 1;
-      set({ profileSyncRevision: next });
+    profileSyncRevisions: {},
+    bumpProfileSyncRevision: (profileId) => {
+      const revisions = get().profileSyncRevisions;
+      const next = (revisions[profileId] ?? 0) + 1;
+      set({ profileSyncRevisions: { ...revisions, [profileId]: next } });
       return next;
     },
   }));
@@ -85,6 +86,25 @@ beforeEach(() => {
 });
 
 describe("removeMod", () => {
+  it("preserves active progress and visibility when removing from another profile", () => {
+    store.setState({ hiddenHeroMods: { "1": true } });
+    const before = store.getState();
+    store.getState().removeMod("1", createProfileId("secondary"));
+    expect(store.getState().modProgress).toBe(before.modProgress);
+    expect(store.getState().hiddenHeroMods).toBe(before.hiddenHeroMods);
+    expect(store.getState().localMods).toBe(before.localMods);
+    expect(store.getState().profiles.secondary.mods).toEqual([]);
+  });
+
+  it("preserves active progress and visibility when nuking another profile", () => {
+    store.setState({ hiddenHeroMods: { "1": true } });
+    const before = store.getState();
+    store.getState().nukeModsState([], createProfileId("secondary"));
+    expect(store.getState().modProgress).toBe(before.modProgress);
+    expect(store.getState().hiddenHeroMods).toBe(before.hiddenHeroMods);
+    expect(store.getState().localMods).toBe(before.localMods);
+    expect(store.getState().profiles.secondary.mods).toEqual([]);
+  });
   it("clears the mod from the active profile's enabled mods", () => {
     store.getState().removeMod("1");
 

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -141,7 +141,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   defaultSort: SortType.LAST_UPDATED,
   setDefaultSort: (sortType: SortType) => set({ defaultSort: sortType }),
-  addLocalMod: (mod, additional, requestedProfileId) =>
+  addLocalMod: (mod, additional, requestedProfileId) => {
+    get().bumpProfileSyncRevision();
     set((state) => {
       const profileId = requestedProfileId ?? state.activeProfileId;
       const profile = state.profiles[profileId];
@@ -184,7 +185,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       return {
         localMods: [...state.localMods, newMod],
       };
-    }),
+    });
+  },
 
   addIdentifiedLocalMod: (mod, filePath, markAsInstalled = true) =>
     set((state) => {
@@ -319,7 +321,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
     );
   },
 
-  removeMod: (remoteId, requestedProfileId) =>
+  removeMod: (remoteId, requestedProfileId) => {
+    get().bumpProfileSyncRevision();
     set((state) => {
       const profileId = requestedProfileId ?? state.activeProfileId;
       const newProgress = { ...state.modProgress };
@@ -359,7 +362,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         modProgress: newProgress,
         hiddenHeroMods,
       };
-    }),
+    });
+  },
 
   setMods: (mods) => set({ localMods: mods }),
 

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -11,10 +11,11 @@ import {
   ModStatus,
   type Progress,
 } from "@/types/mods";
+import type { ProfileId } from "@/types/profiles";
 import type { State } from "..";
 import {
-  applyToModsAndActiveProfile,
   applyToModsAndAllProfiles,
+  applyToModsInProfile,
 } from "../utils/mod-slice";
 
 export type ModProgress = {
@@ -51,36 +52,57 @@ export type ModsState = {
   heroDetection: HeroDetectionProgress;
 
   setDefaultSort: (sortType: SortType) => void;
-  addLocalMod: (mod: ModDto, additional?: Partial<LocalMod>) => void;
+  addLocalMod: (
+    mod: ModDto,
+    additional?: Partial<LocalMod>,
+    profileId?: ProfileId,
+  ) => void;
   addIdentifiedLocalMod: (
     mod: ModDto,
     filePath: string,
     markAsInstalled?: boolean,
   ) => void;
-  removeMod: (remoteId: string) => void;
+  removeMod: (remoteId: string, profileId?: ProfileId) => void;
   setMods: (mods: LocalMod[]) => void;
-  setModStatus: (remoteId: string, status: ModStatus) => void;
+  setModStatus: (
+    remoteId: string,
+    status: ModStatus,
+    profileId?: ProfileId,
+  ) => void;
   setModProgress: (remoteId: string, progress: Progress) => void;
   clearMods: () => void;
-  nukeModsState: (keepRemoteIds: string[]) => void;
+  nukeModsState: (keepRemoteIds: string[], profileId?: ProfileId) => void;
   setInstalledVpks: (
     remoteId: string,
     vpks: string[],
     fileTree?: ModFileTree,
+    profileId?: ProfileId,
   ) => void;
   setSelectedDownloads: (
     remoteId: string,
     downloads: ModDownloadItem[],
+    profileId?: ProfileId,
   ) => void;
-  setModDownloads: (remoteId: string, downloads: ModDownloadItem[]) => void;
-  setActiveVariantArchive: (remoteId: string, archiveName: string) => void;
+  setModDownloads: (
+    remoteId: string,
+    downloads: ModDownloadItem[],
+    profileId?: ProfileId,
+  ) => void;
+  setActiveVariantArchive: (
+    remoteId: string,
+    archiveName: string,
+    profileId?: ProfileId,
+  ) => void;
   getModProgress: (remoteId: string) => ModProgress | undefined;
   setAnalysisResult: (result: AnalyzeAddonsResult | null) => void;
   setAnalysisDialogOpen: (open: boolean) => void;
   clearAnalysisDialog: () => void;
-  setModOrder: (remoteId: string, order: number) => void;
-  reorderMods: (orderedRemoteIds: string[]) => void;
-  updateModVpksAfterReorder: (vpkMappings: Array<[string, string[]]>) => void;
+  setModOrder: (remoteId: string, order: number, profileId?: ProfileId) => void;
+  reorderMods: (orderedRemoteIds: string[], profileId?: ProfileId) => void;
+  updateModVpksAfterReorder: (
+    vpkMappings: Array<[string, string[]]>,
+    profileId?: ProfileId,
+  ) => void;
   getOrderedMods: () => LocalMod[];
   getNextInstallOrder: () => number;
   migrateLegacyMods: () => void;
@@ -119,15 +141,19 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   defaultSort: SortType.LAST_UPDATED,
   setDefaultSort: (sortType: SortType) => set({ defaultSort: sortType }),
-  addLocalMod: (mod, additional) =>
+  addLocalMod: (mod, additional, requestedProfileId) =>
     set((state) => {
-      if (state.localMods.some((m) => m.id === mod.id)) {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      const profile = state.profiles[profileId];
+      const profileMods = profile?.mods ?? state.localMods;
+
+      if (profileMods.some((m) => m.id === mod.id)) {
         return state;
       }
 
       const maxOrder =
-        state.localMods.length > 0
-          ? Math.max(...state.localMods.map((m) => m.installOrder ?? -1))
+        profileMods.length > 0
+          ? Math.max(...profileMods.map((m) => m.installOrder ?? -1))
           : -1;
       const installOrder = additional?.installOrder ?? maxOrder + 1;
 
@@ -143,20 +169,14 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         selectedDownloads: additional?.selectedDownloads,
       };
 
-      const { activeProfileId, profiles } = state;
-      const currentProfile = profiles[activeProfileId];
-
-      if (currentProfile) {
-        const updatedProfile = {
-          ...currentProfile,
-          mods: [...currentProfile.mods, newMod],
-        };
-
+      if (profile) {
+        const nextMods = [...profile.mods, newMod];
         return {
-          localMods: [...state.localMods, newMod],
+          localMods:
+            state.activeProfileId === profileId ? nextMods : state.localMods,
           profiles: {
             ...state.profiles,
-            [activeProfileId]: updatedProfile,
+            [profileId]: { ...profile, mods: nextMods },
           },
         };
       }
@@ -257,8 +277,12 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       };
     }),
 
-  setModStatus: (remoteId, status) => {
-    const mod = get().localMods.find((m) => m.remoteId === remoteId);
+  setModStatus: (remoteId, status, requestedProfileId) => {
+    const state = get();
+    const profileId = requestedProfileId ?? state.activeProfileId;
+    const mod = state.profiles[profileId]?.mods.find(
+      (candidate) => candidate.remoteId === remoteId,
+    );
     if (!mod) {
       logger.withMetadata({ remoteId }).error("Mod not found");
       return;
@@ -276,33 +300,35 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       return;
     }
 
-    return set((state) => ({
-      localMods: state.localMods.map((mod) => {
-        if (mod.remoteId !== remoteId) return mod;
-        return {
-          ...mod,
-          status,
-          downloadedAt:
-            (status === ModStatus.Downloaded &&
-              mod.status !== ModStatus.Installed) ||
-            (status === ModStatus.Installed && !mod.downloadedAt)
-              ? new Date()
-              : mod.downloadedAt,
-        };
-      }),
-    }));
+    return set((state) =>
+      applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => {
+          if (mod.remoteId !== remoteId) return mod;
+          return {
+            ...mod,
+            status,
+            downloadedAt:
+              (status === ModStatus.Downloaded &&
+                mod.status !== ModStatus.Installed) ||
+              (status === ModStatus.Installed && !mod.downloadedAt)
+                ? new Date()
+                : mod.downloadedAt,
+          };
+        }),
+      ),
+    );
   },
 
-  removeMod: (remoteId) =>
+  removeMod: (remoteId, requestedProfileId) =>
     set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
       const newProgress = { ...state.modProgress };
       delete newProgress[remoteId];
       // Dropped along with the mod, so re-downloading it does not come back
       // already hidden from its hero.
       const { [remoteId]: _hidden, ...hiddenHeroMods } = state.hiddenHeroMods;
 
-      const { activeProfileId, profiles } = state;
-      const currentProfile = profiles[activeProfileId];
+      const currentProfile = state.profiles[profileId];
 
       if (currentProfile) {
         const { [remoteId]: _removed, ...remainingEnabledMods } =
@@ -315,12 +341,15 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         };
 
         return {
-          localMods: state.localMods.filter((mod) => mod.remoteId !== remoteId),
+          localMods:
+            state.activeProfileId === profileId
+              ? state.localMods.filter((mod) => mod.remoteId !== remoteId)
+              : state.localMods,
           modProgress: newProgress,
           hiddenHeroMods,
           profiles: {
             ...state.profiles,
-            [activeProfileId]: updatedProfile,
+            [profileId]: updatedProfile,
           },
         };
       }
@@ -359,11 +388,17 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
   // holding its own copy of every mod - exactly the drift a nuke is supposed to
   // remove. This wipes both, keeping only the mods the caller wants to survive
   // (local mods, which cannot be re-downloaded).
-  nukeModsState: (keepRemoteIds) =>
+  nukeModsState: (keepRemoteIds, requestedProfileId) =>
     set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
       const keep = new Set(keepRemoteIds);
-      const localMods = state.localMods.filter((mod) => keep.has(mod.remoteId));
-      const profile = state.profiles[state.activeProfileId];
+      const profile = state.profiles[profileId];
+      const profileMods = profile?.mods ?? state.localMods;
+      const nextProfileMods = profileMods.filter((mod) =>
+        keep.has(mod.remoteId),
+      );
+      const localMods =
+        state.activeProfileId === profileId ? nextProfileMods : state.localMods;
       const hiddenHeroMods = Object.fromEntries(
         Object.entries(state.hiddenHeroMods).filter(([remoteId]) =>
           keep.has(remoteId),
@@ -372,9 +407,9 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
       logger
         .withMetadata({
-          profileId: state.activeProfileId,
-          removed: state.localMods.length - localMods.length,
-          kept: localMods.length,
+          profileId,
+          removed: profileMods.length - nextProfileMods.length,
+          kept: nextProfileMods.length,
         })
         .info("Nuking mods state");
 
@@ -388,9 +423,9 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         hiddenHeroMods,
         profiles: {
           ...state.profiles,
-          [state.activeProfileId]: {
+          [profileId]: {
             ...profile,
-            mods: profile.mods.filter((mod) => keep.has(mod.remoteId)),
+            mods: nextProfileMods,
             enabledMods: Object.fromEntries(
               Object.entries(profile.enabledMods).filter(([remoteId]) =>
                 keep.has(remoteId),
@@ -415,76 +450,91 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   getModProgress: (remoteId) => get().modProgress[remoteId],
 
-  setInstalledVpks: (
-    remoteId: string,
-    vpks: string[],
-    fileTree?: ModFileTree,
-  ) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        status:
-          mod.remoteId === remoteId && vpks.length > 0
-            ? ModStatus.Installed
-            : mod.status,
-        installedVpks: mod.remoteId === remoteId ? vpks : mod.installedVpks,
-        installedFileTree:
-          mod.remoteId === remoteId ? fileTree : mod.installedFileTree,
-      })),
-    })),
+  setInstalledVpks: (remoteId, vpks, fileTree, requestedProfileId) =>
+    set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      return applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => ({
+          ...mod,
+          status:
+            mod.remoteId === remoteId && vpks.length > 0
+              ? ModStatus.Installed
+              : mod.status,
+          installedVpks: mod.remoteId === remoteId ? vpks : mod.installedVpks,
+          installedFileTree:
+            mod.remoteId === remoteId ? fileTree : mod.installedFileTree,
+        })),
+      );
+    }),
 
-  setSelectedDownloads: (remoteId: string, downloads: ModDownloadItem[]) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        selectedDownloads:
-          mod.remoteId === remoteId ? downloads : mod.selectedDownloads,
-      })),
-    })),
+  setSelectedDownloads: (remoteId, downloads, requestedProfileId) =>
+    set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      return applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => ({
+          ...mod,
+          selectedDownloads:
+            mod.remoteId === remoteId ? downloads : mod.selectedDownloads,
+        })),
+      );
+    }),
 
-  setModDownloads: (remoteId: string, downloads: ModDownloadItem[]) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        downloads: mod.remoteId === remoteId ? downloads : mod.downloads,
-      })),
-    })),
+  setModDownloads: (remoteId, downloads, requestedProfileId) =>
+    set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      return applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => ({
+          ...mod,
+          downloads: mod.remoteId === remoteId ? downloads : mod.downloads,
+        })),
+      );
+    }),
 
-  setActiveVariantArchive: (remoteId: string, archiveName: string) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        activeVariantArchive:
-          mod.remoteId === remoteId ? archiveName : mod.activeVariantArchive,
-      })),
-    })),
+  setActiveVariantArchive: (remoteId, archiveName, requestedProfileId) =>
+    set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      return applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => ({
+          ...mod,
+          activeVariantArchive:
+            mod.remoteId === remoteId ? archiveName : mod.activeVariantArchive,
+        })),
+      );
+    }),
 
   setAnalysisResult: (result) => set({ analysisResult: result }),
   setAnalysisDialogOpen: (open) => set({ analysisDialogOpen: open }),
   clearAnalysisDialog: () =>
     set({ analysisResult: null, analysisDialogOpen: false }),
 
-  setModOrder: (remoteId: string, order: number) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => ({
-        ...mod,
-        installOrder: mod.remoteId === remoteId ? order : mod.installOrder,
-      })),
-    })),
-
-  reorderMods: (orderedRemoteIds: string[]) =>
-    set((state) => ({
-      localMods: state.localMods.map((mod) => {
-        const newOrder = orderedRemoteIds.indexOf(mod.remoteId);
-        return {
-          ...mod,
-          installOrder: newOrder >= 0 ? newOrder : mod.installOrder,
-        };
-      }),
-    })),
-
-  updateModVpksAfterReorder: (vpkMappings: Array<[string, string[]]>) =>
+  setModOrder: (remoteId, order, requestedProfileId) =>
     set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      return applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => ({
+          ...mod,
+          installOrder: mod.remoteId === remoteId ? order : mod.installOrder,
+        })),
+      );
+    }),
+
+  reorderMods: (orderedRemoteIds, requestedProfileId) =>
+    set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
+      return applyToModsInProfile(state, profileId, (mods) =>
+        mods.map((mod) => {
+          const newOrder = orderedRemoteIds.indexOf(mod.remoteId);
+          return {
+            ...mod,
+            installOrder: newOrder >= 0 ? newOrder : mod.installOrder,
+          };
+        }),
+      );
+    }),
+
+  updateModVpksAfterReorder: (vpkMappings, requestedProfileId) =>
+    set((state) => {
+      const profileId = requestedProfileId ?? state.activeProfileId;
       logger
         .withMetadata({
           mappingsCount: vpkMappings.length,
@@ -515,7 +565,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
           return mod;
         });
 
-      return applyToModsAndActiveProfile(state, updateMods);
+      return applyToModsInProfile(state, profileId, updateMods);
     }),
 
   getOrderedMods: () => {

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -142,7 +142,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
   defaultSort: SortType.LAST_UPDATED,
   setDefaultSort: (sortType: SortType) => set({ defaultSort: sortType }),
   addLocalMod: (mod, additional, requestedProfileId) => {
-    get().bumpProfileSyncRevision();
+    get().bumpProfileSyncRevision(requestedProfileId ?? get().activeProfileId);
     set((state) => {
       const profileId = requestedProfileId ?? state.activeProfileId;
       const profile = state.profiles[profileId];
@@ -302,6 +302,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       return;
     }
 
+    get().bumpProfileSyncRevision(profileId);
     return set((state) =>
       applyToModsInProfile(state, profileId, (mods) =>
         mods.map((mod) => {
@@ -322,9 +323,10 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
   },
 
   removeMod: (remoteId, requestedProfileId) => {
-    get().bumpProfileSyncRevision();
+    get().bumpProfileSyncRevision(requestedProfileId ?? get().activeProfileId);
     set((state) => {
       const profileId = requestedProfileId ?? state.activeProfileId;
+      const isActive = profileId === state.activeProfileId;
       const newProgress = { ...state.modProgress };
       delete newProgress[remoteId];
       // Dropped along with the mod, so re-downloading it does not come back
@@ -348,8 +350,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
             state.activeProfileId === profileId
               ? state.localMods.filter((mod) => mod.remoteId !== remoteId)
               : state.localMods,
-          modProgress: newProgress,
-          hiddenHeroMods,
+          modProgress: isActive ? newProgress : state.modProgress,
+          hiddenHeroMods: isActive ? hiddenHeroMods : state.hiddenHeroMods,
           profiles: {
             ...state.profiles,
             [profileId]: updatedProfile,
@@ -357,6 +359,7 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         };
       }
 
+      if (!isActive) return state;
       return {
         localMods: state.localMods.filter((mod) => mod.remoteId !== remoteId),
         modProgress: newProgress,
@@ -392,9 +395,11 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
   // holding its own copy of every mod - exactly the drift a nuke is supposed to
   // remove. This wipes both, keeping only the mods the caller wants to survive
   // (local mods, which cannot be re-downloaded).
-  nukeModsState: (keepRemoteIds, requestedProfileId) =>
-    set((state) => {
+  nukeModsState: (keepRemoteIds, requestedProfileId) => {
+    get().bumpProfileSyncRevision(requestedProfileId ?? get().activeProfileId);
+    return set((state) => {
       const profileId = requestedProfileId ?? state.activeProfileId;
+      const isActive = profileId === state.activeProfileId;
       const keep = new Set(keepRemoteIds);
       const profile = state.profiles[profileId];
       const profileMods = profile?.mods ?? state.localMods;
@@ -403,11 +408,14 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
       );
       const localMods =
         state.activeProfileId === profileId ? nextProfileMods : state.localMods;
-      const hiddenHeroMods = Object.fromEntries(
-        Object.entries(state.hiddenHeroMods).filter(([remoteId]) =>
-          keep.has(remoteId),
-        ),
-      );
+      const hiddenHeroMods = isActive
+        ? Object.fromEntries(
+            Object.entries(state.hiddenHeroMods).filter(([remoteId]) =>
+              keep.has(remoteId),
+            ),
+          )
+        : state.hiddenHeroMods;
+      const modProgress = isActive ? {} : state.modProgress;
 
       logger
         .withMetadata({
@@ -418,12 +426,12 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
         .info("Nuking mods state");
 
       if (!profile) {
-        return { localMods, modProgress: {}, hiddenHeroMods };
+        return { localMods, modProgress, hiddenHeroMods };
       }
 
       return {
         localMods,
-        modProgress: {},
+        modProgress,
         hiddenHeroMods,
         profiles: {
           ...state.profiles,
@@ -438,7 +446,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
           },
         },
       };
-    }),
+    });
+  },
 
   setModProgress: (remoteId, progress) =>
     set((state) => ({
@@ -454,8 +463,9 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
 
   getModProgress: (remoteId) => get().modProgress[remoteId],
 
-  setInstalledVpks: (remoteId, vpks, fileTree, requestedProfileId) =>
-    set((state) => {
+  setInstalledVpks: (remoteId, vpks, fileTree, requestedProfileId) => {
+    get().bumpProfileSyncRevision(requestedProfileId ?? get().activeProfileId);
+    return set((state) => {
       const profileId = requestedProfileId ?? state.activeProfileId;
       return applyToModsInProfile(state, profileId, (mods) =>
         mods.map((mod) => ({
@@ -469,7 +479,8 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
             mod.remoteId === remoteId ? fileTree : mod.installedFileTree,
         })),
       );
-    }),
+    });
+  },
 
   setSelectedDownloads: (remoteId, downloads, requestedProfileId) =>
     set((state) => {

--- a/apps/desktop/src/lib/store/slices/profiles.test-support.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.test-support.ts
@@ -1,0 +1,92 @@
+import { mock } from "bun:test";
+
+import type { ModDto } from "@deadlock-mods/shared";
+import { ModStatus, type LocalMod } from "@/types/mods";
+import { type ProfileVpkSnapshot } from "@/types/profiles";
+
+const loggerMock = {
+  withMetadata() {
+    return this;
+  },
+  withError() {
+    return this;
+  },
+  info() {},
+  warn() {},
+  error() {},
+};
+mock.module("@/lib/logger", () => ({ default: loggerMock }));
+
+export const modFor = (remoteId: string): LocalMod => ({
+  id: remoteId,
+  remoteId,
+  name: `Mod ${remoteId}`,
+  description: null,
+  remoteUrl: `https://gamebanana.com/mods/${remoteId}`,
+  category: "Skins",
+  likes: 0,
+  author: "Fixture",
+  downloadable: true,
+  remoteAddedAt: new Date(0),
+  remoteUpdatedAt: new Date(0),
+  tags: [],
+  images: [],
+  hero: null,
+  isAudio: false,
+  isMap: false,
+  audioUrl: null,
+  downloadCount: 0,
+  isNSFW: false,
+  isObsolete: false,
+  isBlacklisted: false,
+  blacklistReason: null,
+  blacklistedAt: null,
+  blacklistedBy: null,
+  filesUpdatedAt: null,
+  metadata: null,
+  dependencies: null,
+  overrides: null,
+  createdAt: null,
+  updatedAt: null,
+  status: ModStatus.Downloaded,
+});
+
+export const snapshotFor = (
+  modId = "42",
+  fileShard = 1,
+): ProfileVpkSnapshot => ({
+  manifest: {
+    version: 3,
+    mods: {
+      [modId]: {
+        enabled: true,
+        shard: 1,
+        currentVpks: ["pak01_dir.vpk"],
+        disabledVpks: [],
+        originalVpkNames: ["original.vpk"],
+        order: 0,
+      },
+    },
+  },
+  files: [
+    { shard: fileShard, filename: "pak01_dir.vpk", locator: "pak01_dir.vpk" },
+  ],
+});
+
+export const profileTestBackend: {
+  readSnapshot: (folder: string | null) => Promise<ProfileVpkSnapshot>;
+  readMetadata: (id: string) => Promise<ModDto>;
+} = {
+  readSnapshot: async () => snapshotFor(),
+  readMetadata: async (id) => modFor(id),
+};
+mock.module("@tauri-apps/api/core", () => ({
+  invoke: async (command: string, args?: { profileFolder?: string | null }) => {
+    if (command === "get_profile_vpk_snapshot")
+      return profileTestBackend.readSnapshot(args?.profileFolder ?? null);
+    return undefined;
+  },
+}));
+mock.module("@/lib/api-client", () => ({
+  getMod: (id: string) => profileTestBackend.readMetadata(id),
+}));

--- a/apps/desktop/src/lib/store/slices/profiles.test.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.test.ts
@@ -1,0 +1,170 @@
+import {
+  profileTestBackend,
+  modFor,
+  snapshotFor,
+} from "./profiles.test-support";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { create } from "zustand";
+import type { ModDto } from "@deadlock-mods/shared";
+import { ModStatus, type LocalMod } from "@/types/mods";
+import {
+  createProfileId,
+  type ModProfile,
+  type ProfileVpkSnapshot,
+} from "@/types/profiles";
+import type { ProfilesState } from "./profiles";
+
+// Bun evaluates static imports before module mocks; load the slice after its IPC/API mocks.
+const { createProfilesSlice } = await import("./profiles");
+
+const profileFor = (id: string, mods: LocalMod[] = []): ModProfile => ({
+  id: createProfileId(id),
+  name: id,
+  createdAt: new Date(0),
+  enabledMods: {},
+  isDefault: id === "default",
+  folderName: id === "default" ? null : id,
+  mods,
+});
+const createTestStore = () =>
+  create<ProfilesState & { localMods: LocalMod[] }>()((set, get, api) => ({
+    ...createProfilesSlice(set, get, api),
+    localMods: [],
+  }));
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+beforeEach(() => {
+  profileTestBackend.readSnapshot = async () => snapshotFor();
+  profileTestBackend.readMetadata = async (id) => modFor(id);
+});
+
+describe("profile snapshot reconciliation", () => {
+  it("allows overlapping syncs for different profiles", async () => {
+    const store = createTestStore();
+    store.setState({
+      profiles: {
+        default: profileFor("default", [modFor("42")]),
+        secondary: profileFor("secondary", [modFor("42")]),
+      },
+    });
+    const first = deferred<ProfileVpkSnapshot>();
+    profileTestBackend.readSnapshot = (folder) =>
+      folder === null ? first.promise : Promise.resolve(snapshotFor());
+    const pending = store
+      .getState()
+      .syncProfileEnabledMods(createProfileId("default"));
+    await store.getState().syncProfileEnabledMods(createProfileId("secondary"));
+    first.resolve(snapshotFor());
+    await pending;
+    expect(store.getState().profiles.default.mods[0].status).toBe(
+      ModStatus.Installed,
+    );
+    expect(store.getState().profiles.secondary.mods[0].status).toBe(
+      ModStatus.Installed,
+    );
+  });
+
+  it("rejects a stale sync for the same profile", async () => {
+    const store = createTestStore();
+    store.setState({
+      profiles: { default: profileFor("default", [modFor("42")]) },
+    });
+    const first = deferred<ProfileVpkSnapshot>();
+    profileTestBackend.readSnapshot = () => first.promise;
+    const pending = store
+      .getState()
+      .syncProfileEnabledMods(createProfileId("default"));
+    store.getState().bumpProfileSyncRevision(createProfileId("default"));
+    first.resolve(snapshotFor());
+    await pending;
+    expect(store.getState().profiles.default.mods[0].status).toBe(
+      ModStatus.Downloaded,
+    );
+  });
+
+  it("does not restore installed status from a VPK in the wrong shard", async () => {
+    const store = createTestStore();
+    profileTestBackend.readSnapshot = async () => snapshotFor("42", 2);
+    await store.getState().restoreModsFromManifest();
+    expect(store.getState().localMods[0].status).toBe(ModStatus.Downloaded);
+    expect(store.getState().localMods[0].installedVpks).toEqual([]);
+    expect(store.getState().profiles.default.enabledMods).toEqual({});
+  });
+
+  it("refreshes placeholder metadata on a later restoration", async () => {
+    const store = createTestStore();
+    profileTestBackend.readMetadata = async () => {
+      throw new Error("Catalog temporarily unavailable");
+    };
+    await store.getState().restoreModsFromManifest();
+    expect(store.getState().localMods[0].metadataPending).toBe(true);
+    expect(store.getState().localMods[0].status).toBe(ModStatus.Installed);
+    profileTestBackend.readMetadata = async (id) => modFor(id);
+    await store.getState().restoreModsFromManifest();
+    expect(store.getState().localMods).toHaveLength(1);
+    expect(store.getState().localMods[0].name).toBe("Mod 42");
+    expect(store.getState().localMods[0].metadataPending).toBe(false);
+    expect(store.getState().localMods[0].installedVpks).toEqual([
+      "pak01_dir.vpk",
+    ]);
+  });
+
+  it("validates files for placeholders when metadata is unavailable", async () => {
+    const store = createTestStore();
+    profileTestBackend.readSnapshot = async () => ({
+      ...snapshotFor(),
+      files: [],
+    });
+    profileTestBackend.readMetadata = async () => {
+      throw new Error("Offline");
+    };
+    await store.getState().restoreModsFromManifest();
+    expect(store.getState().localMods[0].metadataPending).toBe(true);
+    expect(store.getState().localMods[0].status).toBe(ModStatus.Downloaded);
+  });
+
+  it("merges into current profile state after waiting for metadata", async () => {
+    const store = createTestStore();
+    const started = deferred<void>();
+    const metadata = deferred<ModDto>();
+    profileTestBackend.readMetadata = () => {
+      started.resolve();
+      return metadata.promise;
+    };
+    const pending = store.getState().restoreModsFromManifest();
+    await started.promise;
+    const concurrent = modFor("99");
+    store.setState({
+      profiles: { default: profileFor("default", [concurrent]) },
+      localMods: [concurrent],
+    });
+    metadata.resolve(modFor("42"));
+    await pending;
+    expect(store.getState().localMods.map((mod) => mod.remoteId)).toEqual([
+      "99",
+      "42",
+    ]);
+  });
+
+  it("does not resurrect a mod removed during metadata lookup", async () => {
+    const store = createTestStore();
+    const started = deferred<void>();
+    const metadata = deferred<ModDto>();
+    profileTestBackend.readMetadata = () => {
+      started.resolve();
+      return metadata.promise;
+    };
+    const pending = store.getState().restoreModsFromManifest();
+    await started.promise;
+    store.getState().bumpProfileSyncRevision(createProfileId("default"));
+    metadata.resolve(modFor("42"));
+    await pending;
+    expect(store.getState().localMods).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -16,14 +16,18 @@ import {
   type ProfileId,
   type ProfileSwitchResult,
   type ProfileVpkFile,
+  type ProfileVpkSnapshot,
   type SeedManifestEntry,
   type VpkManifest,
+  type VpkManifestEntry,
 } from "@/types/profiles";
+import { applyToModsInProfile } from "../utils/mod-slice";
 
 export interface ProfilesState {
   profiles: Record<ProfileId, ModProfile>;
   activeProfileId: ProfileId;
   isSwitching: boolean;
+  profileSyncRevision: number;
 
   createProfile: (
     name: string,
@@ -62,6 +66,7 @@ export interface ProfilesState {
   getProfilesCount: () => number;
   getEnabledModsCount: () => number;
   syncProfilesWithFilesystem: () => Promise<void>;
+  bumpProfileSyncRevision: () => number;
   syncProfileEnabledMods: (profileId: ProfileId) => Promise<void>;
   restoreModsFromManifest: () => Promise<void>;
   saveCurrentModsToProfile: () => void;
@@ -110,6 +115,49 @@ const getRecoveredProfileDetails = (folderName: string) => {
 
 const shouldReplaceRecoveredProfileName = (profile: ModProfile) =>
   profile.description === RECOVERED_PROFILE_DESCRIPTION || !profile.name.trim();
+
+const placeholderModFromManifest = (
+  modId: string,
+  entry: VpkManifestEntry,
+): LocalMod => {
+  const now = new Date();
+  const currentVpks = entry.currentVpks ?? [];
+  const isEnabled = entry.enabled && currentVpks.length > 0;
+  return {
+    id: modId,
+    remoteId: modId,
+    name: modId,
+    description: null,
+    remoteUrl: "",
+    category: "local",
+    likes: 0,
+    author: "",
+    downloadable: false,
+    remoteAddedAt: now,
+    remoteUpdatedAt: now,
+    tags: [],
+    images: [],
+    hero: null,
+    isAudio: false,
+    isMap: false,
+    audioUrl: null,
+    downloadCount: 0,
+    isNSFW: false,
+    isObsolete: false,
+    isBlacklisted: false,
+    blacklistReason: null,
+    blacklistedAt: null,
+    blacklistedBy: null,
+    filesUpdatedAt: null,
+    overrides: null,
+    createdAt: now,
+    updatedAt: now,
+    status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
+    installedVpks: isEnabled ? currentVpks : [],
+    installOrder: entry.order ?? undefined,
+    downloadedAt: now,
+  };
+};
 
 const pickRecoveredProfileSource = (
   existingProfile: ModProfile | undefined,
@@ -196,6 +244,13 @@ export const createProfilesSlice: StateCreator<
   },
   activeProfileId: DEFAULT_PROFILE_ID,
   isSwitching: false,
+  profileSyncRevision: 0,
+
+  bumpProfileSyncRevision: () => {
+    const next = (get().profileSyncRevision ?? 0) + 1;
+    set({ profileSyncRevision: next });
+    return next;
+  },
 
   createProfile: async (name: string, description?: string) => {
     const profileId = createProfileId(
@@ -736,8 +791,9 @@ export const createProfilesSlice: StateCreator<
   },
 
   syncProfileEnabledMods: async (profileId: ProfileId) => {
+    const revision = get().bumpProfileSyncRevision();
     try {
-      const { profiles, localMods } = get();
+      const { profiles } = get();
       const profile = profiles[profileId];
 
       if (!profile) {
@@ -745,31 +801,44 @@ export const createProfilesSlice: StateCreator<
         return;
       }
 
+      const localMods = profile.mods;
+
       logger
         .withMetadata({
           profileId,
           folderName: profile.folderName,
+          revision,
         })
         .info("Syncing profile enabled mods with filesystem");
 
-      const allVpks = await invoke<ProfileVpkFile[]>(
-        "get_profile_installed_vpks",
-        {
-          profileFolder: profile.folderName,
-        },
-      );
+      let allVpks: ProfileVpkFile[] = [];
       let manifest: VpkManifest = { version: 0, mods: {} };
       try {
-        manifest = await invoke<VpkManifest>("get_profile_vpk_manifest", {
-          profileFolder: profile.folderName,
-        });
+        const snapshot = await invoke<ProfileVpkSnapshot>(
+          "get_profile_vpk_snapshot",
+          {
+            profileFolder: profile.folderName,
+          },
+        );
+        allVpks = snapshot.files;
+        manifest = snapshot.manifest;
       } catch (error) {
         logger
           .withMetadata({ profileId, folderName: profile.folderName })
           .withError(error)
           .warn(
-            "Failed to load VPK manifest; falling back to filename-pattern detection",
+            "Failed to load VPK snapshot; falling back to filename-pattern detection",
           );
+        try {
+          allVpks = await invoke<ProfileVpkFile[]>(
+            "get_profile_installed_vpks",
+            {
+              profileFolder: profile.folderName,
+            },
+          );
+        } catch {
+          allVpks = [];
+        }
       }
 
       logger
@@ -960,16 +1029,39 @@ export const createProfilesSlice: StateCreator<
         })
         .info("Synced profile enabled mods");
 
-      set((state) => ({
-        localMods: updatedLocalMods,
-        profiles: {
-          ...state.profiles,
-          [profileId]: {
-            ...profile,
-            enabledMods: updatedEnabledMods,
+      set((state) => {
+        if (state.profileSyncRevision !== revision) {
+          logger
+            .withMetadata({
+              profileId,
+              revision,
+              current: state.profileSyncRevision,
+            })
+            .info("Dropping stale profile sync result");
+          return state;
+        }
+
+        const next = applyToModsInProfile(
+          state,
+          profileId,
+          () => updatedLocalMods,
+        );
+        const nextProfile = next.profiles[profileId];
+        if (!nextProfile) {
+          return next;
+        }
+
+        return {
+          ...next,
+          profiles: {
+            ...next.profiles,
+            [profileId]: {
+              ...nextProfile,
+              enabledMods: updatedEnabledMods,
+            },
           },
-        },
-      }));
+        };
+      });
     } catch (error) {
       logger
         .withMetadata({ profileId })
@@ -979,28 +1071,34 @@ export const createProfilesSlice: StateCreator<
   },
 
   restoreModsFromManifest: async () => {
-    const { localMods, activeProfileId, profiles } = get();
-    if (localMods.length > 0) {
-      return;
-    }
-
+    const { activeProfileId, profiles } = get();
     const profile = profiles[activeProfileId];
     if (!profile) {
       return;
     }
 
-    let manifest: VpkManifest = { version: 0, mods: {} };
+    let snapshot: ProfileVpkSnapshot;
     try {
-      manifest = await invoke<VpkManifest>("get_profile_vpk_manifest", {
+      snapshot = await invoke<ProfileVpkSnapshot>("get_profile_vpk_snapshot", {
         profileFolder: profile.folderName,
       });
     } catch (error) {
-      logger.withError(error).warn("Failed to load manifest for restoration");
+      logger.withError(error).warn("Failed to load snapshot for restoration");
       return;
     }
 
-    const manifestEntries = Object.entries(manifest.mods);
+    const manifestEntries = Object.entries(snapshot.manifest.mods);
     if (manifestEntries.length === 0) {
+      return;
+    }
+
+    const trackedById = new Map(
+      profile.mods.map((mod) => [mod.remoteId, mod] as const),
+    );
+    const missingEntries = manifestEntries.filter(
+      ([modId]) => !trackedById.has(modId),
+    );
+    if (missingEntries.length === 0) {
       return;
     }
 
@@ -1008,64 +1106,75 @@ export const createProfilesSlice: StateCreator<
       .withMetadata({
         profileId: activeProfileId,
         manifestModCount: manifestEntries.length,
+        missingCount: missingEntries.length,
       })
-      .info("Restoring mods from manifest (local state is empty)");
+      .info("Reconciling missing mods from manifest");
 
-    const restoredMods: LocalMod[] = [];
-    const enabledMods: Record<string, ModProfileEntry> = {};
+    const restoredMods: LocalMod[] = [...profile.mods];
+    const enabledMods: Record<string, ModProfileEntry> = {
+      ...profile.enabledMods,
+    };
 
-    for (const [modId, entry] of manifestEntries) {
+    for (const [modId, entry] of missingEntries) {
+      let restoredMod: LocalMod;
       try {
         const modDetails = await getMod(modId);
         const currentVpks = entry.currentVpks ?? [];
         const isEnabled = entry.enabled && currentVpks.length > 0;
-
-        const restoredMod: LocalMod = {
+        restoredMod = {
           ...modDetails,
           status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
           installedVpks: isEnabled ? currentVpks : [],
           installOrder: entry.order ?? restoredMods.length,
           downloadedAt: new Date(),
         };
-
-        restoredMods.push(restoredMod);
-
-        if (isEnabled) {
-          enabledMods[modId] = {
-            remoteId: modId,
-            enabled: true,
-            lastModified: new Date(),
-          };
-        }
-
-        logger
-          .withMetadata({ modId, name: modDetails.name, isEnabled })
-          .info("Restored mod from manifest");
       } catch (error) {
         logger
           .withMetadata({ modId })
           .withError(error)
-          .warn("Failed to fetch mod details during manifest restoration");
+          .warn("Using placeholder for unavailable catalog metadata");
+        restoredMod = placeholderModFromManifest(modId, entry);
+      }
+
+      restoredMods.push(restoredMod);
+      if (restoredMod.status === ModStatus.Installed) {
+        enabledMods[modId] = {
+          remoteId: modId,
+          enabled: true,
+          lastModified: new Date(),
+        };
       }
     }
 
-    if (restoredMods.length > 0) {
-      set((state) => ({
-        localMods: restoredMods,
+    set((state) => {
+      const current = state.profiles[activeProfileId];
+      if (!current) {
+        return state;
+      }
+      const next = applyToModsInProfile(
+        state,
+        activeProfileId,
+        () => restoredMods,
+      );
+      const nextProfile = next.profiles[activeProfileId];
+      if (!nextProfile) {
+        return next;
+      }
+      return {
+        ...next,
         profiles: {
-          ...state.profiles,
+          ...next.profiles,
           [activeProfileId]: {
-            ...profile,
-            enabledMods: { ...profile.enabledMods, ...enabledMods },
-            mods: restoredMods,
+            ...nextProfile,
+            enabledMods,
           },
         },
-      }));
+      };
+    });
 
-      logger
-        .withMetadata({ restoredCount: restoredMods.length })
-        .info("Manifest restoration complete");
-    }
+    logger
+      .withMetadata({ restoredCount: missingEntries.length })
+      .info("Manifest reconciliation complete");
   },
 
   syncProfilesWithFilesystem: async () => {

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -27,7 +27,7 @@ export interface ProfilesState {
   profiles: Record<ProfileId, ModProfile>;
   activeProfileId: ProfileId;
   isSwitching: boolean;
-  profileSyncRevision: number;
+  profileSyncRevisions: Record<ProfileId, number>;
 
   createProfile: (
     name: string,
@@ -66,7 +66,7 @@ export interface ProfilesState {
   getProfilesCount: () => number;
   getEnabledModsCount: () => number;
   syncProfilesWithFilesystem: () => Promise<void>;
-  bumpProfileSyncRevision: () => number;
+  bumpProfileSyncRevision: (profileId: ProfileId) => number;
   syncProfileEnabledMods: (profileId: ProfileId) => Promise<void>;
   restoreModsFromManifest: () => Promise<void>;
   saveCurrentModsToProfile: () => void;
@@ -119,10 +119,10 @@ const shouldReplaceRecoveredProfileName = (profile: ModProfile) =>
 const placeholderModFromManifest = (
   modId: string,
   entry: VpkManifestEntry,
+  installedVpks: string[],
 ): LocalMod => {
   const now = new Date();
-  const currentVpks = entry.currentVpks ?? [];
-  const isEnabled = entry.enabled && currentVpks.length > 0;
+  const isEnabled = installedVpks.length > 0;
   return {
     id: modId,
     remoteId: modId,
@@ -155,7 +155,8 @@ const placeholderModFromManifest = (
     createdAt: now,
     updatedAt: now,
     status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
-    installedVpks: isEnabled ? currentVpks : [],
+    installedVpks,
+    metadataPending: true,
     installOrder: entry.order ?? undefined,
     downloadedAt: now,
   };
@@ -246,11 +247,12 @@ export const createProfilesSlice: StateCreator<
   },
   activeProfileId: DEFAULT_PROFILE_ID,
   isSwitching: false,
-  profileSyncRevision: 0,
+  profileSyncRevisions: {},
 
-  bumpProfileSyncRevision: () => {
-    const next = (get().profileSyncRevision ?? 0) + 1;
-    set({ profileSyncRevision: next });
+  bumpProfileSyncRevision: (profileId) => {
+    const revisions = get().profileSyncRevisions;
+    const next = (revisions[profileId] ?? 0) + 1;
+    set({ profileSyncRevisions: { ...revisions, [profileId]: next } });
     return next;
   },
 
@@ -655,6 +657,8 @@ export const createProfilesSlice: StateCreator<
       lastModified: new Date(),
     };
 
+    get().bumpProfileSyncRevision(profileId);
+
     set((state) => ({
       profiles: {
         ...state.profiles,
@@ -793,7 +797,7 @@ export const createProfilesSlice: StateCreator<
   },
 
   syncProfileEnabledMods: async (profileId: ProfileId) => {
-    const revision = get().bumpProfileSyncRevision();
+    const revision = get().bumpProfileSyncRevision(profileId);
     try {
       const { profiles } = get();
       const profile = profiles[profileId];
@@ -838,7 +842,11 @@ export const createProfilesSlice: StateCreator<
               profileFolder: profile.folderName,
             },
           );
-        } catch {
+        } catch (fallbackError) {
+          logger
+            .withMetadata({ profileId, folderName: profile.folderName })
+            .withError(fallbackError)
+            .warn("Failed to list profile VPKs during snapshot fallback");
           allVpks = [];
         }
       }
@@ -1032,12 +1040,12 @@ export const createProfilesSlice: StateCreator<
         .info("Synced profile enabled mods");
 
       set((state) => {
-        if (state.profileSyncRevision !== revision) {
+        if (state.profileSyncRevisions[profileId] !== revision) {
           logger
             .withMetadata({
               profileId,
               revision,
-              current: state.profileSyncRevision,
+              current: state.profileSyncRevisions[profileId],
             })
             .info("Dropping stale profile sync result");
           return state;
@@ -1078,6 +1086,7 @@ export const createProfilesSlice: StateCreator<
     if (!profile) {
       return;
     }
+    const revision = get().bumpProfileSyncRevision(activeProfileId);
 
     let snapshot: ProfileVpkSnapshot;
     try {
@@ -1085,7 +1094,10 @@ export const createProfilesSlice: StateCreator<
         profileFolder: profile.folderName,
       });
     } catch (error) {
-      logger.withError(error).warn("Failed to load snapshot for restoration");
+      logger
+        .withMetadata({ activeProfileId, folderName: profile.folderName })
+        .withError(error)
+        .warn("Failed to load snapshot for restoration");
       return;
     }
 
@@ -1094,11 +1106,12 @@ export const createProfilesSlice: StateCreator<
       return;
     }
 
-    const trackedById = new Map(
-      profile.mods.map((mod) => [mod.remoteId, mod] as const),
+    const trackedById = new Map<string, LocalMod>(
+      profile.mods.map((mod) => [mod.remoteId, mod]),
     );
     const missingEntries = manifestEntries.filter(
-      ([modId]) => !trackedById.has(modId),
+      ([modId]) =>
+        !trackedById.has(modId) || trackedById.get(modId)?.metadataPending,
     );
     if (missingEntries.length === 0) {
       return;
@@ -1112,22 +1125,33 @@ export const createProfilesSlice: StateCreator<
       })
       .info("Reconciling missing mods from manifest");
 
-    const restoredMods: LocalMod[] = [...profile.mods];
-    const enabledMods: Record<string, ModProfileEntry> = {
-      ...profile.enabledMods,
-    };
+    const restoredMods: LocalMod[] = [];
+    const fileLocators = new Set(
+      snapshot.files.map((file) => `${file.shard}:${file.filename}`),
+    );
 
     for (const [modId, entry] of missingEntries) {
+      const claimedVpks = entry.currentVpks ?? [];
+      const installedVpks =
+        entry.enabled &&
+        claimedVpks.length > 0 &&
+        claimedVpks.every((filename) =>
+          fileLocators.has(`${entry.shard}:${filename}`),
+        )
+          ? claimedVpks
+          : [];
       let restoredMod: LocalMod;
       try {
         const modDetails = await getMod(modId);
-        const currentVpks = entry.currentVpks ?? [];
-        const isEnabled = entry.enabled && currentVpks.length > 0;
+        const isEnabled = installedVpks.length > 0;
         restoredMod = {
+          ...trackedById.get(modId),
           ...modDetails,
+          metadataPending: false,
           status: isEnabled ? ModStatus.Installed : ModStatus.Downloaded,
-          installedVpks: isEnabled ? currentVpks : [],
-          installOrder: entry.order ?? restoredMods.length,
+          installedVpks,
+          installOrder:
+            entry.order ?? profile.mods.length + restoredMods.length,
           downloadedAt: new Date(),
         };
       } catch (error) {
@@ -1135,29 +1159,42 @@ export const createProfilesSlice: StateCreator<
           .withMetadata({ modId })
           .withError(error)
           .warn("Using placeholder for unavailable catalog metadata");
-        restoredMod = placeholderModFromManifest(modId, entry);
+        restoredMod = placeholderModFromManifest(modId, entry, installedVpks);
       }
 
       restoredMods.push(restoredMod);
-      if (restoredMod.status === ModStatus.Installed) {
-        enabledMods[modId] = {
-          remoteId: modId,
-          enabled: true,
-          lastModified: new Date(),
-        };
-      }
     }
 
     set((state) => {
       const current = state.profiles[activeProfileId];
-      if (!current) {
+      if (
+        !current ||
+        current.folderName !== profile.folderName ||
+        state.profileSyncRevisions[activeProfileId] !== revision
+      ) {
         return state;
       }
-      const next = applyToModsInProfile(
-        state,
-        activeProfileId,
-        () => restoredMods,
-      );
+      const enabledMods = { ...current.enabledMods };
+      const next = applyToModsInProfile(state, activeProfileId, (mods) => {
+        const reconciled = [...mods];
+        for (const restored of restoredMods) {
+          const index = reconciled.findIndex(
+            (mod) => mod.remoteId === restored.remoteId,
+          );
+          if (index >= 0 && !reconciled[index].metadataPending) continue;
+          if (index >= 0)
+            reconciled[index] = { ...reconciled[index], ...restored };
+          else reconciled.push(restored);
+          if (restored.status === ModStatus.Installed) {
+            enabledMods[restored.remoteId] = {
+              remoteId: restored.remoteId,
+              enabled: true,
+              lastModified: new Date(),
+            };
+          } else delete enabledMods[restored.remoteId];
+        }
+        return reconciled;
+      });
       const nextProfile = next.profiles[activeProfileId];
       if (!nextProfile) {
         return next;

--- a/apps/desktop/src/lib/store/slices/profiles.ts
+++ b/apps/desktop/src/lib/store/slices/profiles.ts
@@ -149,6 +149,8 @@ const placeholderModFromManifest = (
     blacklistedAt: null,
     blacklistedBy: null,
     filesUpdatedAt: null,
+    metadata: null,
+    dependencies: null,
     overrides: null,
     createdAt: now,
     updatedAt: now,

--- a/apps/desktop/src/lib/store/utils/mod-slice.ts
+++ b/apps/desktop/src/lib/store/utils/mod-slice.ts
@@ -1,4 +1,5 @@
 import type { LocalMod } from "@/types/mods";
+import type { ProfileId } from "@/types/profiles";
 import type { State } from "..";
 
 export type ModSliceState = Pick<
@@ -23,6 +24,35 @@ export const applyToModsAndActiveProfile = (
           },
         }
       : state.profiles,
+  };
+};
+
+export const applyToModsInProfile = (
+  state: ModSliceState,
+  profileId: ProfileId,
+  updateMods: (mods: LocalMod[]) => LocalMod[],
+) => {
+  const profile = state.profiles[profileId];
+
+  if (!profile) {
+    return {
+      localMods: state.localMods,
+      profiles: state.profiles,
+    };
+  }
+
+  const profileMods = updateMods(profile.mods);
+
+  return {
+    localMods:
+      state.activeProfileId === profileId ? profileMods : state.localMods,
+    profiles: {
+      ...state.profiles,
+      [profileId]: {
+        ...profile,
+        mods: profileMods,
+      },
+    },
   };
 };
 

--- a/apps/desktop/src/lib/validation/batch-update.ts
+++ b/apps/desktop/src/lib/validation/batch-update.ts
@@ -13,4 +13,5 @@ export const BatchUpdateResultSchema = z.object({
   succeeded: z.array(z.string()),
   failed: z.array(z.tuple([z.string(), z.string()])),
   installedMods: z.array(InstalledModInfoSchema),
+  vpkMappings: z.array(z.tuple([z.string(), z.array(z.string())])).optional(),
 });

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -155,6 +155,7 @@ export interface BatchUpdateResult {
   succeeded: string[];
   failed: Array<[string, string]>;
   installedMods: InstalledModInfo[];
+  vpkMappings?: Array<[string, string[]]>;
 }
 
 export interface BatchUpdateProgressEvent {

--- a/apps/desktop/src/types/mods.ts
+++ b/apps/desktop/src/types/mods.ts
@@ -29,6 +29,7 @@ export enum ModStatus {
 }
 
 export interface LocalMod extends ModDto {
+  metadataPending?: boolean;
   status: ModStatus;
   downloadedAt?: Date;
   downloads?: ModDownloadItem[];

--- a/apps/desktop/src/types/profiles.ts
+++ b/apps/desktop/src/types/profiles.ts
@@ -40,6 +40,11 @@ export interface ProfileVpkFile {
   locator: string;
 }
 
+export interface ProfileVpkSnapshot {
+  manifest: VpkManifest;
+  files: ProfileVpkFile[];
+}
+
 export interface SeedManifestEntry {
   modId: string;
   enabled: boolean;


### PR DESCRIPTION
Stacked on #704.

## Why

Installed mods were being lost across mass updates, deletes, and profile switches. An audit reproduced nine isolated failures, all tracing back to the same root cause: VPK ownership is triangulated from three sources that can disagree — the `.dmm.json` manifest, the frontend store, and the Rust `mod_repository` — with no shared commit boundary. Each fix here removes one of those competing sources so the manifest is authoritative.

## The P0

`remove_mod_vpks` unioned the manifest's owned paths with filenames supplied by the frontend and the mod repository. `ShardLocator::from_legacy_name` resolves a bare `pak01_dir.vpk` to shard 1, so deleting a mod that lives in shard 2 could delete a *different* mod's shard-1 file. When a manifest entry exists, deletion now uses only `entry.file_paths()`. Legacy discovery, used only when no entry exists, skips any file another entry already claims.

## What else changed

- **Batch updates no longer delete before downloading.** `batch_update_mods` removed the old VPKs first, so a failed download lost the installation. It now downloads and extracts into a prepared directory, then replaces files and the manifest together through `update_mod_from_prepared`. Disappearance from the active-download map is no longer treated as success; `queue_download_and_prepare` awaits a real extraction result.
- **One reorder per batch.** Installing can reorder the whole profile, so per-mod VPK mappings captured mid-batch went stale and could move untouched mods. The profile is reordered once after the batch and the final mapping is returned to the frontend.
- **Profile-scoped async state.** `syncProfileEnabledMods` read `localMods`, awaited two IPC calls, then blind-wrote the result, so a background sync of profile A could overwrite profile B, erase concurrent adds, or resurrect deletes. It now pins a profile plus a monotonic revision, drops stale results, and writes through `applyToModsInProfile`.
- **Partial losses can recover.** `restoreModsFromManifest` returned early whenever any local mod existed, so losing a few mods was unrecoverable. It now reconciles the manifest entries that are missing, and keeps a placeholder when catalog metadata is unavailable so local imports survive.
- **Remaining writers.** Enabled replacement routes through the same journaled operation, `validate_tree` rejects overlapping path claims, archive imports commit to the manifest, and backup restore refreshes tracked state.

## Testing

- New Rust regression tests for cross-shard deletion, stale frontend filenames, conflicting claims, and prepared-file replacement
- `cargo check`, `cargo test --lib remove_mod_vpks`, `cargo test --lib update_mod_from_prepared`
- `pnpm --filter @deadlock-mods/desktop check-types`, `bun test apps/desktop/src/lib/store/slices/mods.test.ts`

Not yet verified against a running app. Install, update, delete, and profile switching still need a live pass through tauri-mcp before this leaves draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Desktop app:** Makes the VPK manifest the authoritative source for installed files.
- Uses manifest-owned paths for deletion and prevents cross-shard, stale-filename, and conflicting-claim deletions.
- Adds journaled staging and crash recovery for VPK updates.
- Prepares downloaded VPK files before replacement. Existing installations remain intact when downloads fail.
- Reorders profiles once per batch and returns final VPK mappings.
- Scopes profile synchronization to snapshots and revisions.
- Reconciles missing profile mods during restore and preserves local imports when catalog metadata is unavailable.
- Updates archive imports, backup restores, and other operations through manifest-aware state changes.
- Adds Rust regression tests for deletion, conflicting claims, and prepared-file replacement.

## Validation

- Rust compilation and tests.
- Desktop type checking.
- Desktop store tests.
- Live install, update, delete, and profile-switch verification remains outstanding.

No changes affect the API, bot, www, docs, or shared packages. No database migrations, Tauri plugin changes, or Rust FFI boundary changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Stack tracking

Tracked in #673 (PR 11 of 19). Based on #704. Followed by #707.

<!-- review-followup-20260909 -->
Review fixes: scope reconciliation revisions to each profile, preserve active state during inactive-profile removal, reject stale restoration results, retry placeholder metadata, and verify actual VPK files and shards before marking restored mods installed. Prepared updates preserve metadata, accept mixed-case VPK extensions, and own extraction directories through cleanup guards. Snapshot lock errors now return normally with profile-aware diagnostic context. The rollback cleanup fix and its regression were moved here from the later filesystem E2E PR so this PR passes independently.

Integrated-stack validation: 363 Rust tests and 326 desktop Bun tests pass, along with workspace/E2E typechecks and formatting/lint checks.

