### PR TITLE
feat(desktop): cache GameBanana catalog in SQLite

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -1282,12 +1282,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1305,11 +1329,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1378,6 +1413,8 @@ dependencies = [
  "clap",
  "crc32fast",
  "deadlock-discord-presence",
+ "diesel",
+ "diesel_migrations",
  "dirs",
  "dmp-parser",
  "dotenvy",
@@ -1392,6 +1429,7 @@ dependencies = [
  "junction",
  "keyvalues-parser",
  "keyvalues-serde",
+ "libsqlite3-sys",
  "log",
  "memchr",
  "notify",
@@ -1504,6 +1542,53 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "diesel"
+version = "2.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715377c6e464cb44bb89bd8487584240516c8d5052bc645d6babc50bb8be46c3"
+dependencies = [
+ "diesel_derives",
+ "downcast-rs 2.0.2",
+ "libsqlite3-sys",
+ "r2d2",
+ "sqlite-wasm-rs",
+ "time",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "dsl_auto_type",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0f4a98124ba6d4ca75da535f65984badec16a003b6e2f94a01e31a79490b8"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
+dependencies = [
  "syn 2.0.117",
 ]
 
@@ -1676,12 +1761,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
+dependencies = [
+ "darling 0.21.3",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2510,6 +2615,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -3320,6 +3434,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,6 +3576,27 @@ dependencies = [
  "cc",
  "float-cmp",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "migrations_internals"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
+dependencies = [
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fc5ac76be324cfd2d3f2cf0fdf5d5d3c4f14ed8aaebadb09e304ba42282703"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -5097,6 +5243,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5467,6 +5624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5635,6 +5802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -5955,7 +6131,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6263,6 +6439,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8231,7 +8419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
- "downcast-rs",
+ "downcast-rs 1.2.1",
  "rustix",
  "smallvec",
  "wayland-sys",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -68,6 +68,13 @@ hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json", "stream", "socks"] }
+diesel = { version = "2.3.12", default-features = false, features = [
+  "sqlite",
+  "r2d2",
+  "32-column-tables",
+] }
+diesel_migrations = "2.3.2"
+libsqlite3-sys = { version = "0.38", features = ["bundled"] }
 futures = "0.3"
 tauri-plugin-dialog = "2.7.1"
 memchr = "2.8.0"

--- a/apps/desktop/src-tauri/migrations/gamebanana_catalog/20260830000000_create_catalog/down.sql
+++ b/apps/desktop/src-tauri/migrations/gamebanana_catalog/20260830000000_create_catalog/down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER IF EXISTS submission_fts_update;
+DROP TRIGGER IF EXISTS submission_fts_delete;
+DROP TRIGGER IF EXISTS submission_fts_insert;
+DROP TABLE IF EXISTS submission_fts;
+DROP TABLE IF EXISTS sync_state;
+DROP TABLE IF EXISTS sync_cursor;
+DROP TABLE IF EXISTS submission;

--- a/apps/desktop/src-tauri/migrations/gamebanana_catalog/20260830000000_create_catalog/up.sql
+++ b/apps/desktop/src-tauri/migrations/gamebanana_catalog/20260830000000_create_catalog/up.sql
@@ -1,0 +1,87 @@
+CREATE TABLE submission (
+  provider TEXT NOT NULL,
+  submission_type TEXT NOT NULL,
+  submission_id TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  author TEXT NOT NULL DEFAULT 'Unknown',
+  description TEXT NOT NULL DEFAULT '',
+  profile_url TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'Other',
+  hero TEXT,
+  is_audio INTEGER NOT NULL DEFAULT 0 CHECK (is_audio IN (0, 1)),
+  is_map INTEGER NOT NULL DEFAULT 0 CHECK (is_map IN (0, 1)),
+  is_nsfw INTEGER NOT NULL DEFAULT 0 CHECK (is_nsfw IN (0, 1)),
+  is_obsolete INTEGER NOT NULL DEFAULT 0 CHECK (is_obsolete IN (0, 1)),
+  is_tombstoned INTEGER NOT NULL DEFAULT 0 CHECK (is_tombstoned IN (0, 1)),
+  is_hydrated INTEGER NOT NULL DEFAULT 0 CHECK (is_hydrated IN (0, 1)),
+  has_files INTEGER NOT NULL DEFAULT 0 CHECK (has_files IN (0, 1)),
+  download_count INTEGER NOT NULL DEFAULT 0,
+  likes INTEGER NOT NULL DEFAULT 0,
+  remote_added_at INTEGER NOT NULL DEFAULT 0,
+  remote_updated_at INTEGER NOT NULL DEFAULT 0,
+  files_updated_at INTEGER NOT NULL DEFAULT 0,
+  last_seen_snapshot TEXT,
+  PRIMARY KEY (provider, submission_type, submission_id)
+);
+
+CREATE INDEX submission_browse_updated
+  ON submission(is_tombstoned, remote_updated_at DESC);
+CREATE INDEX submission_browse_downloads
+  ON submission(is_tombstoned, download_count DESC);
+CREATE INDEX submission_filter_category
+  ON submission(is_tombstoned, category);
+CREATE INDEX submission_filter_hero
+  ON submission(is_tombstoned, hero);
+
+CREATE VIRTUAL TABLE submission_fts USING fts5(
+  provider UNINDEXED,
+  submission_type UNINDEXED,
+  submission_id UNINDEXED,
+  name,
+  author,
+  description,
+  tokenize = 'unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER submission_fts_insert AFTER INSERT ON submission BEGIN
+  INSERT INTO submission_fts(
+    provider, submission_type, submission_id, name, author, description
+  ) VALUES (
+    new.provider, new.submission_type, new.submission_id,
+    new.name, new.author, new.description
+  );
+END;
+
+CREATE TRIGGER submission_fts_delete AFTER DELETE ON submission BEGIN
+  DELETE FROM submission_fts
+  WHERE provider = old.provider
+    AND submission_type = old.submission_type
+    AND submission_id = old.submission_id;
+END;
+
+CREATE TRIGGER submission_fts_update AFTER UPDATE OF name, author, description ON submission BEGIN
+  DELETE FROM submission_fts
+  WHERE provider = old.provider
+    AND submission_type = old.submission_type
+    AND submission_id = old.submission_id;
+  INSERT INTO submission_fts(
+    provider, submission_type, submission_id, name, author, description
+  ) VALUES (
+    new.provider, new.submission_type, new.submission_id,
+    new.name, new.author, new.description
+  );
+END;
+
+CREATE TABLE sync_cursor (
+  submission_type TEXT PRIMARY KEY,
+  next_page INTEGER NOT NULL DEFAULT 1,
+  snapshot_id TEXT,
+  snapshot_complete INTEGER NOT NULL DEFAULT 0 CHECK (snapshot_complete IN (0, 1)),
+  high_water_mark INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE sync_state (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/apps/desktop/src-tauri/src/errors.rs
+++ b/apps/desktop/src-tauri/src/errors.rs
@@ -52,6 +52,8 @@ pub enum Error {
   ProviderResponseTooLarge { limit: usize },
   #[error("GameBanana request was cancelled")]
   ProviderCancelled,
+  #[error("Catalog error: {0}")]
+  Catalog(String),
   #[error("Tauri error: {0}")]
   Tauri(#[from] tauri::Error),
   #[error("Failed to create backup: {0}")]
@@ -89,6 +91,12 @@ pub enum Error {
   },
 }
 
+impl From<diesel::result::Error> for Error {
+  fn from(error: diesel::result::Error) -> Self {
+    Self::Catalog(error.to_string())
+  }
+}
+
 impl serde::Serialize for Error {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where
@@ -124,6 +132,7 @@ impl serde::Serialize for Error {
       Error::ProviderInvalidResponse(_) => "providerInvalidResponse",
       Error::ProviderResponseTooLarge { .. } => "providerResponseTooLarge",
       Error::ProviderCancelled => "providerCancelled",
+      Error::Catalog(_) => "catalogError",
       Error::Tauri(_) => "tauri",
       Error::BackupCreationFailed(_) => "backupCreationFailed",
       Error::BackupRestoreFailed(_) => "backupRestoreFailed",
@@ -201,6 +210,10 @@ mod tests {
         "providerResponseTooLarge",
       ),
       (Error::ProviderCancelled, "providerCancelled"),
+      (
+        Error::Catalog("database unavailable".into()),
+        "catalogError",
+      ),
     ];
 
     for (error, expected_kind) in cases {

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/mod.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/mod.rs
@@ -1,0 +1,7 @@
+mod pool;
+mod schema;
+mod store;
+mod sync;
+
+pub use store::{Catalog, CatalogRecord, SyncCursor};
+pub use sync::{CatalogSync, SyncOutcome};

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/pool.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/pool.rs
@@ -1,0 +1,76 @@
+use super::schema;
+use crate::errors::Error;
+use diesel::connection::SimpleConnection;
+use diesel::r2d2::{ConnectionManager, CustomizeConnection, Pool};
+use diesel::sqlite::SqliteConnection;
+use std::path::Path;
+
+type DieselPool = Pool<ConnectionManager<SqliteConnection>>;
+
+#[derive(Clone)]
+pub struct ConnectionPool {
+  inner: DieselPool,
+}
+
+#[derive(Debug)]
+struct SqliteCustomizer;
+
+impl CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for SqliteCustomizer {
+  fn on_acquire(&self, connection: &mut SqliteConnection) -> Result<(), diesel::r2d2::Error> {
+    connection
+      .batch_execute(
+        "PRAGMA foreign_keys = ON;
+         PRAGMA journal_mode = WAL;
+         PRAGMA synchronous = NORMAL;
+         PRAGMA busy_timeout = 5000;",
+      )
+      .map_err(diesel::r2d2::Error::QueryError)
+  }
+}
+
+impl ConnectionPool {
+  pub async fn open(path: impl AsRef<Path>, size: usize) -> Result<Self, Error> {
+    let max_size = u32::try_from(size)
+      .ok()
+      .filter(|size| *size > 0)
+      .ok_or_else(|| {
+        Error::Catalog("connection pool size must be greater than zero".to_string())
+      })?;
+    let path = path.as_ref().to_path_buf();
+    if let Some(parent) = path.parent() {
+      std::fs::create_dir_all(parent)
+        .map_err(|error| Error::Catalog(format!("failed to create catalog directory: {error}")))?;
+    }
+    let database_url = path
+      .to_str()
+      .ok_or_else(|| Error::Catalog("catalog path is not valid UTF-8".to_string()))?
+      .to_string();
+
+    let inner = tokio::task::spawn_blocking(move || {
+      Pool::builder()
+        .max_size(max_size)
+        .connection_customizer(Box::new(SqliteCustomizer))
+        .build(ConnectionManager::<SqliteConnection>::new(database_url))
+        .map_err(schema::catalog_error)
+    })
+    .await
+    .map_err(|error| Error::Catalog(format!("catalog pool task failed: {error}")))??;
+    let pool = Self { inner };
+    pool.run(schema::migrate).await?;
+    Ok(pool)
+  }
+
+  pub async fn run<T, F>(&self, operation: F) -> Result<T, Error>
+  where
+    T: Send + 'static,
+    F: FnOnce(&mut SqliteConnection) -> Result<T, Error> + Send + 'static,
+  {
+    let pool = self.inner.clone();
+    tokio::task::spawn_blocking(move || {
+      let mut connection = pool.get().map_err(schema::catalog_error)?;
+      operation(&mut connection)
+    })
+    .await
+    .map_err(|error| Error::Catalog(format!("catalog task failed: {error}")))?
+  }
+}

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/schema.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/schema.rs
@@ -1,0 +1,89 @@
+use crate::errors::Error;
+use diesel::sqlite::SqliteConnection;
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations/gamebanana_catalog");
+
+diesel::table! {
+  submission (provider, submission_type, submission_id) {
+    provider -> Text,
+    submission_type -> Text,
+    submission_id -> Text,
+    slug -> Text,
+    name -> Text,
+    author -> Text,
+    description -> Text,
+    profile_url -> Text,
+    category -> Text,
+    hero -> Nullable<Text>,
+    is_audio -> Bool,
+    is_map -> Bool,
+    is_nsfw -> Bool,
+    is_obsolete -> Bool,
+    is_tombstoned -> Bool,
+    is_hydrated -> Bool,
+    has_files -> Bool,
+    download_count -> BigInt,
+    likes -> BigInt,
+    remote_added_at -> BigInt,
+    remote_updated_at -> BigInt,
+    files_updated_at -> BigInt,
+    last_seen_snapshot -> Nullable<Text>,
+  }
+}
+
+diesel::table! {
+  sync_cursor (submission_type) {
+    submission_type -> Text,
+    next_page -> BigInt,
+    snapshot_id -> Nullable<Text>,
+    snapshot_complete -> Bool,
+    high_water_mark -> BigInt,
+  }
+}
+
+diesel::table! {
+  sync_state (key) {
+    key -> Text,
+    value -> Text,
+  }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(submission, sync_cursor, sync_state);
+
+pub fn migrate(connection: &mut SqliteConnection) -> Result<(), Error> {
+  connection
+    .run_pending_migrations(MIGRATIONS)
+    .map(|_| ())
+    .map_err(catalog_error)
+}
+
+pub fn catalog_error(error: impl std::fmt::Display) -> Error {
+  Error::Catalog(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::migrate;
+  use diesel::Connection;
+  use diesel::prelude::*;
+  use diesel::sqlite::SqliteConnection;
+  use diesel_migrations::MigrationHarness;
+
+  #[test]
+  fn migrations_create_fts_and_are_idempotent() {
+    let mut connection = SqliteConnection::establish(":memory:").unwrap();
+    migrate(&mut connection).unwrap();
+    migrate(&mut connection).unwrap();
+
+    let applied = connection.applied_migrations().unwrap();
+    let fts_exists = diesel::select(diesel::dsl::sql::<diesel::sql_types::Bool>(
+      "EXISTS(SELECT 1 FROM sqlite_master WHERE name = 'submission_fts')",
+    ))
+    .get_result::<bool>(&mut connection)
+    .unwrap();
+
+    assert_eq!(applied.len(), 1);
+    assert!(fts_exists);
+  }
+}

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/store.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/store.rs
@@ -1,0 +1,601 @@
+use super::pool::ConnectionPool;
+use super::schema::{submission, sync_cursor, sync_state};
+use crate::errors::Error;
+use crate::providers::{SubmissionProvider, SubmissionRef, SubmissionType};
+use diesel::OptionalExtension;
+use diesel::prelude::*;
+use diesel::sqlite::Sqlite;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogRecord {
+  pub submission: SubmissionRef,
+  pub name: String,
+  pub author: String,
+  pub description: String,
+  pub profile_url: String,
+  pub category: String,
+  pub hero: Option<String>,
+  pub is_audio: bool,
+  pub is_map: bool,
+  pub is_nsfw: bool,
+  pub is_obsolete: bool,
+  pub is_tombstoned: bool,
+  pub is_hydrated: bool,
+  pub has_files: bool,
+  pub download_count: u64,
+  pub likes: u64,
+  pub remote_added_at: i64,
+  pub remote_updated_at: i64,
+  pub files_updated_at: i64,
+  pub last_seen_snapshot: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncCursor {
+  pub next_page: u32,
+  pub snapshot_id: Option<String>,
+  pub snapshot_complete: bool,
+  pub high_water_mark: i64,
+}
+
+#[derive(Clone)]
+pub struct Catalog {
+  pub(super) pool: ConnectionPool,
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable, Insertable, AsChangeset)]
+#[diesel(
+  table_name = submission,
+  primary_key(provider, submission_type, submission_id),
+  treat_none_as_null = true,
+  check_for_backend(Sqlite)
+)]
+pub(super) struct SubmissionRow {
+  pub provider: String,
+  pub submission_type: String,
+  pub submission_id: String,
+  pub slug: String,
+  pub name: String,
+  pub author: String,
+  pub description: String,
+  pub profile_url: String,
+  pub category: String,
+  pub hero: Option<String>,
+  pub is_audio: bool,
+  pub is_map: bool,
+  pub is_nsfw: bool,
+  pub is_obsolete: bool,
+  pub is_tombstoned: bool,
+  pub is_hydrated: bool,
+  pub has_files: bool,
+  pub download_count: i64,
+  pub likes: i64,
+  pub remote_added_at: i64,
+  pub remote_updated_at: i64,
+  pub files_updated_at: i64,
+  pub last_seen_snapshot: Option<String>,
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable, Insertable, AsChangeset)]
+#[diesel(table_name = sync_cursor, primary_key(submission_type), treat_none_as_null = true)]
+struct SyncCursorRow {
+  submission_type: String,
+  next_page: i64,
+  snapshot_id: Option<String>,
+  snapshot_complete: bool,
+  high_water_mark: i64,
+}
+
+#[derive(Debug, Insertable, AsChangeset)]
+#[diesel(table_name = sync_state)]
+struct SyncStateRow {
+  key: String,
+  value: String,
+}
+
+#[cfg(test)]
+#[derive(QueryableByName)]
+struct SlugRow {
+  #[diesel(sql_type = diesel::sql_types::Text)]
+  slug: String,
+}
+
+impl Catalog {
+  pub async fn open(path: impl AsRef<Path>, pool_size: usize) -> Result<Self, Error> {
+    Ok(Self {
+      pool: ConnectionPool::open(path, pool_size).await?,
+    })
+  }
+
+  pub async fn upsert_page(
+    &self,
+    records: Vec<CatalogRecord>,
+    submission_type: SubmissionType,
+    next_page: u32,
+    snapshot_id: Option<String>,
+    snapshot_complete: bool,
+  ) -> Result<(), Error> {
+    self
+      .pool
+      .run(move |connection| {
+        connection.transaction::<_, Error, _>(|connection| {
+          for record in records {
+            upsert_record(connection, record)?;
+          }
+          let cursor = SyncCursorRow {
+            submission_type: submission_type_name(submission_type).to_string(),
+            next_page: i64::from(next_page),
+            snapshot_id,
+            snapshot_complete,
+            high_water_mark: 0,
+          };
+          diesel::insert_into(sync_cursor::table)
+            .values(&cursor)
+            .on_conflict(sync_cursor::submission_type)
+            .do_update()
+            .set((
+              sync_cursor::next_page.eq(cursor.next_page),
+              sync_cursor::snapshot_id.eq(&cursor.snapshot_id),
+              sync_cursor::snapshot_complete.eq(cursor.snapshot_complete),
+            ))
+            .execute(connection)?;
+          Ok(())
+        })
+      })
+      .await
+  }
+
+  pub async fn cursor(&self, submission_type: SubmissionType) -> Result<SyncCursor, Error> {
+    self
+      .pool
+      .run(move |connection| {
+        let row = sync_cursor::table
+          .find(submission_type_name(submission_type))
+          .select(SyncCursorRow::as_select())
+          .first(connection)
+          .optional()?;
+        row.map(SyncCursor::try_from).transpose().map(|cursor| {
+          cursor.unwrap_or(SyncCursor {
+            next_page: 1,
+            snapshot_id: None,
+            snapshot_complete: false,
+            high_water_mark: 0,
+          })
+        })
+      })
+      .await
+  }
+
+  pub async fn complete_snapshot(&self, snapshot_id: String) -> Result<usize, Error> {
+    self
+      .pool
+      .run(move |connection| {
+        connection.transaction::<_, Error, _>(|connection| {
+          let tombstoned = diesel::update(
+            submission::table
+              .filter(submission::is_tombstoned.eq(false))
+              .filter(
+                submission::last_seen_snapshot
+                  .is_null()
+                  .or(submission::last_seen_snapshot.ne(&snapshot_id)),
+              ),
+          )
+          .set(submission::is_tombstoned.eq(true))
+          .execute(connection)?;
+          diesel::update(sync_cursor::table)
+            .set((
+              sync_cursor::next_page.eq(1_i64),
+              sync_cursor::snapshot_id.eq(Option::<String>::None),
+              sync_cursor::snapshot_complete.eq(false),
+            ))
+            .execute(connection)?;
+          Ok(tombstoned)
+        })
+      })
+      .await
+  }
+
+  pub async fn count_visible(&self) -> Result<u64, Error> {
+    self
+      .pool
+      .run(|connection| {
+        let count = submission::table
+          .filter(submission::is_tombstoned.eq(false))
+          .count()
+          .get_result::<i64>(connection)?;
+        u64::try_from(count).map_err(|_| Error::Catalog("catalog count was negative".to_string()))
+      })
+      .await
+  }
+
+  pub async fn upsert_records(&self, records: Vec<CatalogRecord>) -> Result<(), Error> {
+    self
+      .pool
+      .run(move |connection| {
+        connection.transaction::<_, Error, _>(|connection| {
+          for record in records {
+            upsert_record(connection, record)?;
+          }
+          Ok(())
+        })
+      })
+      .await
+  }
+
+  pub async fn set_high_water_mark(
+    &self,
+    submission_type: SubmissionType,
+    high_water_mark: i64,
+  ) -> Result<(), Error> {
+    self
+      .pool
+      .run(move |connection| {
+        let submission_type = submission_type_name(submission_type).to_string();
+        let existing = sync_cursor::table
+          .find(&submission_type)
+          .select(SyncCursorRow::as_select())
+          .first::<SyncCursorRow>(connection)
+          .optional()?;
+        let cursor = existing
+          .map(|mut cursor| {
+            cursor.high_water_mark = cursor.high_water_mark.max(high_water_mark);
+            cursor
+          })
+          .unwrap_or(SyncCursorRow {
+            submission_type,
+            next_page: 1,
+            snapshot_id: None,
+            snapshot_complete: false,
+            high_water_mark,
+          });
+        diesel::insert_into(sync_cursor::table)
+          .values(&cursor)
+          .on_conflict(sync_cursor::submission_type)
+          .do_update()
+          .set(sync_cursor::high_water_mark.eq(cursor.high_water_mark))
+          .execute(connection)?;
+        Ok(())
+      })
+      .await
+  }
+
+  pub async fn state(&self, key: &'static str) -> Result<Option<String>, Error> {
+    self
+      .pool
+      .run(move |connection| {
+        sync_state::table
+          .find(key)
+          .select(sync_state::value)
+          .first(connection)
+          .optional()
+          .map_err(Error::from)
+      })
+      .await
+  }
+
+  pub async fn set_state(&self, key: &'static str, value: String) -> Result<(), Error> {
+    self
+      .pool
+      .run(move |connection| {
+        let state = SyncStateRow {
+          key: key.to_string(),
+          value,
+        };
+        diesel::insert_into(sync_state::table)
+          .values(&state)
+          .on_conflict(sync_state::key)
+          .do_update()
+          .set(sync_state::value.eq(&state.value))
+          .execute(connection)?;
+        Ok(())
+      })
+      .await
+  }
+
+  #[cfg(test)]
+  pub async fn search_slugs(&self, query: String) -> Result<Vec<String>, Error> {
+    self
+      .pool
+      .run(move |connection| {
+        diesel::sql_query(
+          "SELECT submission.slug
+           FROM submission_fts
+           JOIN submission USING(provider, submission_type, submission_id)
+           WHERE submission_fts MATCH ? AND submission.is_tombstoned = 0
+           ORDER BY submission.slug",
+        )
+        .bind::<diesel::sql_types::Text, _>(query)
+        .load::<SlugRow>(connection)
+        .map(|rows| rows.into_iter().map(|row| row.slug).collect())
+        .map_err(Error::from)
+      })
+      .await
+  }
+}
+
+impl SubmissionRow {
+  fn from_record(record: CatalogRecord) -> Result<Self, Error> {
+    let slug = record.submission.to_slug();
+    Ok(Self {
+      provider: provider_name(record.submission.provider).to_string(),
+      submission_type: submission_type_name(record.submission.submission_type).to_string(),
+      submission_id: record.submission.submission_id,
+      slug,
+      name: record.name,
+      author: record.author,
+      description: record.description,
+      profile_url: record.profile_url,
+      category: record.category,
+      hero: record.hero,
+      is_audio: record.is_audio,
+      is_map: record.is_map,
+      is_nsfw: record.is_nsfw,
+      is_obsolete: record.is_obsolete,
+      is_tombstoned: record.is_tombstoned,
+      is_hydrated: record.is_hydrated,
+      has_files: record.has_files,
+      download_count: i64::try_from(record.download_count)
+        .map_err(|_| Error::Catalog("download count exceeds SQLite range".to_string()))?,
+      likes: i64::try_from(record.likes)
+        .map_err(|_| Error::Catalog("like count exceeds SQLite range".to_string()))?,
+      remote_added_at: record.remote_added_at,
+      remote_updated_at: record.remote_updated_at,
+      files_updated_at: record.files_updated_at,
+      last_seen_snapshot: record.last_seen_snapshot,
+    })
+  }
+
+  fn merge(self, incoming: Self) -> Self {
+    let hydrated = incoming.is_hydrated;
+    Self {
+      provider: incoming.provider,
+      submission_type: incoming.submission_type,
+      submission_id: incoming.submission_id,
+      slug: incoming.slug,
+      name: incoming.name,
+      author: incoming.author,
+      description: if hydrated {
+        incoming.description
+      } else {
+        self.description
+      },
+      profile_url: incoming.profile_url,
+      category: if hydrated {
+        incoming.category
+      } else {
+        self.category
+      },
+      hero: if hydrated { incoming.hero } else { self.hero },
+      is_audio: incoming.is_audio,
+      is_map: if hydrated {
+        incoming.is_map
+      } else {
+        self.is_map
+      },
+      is_nsfw: if hydrated {
+        incoming.is_nsfw
+      } else {
+        self.is_nsfw
+      },
+      is_obsolete: incoming.is_obsolete,
+      is_tombstoned: false,
+      is_hydrated: self.is_hydrated || hydrated,
+      has_files: incoming.has_files,
+      download_count: if hydrated {
+        incoming.download_count
+      } else {
+        self.download_count
+      },
+      likes: self.likes.max(incoming.likes),
+      remote_added_at: incoming.remote_added_at,
+      remote_updated_at: self.remote_updated_at.max(incoming.remote_updated_at),
+      files_updated_at: self.files_updated_at.max(incoming.files_updated_at),
+      last_seen_snapshot: incoming.last_seen_snapshot.or(self.last_seen_snapshot),
+    }
+  }
+}
+
+impl TryFrom<SyncCursorRow> for SyncCursor {
+  type Error = Error;
+
+  fn try_from(row: SyncCursorRow) -> Result<Self, Self::Error> {
+    Ok(Self {
+      next_page: u32::try_from(row.next_page)
+        .map_err(|_| Error::Catalog("catalog cursor page is out of range".to_string()))?,
+      snapshot_id: row.snapshot_id,
+      snapshot_complete: row.snapshot_complete,
+      high_water_mark: row.high_water_mark,
+    })
+  }
+}
+
+fn upsert_record(
+  connection: &mut diesel::sqlite::SqliteConnection,
+  record: CatalogRecord,
+) -> Result<(), Error> {
+  let incoming = SubmissionRow::from_record(record)?;
+  let existing = submission::table
+    .find((
+      &incoming.provider,
+      &incoming.submission_type,
+      &incoming.submission_id,
+    ))
+    .select(SubmissionRow::as_select())
+    .first::<SubmissionRow>(connection)
+    .optional()?;
+  let row = existing
+    .map(|existing| existing.merge(incoming.clone()))
+    .unwrap_or(incoming);
+  diesel::insert_into(submission::table)
+    .values(&row)
+    .on_conflict((
+      submission::provider,
+      submission::submission_type,
+      submission::submission_id,
+    ))
+    .do_update()
+    .set(&row)
+    .execute(connection)?;
+  Ok(())
+}
+
+pub(super) fn provider_name(provider: SubmissionProvider) -> &'static str {
+  match provider {
+    SubmissionProvider::Gamebanana => "gamebanana",
+    SubmissionProvider::Local => "local",
+  }
+}
+
+pub(super) fn submission_type_name(submission_type: SubmissionType) -> &'static str {
+  match submission_type {
+    SubmissionType::Mod => "mod",
+    SubmissionType::Sound => "sound",
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Catalog, CatalogRecord};
+  use crate::providers::SubmissionRef;
+  use tempfile::tempdir;
+
+  fn record(slug: &str, name: &str, snapshot: &str) -> CatalogRecord {
+    CatalogRecord {
+      submission: SubmissionRef::parse_slug(slug).unwrap(),
+      name: name.to_string(),
+      author: "DMM".to_string(),
+      description: "searchable catalog text".to_string(),
+      profile_url: format!("https://gamebanana.com/mods/{slug}"),
+      category: "Skins".to_string(),
+      hero: None,
+      is_audio: false,
+      is_map: false,
+      is_nsfw: false,
+      is_obsolete: false,
+      is_tombstoned: false,
+      is_hydrated: true,
+      has_files: true,
+      download_count: 10,
+      likes: 2,
+      remote_added_at: 100,
+      remote_updated_at: 200,
+      files_updated_at: 0,
+      last_seen_snapshot: Some(snapshot.to_string()),
+    }
+  }
+
+  #[tokio::test]
+  async fn page_commit_updates_cursor_and_fts_atomically() {
+    let directory = tempdir().unwrap();
+    let catalog = Catalog::open(directory.path().join("catalog.sqlite3"), 2)
+      .await
+      .unwrap();
+
+    catalog
+      .upsert_page(
+        vec![record("42", "Pink Drifter", "snapshot-a")],
+        crate::providers::SubmissionType::Mod,
+        2,
+        Some("snapshot-a".to_string()),
+        false,
+      )
+      .await
+      .unwrap();
+
+    assert_eq!(catalog.count_visible().await.unwrap(), 1);
+    assert_eq!(
+      catalog
+        .search_slugs("searchable".to_string())
+        .await
+        .unwrap(),
+      vec!["42"]
+    );
+    assert_eq!(
+      catalog
+        .cursor(crate::providers::SubmissionType::Mod)
+        .await
+        .unwrap()
+        .next_page,
+      2
+    );
+  }
+
+  #[tokio::test]
+  async fn only_completed_snapshots_tombstone_unseen_rows() {
+    let directory = tempdir().unwrap();
+    let catalog = Catalog::open(directory.path().join("catalog.sqlite3"), 1)
+      .await
+      .unwrap();
+    catalog
+      .upsert_page(
+        vec![
+          record("1", "Seen once", "snapshot-a"),
+          record("2", "Will remain", "snapshot-a"),
+        ],
+        crate::providers::SubmissionType::Mod,
+        2,
+        Some("snapshot-a".to_string()),
+        false,
+      )
+      .await
+      .unwrap();
+
+    catalog
+      .upsert_page(
+        vec![record("2", "Will remain", "snapshot-b")],
+        crate::providers::SubmissionType::Mod,
+        2,
+        Some("snapshot-b".to_string()),
+        false,
+      )
+      .await
+      .unwrap();
+    assert_eq!(catalog.count_visible().await.unwrap(), 2);
+
+    assert_eq!(
+      catalog
+        .complete_snapshot("snapshot-b".to_string())
+        .await
+        .unwrap(),
+      1
+    );
+    assert_eq!(catalog.count_visible().await.unwrap(), 1);
+  }
+
+  #[tokio::test]
+  async fn mod_and_sound_numeric_ids_do_not_collide() {
+    let directory = tempdir().unwrap();
+    let catalog = Catalog::open(directory.path().join("catalog.sqlite3"), 1)
+      .await
+      .unwrap();
+    let mut sound = record("snd-42", "Sound", "snapshot-a");
+    sound.is_audio = true;
+    sound.profile_url = "https://gamebanana.com/sounds/42".to_string();
+
+    catalog
+      .upsert_page(
+        vec![record("42", "Mod", "snapshot-a")],
+        crate::providers::SubmissionType::Mod,
+        2,
+        Some("snapshot-a".to_string()),
+        true,
+      )
+      .await
+      .unwrap();
+    catalog
+      .upsert_page(
+        vec![sound],
+        crate::providers::SubmissionType::Sound,
+        2,
+        Some("snapshot-a".to_string()),
+        true,
+      )
+      .await
+      .unwrap();
+
+    assert_eq!(catalog.count_visible().await.unwrap(), 2);
+  }
+}

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/store.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/store.rs
@@ -318,7 +318,7 @@ impl Catalog {
 
 impl SubmissionRow {
   fn from_record(record: CatalogRecord) -> Result<Self, Error> {
-    let slug = record.submission.to_slug();
+    let slug = record.submission.to_slug().map_err(|error| Error::InvalidInput(error.to_string()))?;
     Ok(Self {
       provider: provider_name(record.submission.provider).to_string(),
       submission_type: submission_type_name(record.submission.submission_type).to_string(),

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/sync.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/sync.rs
@@ -1,0 +1,596 @@
+use super::store::{Catalog, CatalogRecord};
+use crate::errors::Error;
+use crate::providers::gamebanana::hero_registry;
+use crate::providers::gamebanana::{BulkHydration, GameBananaClient, IndexPage};
+use crate::providers::{SubmissionProvider, SubmissionRef, SubmissionType};
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio_util::sync::CancellationToken;
+
+const INCREMENTAL_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+const FULL_RECONCILIATION_INTERVAL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const HYDRATION_BATCH_SIZE: usize = 50;
+const LAST_INCREMENTAL_AT: &str = "last_incremental_at";
+const LAST_FULL_SYNC_AT: &str = "last_full_sync_at";
+
+type SourceFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
+
+trait CatalogSource: Send + Sync {
+  fn index<'a>(
+    &'a self,
+    submission_type: SubmissionType,
+    page: u32,
+    latest_modified: bool,
+    cancel: &'a CancellationToken,
+  ) -> SourceFuture<'a, IndexPage>;
+
+  fn bulk_hydrate<'a>(
+    &'a self,
+    submissions: &'a [SubmissionRef],
+    cancel: &'a CancellationToken,
+  ) -> SourceFuture<'a, Vec<Option<BulkHydration>>>;
+}
+
+impl CatalogSource for GameBananaClient {
+  fn index<'a>(
+    &'a self,
+    submission_type: SubmissionType,
+    page: u32,
+    latest_modified: bool,
+    cancel: &'a CancellationToken,
+  ) -> SourceFuture<'a, IndexPage> {
+    Box::pin(GameBananaClient::index(
+      self,
+      submission_type,
+      page,
+      latest_modified,
+      cancel,
+    ))
+  }
+
+  fn bulk_hydrate<'a>(
+    &'a self,
+    submissions: &'a [SubmissionRef],
+    cancel: &'a CancellationToken,
+  ) -> SourceFuture<'a, Vec<Option<BulkHydration>>> {
+    Box::pin(GameBananaClient::bulk_hydrate(self, submissions, cancel))
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncOutcome {
+  Full,
+  Incremental,
+  Throttled,
+}
+
+pub struct CatalogSync {
+  catalog: Catalog,
+  source: Box<dyn CatalogSource>,
+  sync_lock: tokio::sync::Mutex<()>,
+}
+
+impl CatalogSync {
+  pub fn new(catalog: Catalog, source: GameBananaClient) -> Self {
+    Self {
+      catalog,
+      source: Box::new(source),
+      sync_lock: tokio::sync::Mutex::new(()),
+    }
+  }
+
+  #[cfg(test)]
+  fn with_source(catalog: Catalog, source: impl CatalogSource + 'static) -> Self {
+    Self {
+      catalog,
+      source: Box::new(source),
+      sync_lock: tokio::sync::Mutex::new(()),
+    }
+  }
+
+  pub async fn synchronize(
+    &self,
+    force_refresh: bool,
+    force_reconcile: bool,
+    cancel: &CancellationToken,
+  ) -> Result<SyncOutcome, Error> {
+    let _sync_guard = self.sync_lock.lock().await;
+    if force_reconcile
+      || self.catalog.count_visible().await? == 0
+      || self.full_reconciliation_due().await?
+    {
+      self.full_sync(cancel).await?;
+      return Ok(SyncOutcome::Full);
+    }
+
+    self.incremental_sync(force_refresh, cancel).await
+  }
+
+  async fn full_sync(&self, cancel: &CancellationToken) -> Result<(), Error> {
+    let mod_cursor = self.catalog.cursor(SubmissionType::Mod).await?;
+    let sound_cursor = self.catalog.cursor(SubmissionType::Sound).await?;
+    let snapshot_id = resumable_snapshot(&mod_cursor.snapshot_id, &sound_cursor.snapshot_id)
+      .unwrap_or_else(new_snapshot_id);
+
+    for submission_type in [SubmissionType::Mod, SubmissionType::Sound] {
+      let cursor = self.catalog.cursor(submission_type).await?;
+      if cursor.snapshot_id.as_deref() == Some(snapshot_id.as_str()) && cursor.snapshot_complete {
+        continue;
+      }
+      let mut page_number = if cursor.snapshot_id.as_deref() == Some(snapshot_id.as_str()) {
+        cursor.next_page
+      } else {
+        1
+      };
+
+      loop {
+        let page = self
+          .source
+          .index(submission_type, page_number, false, cancel)
+          .await?;
+        let index_records = page.valid_records();
+        let high_water_mark = index_records
+          .iter()
+          .filter_map(|record| record.date_modified)
+          .max()
+          .unwrap_or_default();
+        let catalog_records = index_records
+          .iter()
+          .map(|record| from_index(record, submission_type, Some(snapshot_id.clone())))
+          .collect();
+        self
+          .catalog
+          .upsert_page(
+            catalog_records,
+            submission_type,
+            page_number.saturating_add(1),
+            Some(snapshot_id.clone()),
+            page.metadata.is_complete,
+          )
+          .await?;
+        self
+          .catalog
+          .set_high_water_mark(submission_type, high_water_mark)
+          .await?;
+        self
+          .hydrate_records(
+            &index_records,
+            submission_type,
+            Some(snapshot_id.clone()),
+            cancel,
+          )
+          .await;
+
+        if page.metadata.is_complete {
+          break;
+        }
+        page_number = page_number.saturating_add(1);
+      }
+    }
+
+    self.catalog.complete_snapshot(snapshot_id).await?;
+    self
+      .catalog
+      .set_state(LAST_FULL_SYNC_AT, unix_timestamp().to_string())
+      .await?;
+    Ok(())
+  }
+
+  async fn full_reconciliation_due(&self) -> Result<bool, Error> {
+    let last_full_sync = self
+      .catalog
+      .state(LAST_FULL_SYNC_AT)
+      .await?
+      .and_then(|value| value.parse::<u64>().ok())
+      .unwrap_or_default();
+    Ok(unix_timestamp().saturating_sub(last_full_sync) >= FULL_RECONCILIATION_INTERVAL.as_secs())
+  }
+
+  async fn incremental_sync(
+    &self,
+    force: bool,
+    cancel: &CancellationToken,
+  ) -> Result<SyncOutcome, Error> {
+    let now = unix_timestamp();
+    let last_refresh = self
+      .catalog
+      .state(LAST_INCREMENTAL_AT)
+      .await?
+      .and_then(|value| value.parse::<u64>().ok())
+      .unwrap_or_default();
+    if !force && now.saturating_sub(last_refresh) < INCREMENTAL_INTERVAL.as_secs() {
+      return Ok(SyncOutcome::Throttled);
+    }
+
+    for submission_type in [SubmissionType::Mod, SubmissionType::Sound] {
+      let high_water_mark = self.catalog.cursor(submission_type).await?.high_water_mark;
+      let mut newest = high_water_mark;
+      let mut page_number = 1;
+      loop {
+        let page = self
+          .source
+          .index(submission_type, page_number, true, cancel)
+          .await?;
+        let index_records = page.valid_records();
+        let crossed_high_water = high_water_mark > 0
+          && index_records.iter().any(|record| {
+            record
+              .date_modified
+              .is_some_and(|modified| modified < high_water_mark)
+          });
+        newest = index_records
+          .iter()
+          .filter_map(|record| record.date_modified)
+          .max()
+          .unwrap_or(newest)
+          .max(newest);
+        self
+          .catalog
+          .upsert_records(
+            index_records
+              .iter()
+              .map(|record| from_index(record, submission_type, None))
+              .collect(),
+          )
+          .await?;
+        self
+          .hydrate_records(&index_records, submission_type, None, cancel)
+          .await;
+
+        if page.metadata.is_complete || crossed_high_water {
+          break;
+        }
+        page_number = page_number.saturating_add(1);
+      }
+      self
+        .catalog
+        .set_high_water_mark(submission_type, newest)
+        .await?;
+    }
+    self
+      .catalog
+      .set_state(LAST_INCREMENTAL_AT, now.to_string())
+      .await?;
+    Ok(SyncOutcome::Incremental)
+  }
+
+  async fn hydrate_records(
+    &self,
+    index_records: &[crate::providers::gamebanana::models::IndexSubmission],
+    submission_type: SubmissionType,
+    snapshot_id: Option<String>,
+    cancel: &CancellationToken,
+  ) {
+    for batch in index_records.chunks(HYDRATION_BATCH_SIZE) {
+      let submissions = batch
+        .iter()
+        .map(|record| submission_ref(record.id, submission_type))
+        .collect::<Vec<_>>();
+      let Ok(hydrated) = self.source.bulk_hydrate(&submissions, cancel).await else {
+        continue;
+      };
+      let records = batch
+        .iter()
+        .zip(hydrated)
+        .filter_map(|(index, hydration)| {
+          hydration
+            .map(|record| from_hydration(index, record, submission_type, snapshot_id.clone()))
+        })
+        .collect();
+      if let Err(error) = self.catalog.upsert_records(records).await {
+        log::warn!("GameBanana catalog hydration commit failed: {error}");
+      }
+    }
+  }
+}
+
+fn from_index(
+  record: &crate::providers::gamebanana::models::IndexSubmission,
+  submission_type: SubmissionType,
+  snapshot_id: Option<String>,
+) -> CatalogRecord {
+  let category = record
+    .root_category
+    .as_ref()
+    .map(|category| category.name.trim())
+    .filter(|category| !category.is_empty())
+    .unwrap_or("Other")
+    .to_string();
+  let profile_url = if record.profile_url.is_empty() {
+    format!(
+      "https://gamebanana.com/{}/{}",
+      match submission_type {
+        SubmissionType::Mod => "mods",
+        SubmissionType::Sound => "sounds",
+      },
+      record.id
+    )
+  } else {
+    record.profile_url.clone()
+  };
+
+  CatalogRecord {
+    submission: submission_ref(record.id, submission_type),
+    name: record.name.clone(),
+    author: record
+      .submitter
+      .as_ref()
+      .map(|submitter| submitter.name.trim())
+      .filter(|author| !author.is_empty())
+      .unwrap_or("Unknown")
+      .to_string(),
+    description: String::new(),
+    profile_url,
+    category,
+    hero: None,
+    is_audio: submission_type == SubmissionType::Sound,
+    is_map: false,
+    is_nsfw: false,
+    is_obsolete: record.is_obsolete,
+    is_tombstoned: false,
+    is_hydrated: false,
+    has_files: record.has_files,
+    download_count: 0,
+    likes: 0,
+    remote_added_at: record
+      .date_added
+      .filter(|value| *value > 0)
+      .unwrap_or_default(),
+    remote_updated_at: record
+      .date_modified
+      .filter(|value| *value > 0)
+      .or(record.date_added.filter(|value| *value > 0))
+      .unwrap_or_default(),
+    files_updated_at: 0,
+    last_seen_snapshot: snapshot_id,
+  }
+}
+
+fn from_hydration(
+  index: &crate::providers::gamebanana::models::IndexSubmission,
+  hydration: BulkHydration,
+  submission_type: SubmissionType,
+  snapshot_id: Option<String>,
+) -> CatalogRecord {
+  let mut record = from_index(index, submission_type, snapshot_id);
+  let description = if hydration.text.is_empty() {
+    hydration.description
+  } else {
+    hydration.text
+  };
+  let category = if hydration.root_category.trim().is_empty() {
+    hydration.category.trim()
+  } else {
+    hydration.root_category.trim()
+  };
+  record.name = hydration.name;
+  record.description = description;
+  record.category = if category.is_empty() {
+    "Other"
+  } else {
+    category
+  }
+  .to_string();
+  record.hero = hero_registry::resolve_from_skin_category(
+    Some(record.category.as_str()),
+    Some(hydration.category.as_str()),
+    &record.name,
+  );
+  record.is_map = submission_type == SubmissionType::Mod && record.category == "Maps";
+  record.is_nsfw = hydration.is_nsfw;
+  record.download_count = hydration.download_count;
+  record.is_hydrated = true;
+  record
+}
+
+fn submission_ref(id: u64, submission_type: SubmissionType) -> SubmissionRef {
+  SubmissionRef {
+    provider: SubmissionProvider::Gamebanana,
+    submission_type,
+    submission_id: id.to_string(),
+  }
+}
+
+fn resumable_snapshot(
+  mod_snapshot: &Option<String>,
+  sound_snapshot: &Option<String>,
+) -> Option<String> {
+  match (mod_snapshot, sound_snapshot) {
+    (Some(mod_snapshot), Some(sound_snapshot)) if mod_snapshot == sound_snapshot => {
+      Some(mod_snapshot.clone())
+    }
+    (Some(snapshot), None) | (None, Some(snapshot)) => Some(snapshot.clone()),
+    _ => None,
+  }
+}
+
+fn new_snapshot_id() -> String {
+  format!(
+    "snapshot-{}",
+    SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_nanos()
+  )
+}
+
+fn unix_timestamp() -> u64 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .unwrap_or_default()
+    .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{CatalogSource, CatalogSync, SourceFuture};
+  use crate::errors::Error;
+  use crate::providers::gamebanana::{BulkHydration, IndexPage};
+  use crate::providers::{SubmissionRef, SubmissionType};
+  use std::collections::VecDeque;
+  use std::sync::Mutex;
+  use tempfile::tempdir;
+  use tokio_util::sync::CancellationToken;
+
+  struct FakeSource {
+    pages: Mutex<VecDeque<Result<IndexPage, Error>>>,
+  }
+
+  impl CatalogSource for FakeSource {
+    fn index<'a>(
+      &'a self,
+      _submission_type: SubmissionType,
+      _page: u32,
+      _latest_modified: bool,
+      _cancel: &'a CancellationToken,
+    ) -> SourceFuture<'a, IndexPage> {
+      Box::pin(async move { self.pages.lock().unwrap().pop_front().unwrap() })
+    }
+
+    fn bulk_hydrate<'a>(
+      &'a self,
+      submissions: &'a [SubmissionRef],
+      _cancel: &'a CancellationToken,
+    ) -> SourceFuture<'a, Vec<Option<BulkHydration>>> {
+      Box::pin(async move {
+        Ok(
+          submissions
+            .iter()
+            .map(|submission| BulkHydration {
+              name: format!("Submission {}", submission.submission_id),
+              download_count: 5,
+              category: "Drifter".to_string(),
+              root_category: "Skins".to_string(),
+              is_nsfw: false,
+              description: String::new(),
+              text: "hydrated text".to_string(),
+            })
+            .map(Some)
+            .collect(),
+        )
+      })
+    }
+  }
+
+  fn page(id: u64, complete: bool) -> IndexPage {
+    serde_json::from_value(serde_json::json!({
+      "_aMetadata": {
+        "_nRecordCount": 1,
+        "_nPerpage": 1,
+        "_bIsComplete": complete
+      },
+      "_aRecords": [{
+        "_idRow": id,
+        "_sModelName": "Mod",
+        "_sName": format!("Submission {id}"),
+        "_sProfileUrl": format!("https://gamebanana.com/mods/{id}"),
+        "_tsDateModified": id
+      }]
+    }))
+    .unwrap()
+  }
+
+  fn page_with_modified(ids: &[(u64, i64)], complete: bool) -> IndexPage {
+    let records = ids
+      .iter()
+      .map(|(id, modified)| {
+        serde_json::json!({
+          "_idRow": id,
+          "_sModelName": "Mod",
+          "_sName": format!("Submission {id}"),
+          "_sProfileUrl": format!("https://gamebanana.com/mods/{id}"),
+          "_tsDateModified": modified
+        })
+      })
+      .collect::<Vec<_>>();
+    serde_json::from_value(serde_json::json!({
+      "_aMetadata": {
+        "_nRecordCount": records.len(),
+        "_nPerpage": records.len(),
+        "_bIsComplete": complete
+      },
+      "_aRecords": records
+    }))
+    .unwrap()
+  }
+
+  #[tokio::test]
+  async fn interrupted_full_sync_resumes_from_the_committed_page() {
+    let directory = tempdir().unwrap();
+    let catalog = super::Catalog::open(directory.path().join("catalog.sqlite3"), 2)
+      .await
+      .unwrap();
+    let first_source = FakeSource {
+      pages: Mutex::new(VecDeque::from([
+        Ok(page(1, false)),
+        Err(Error::ProviderUnavailable("offline".to_string())),
+      ])),
+    };
+    let sync = CatalogSync::with_source(catalog.clone(), first_source);
+    assert!(sync.full_sync(&CancellationToken::new()).await.is_err());
+    assert_eq!(catalog.count_visible().await.unwrap(), 1);
+    assert_eq!(
+      catalog.cursor(SubmissionType::Mod).await.unwrap().next_page,
+      2
+    );
+
+    let resumed_source = FakeSource {
+      pages: Mutex::new(VecDeque::from([Ok(page(2, true)), Ok(page(3, true))])),
+    };
+    let sync = CatalogSync::with_source(catalog.clone(), resumed_source);
+    sync.full_sync(&CancellationToken::new()).await.unwrap();
+    assert_eq!(catalog.count_visible().await.unwrap(), 3);
+    assert!(
+      catalog
+        .cursor(SubmissionType::Mod)
+        .await
+        .unwrap()
+        .snapshot_id
+        .is_none()
+    );
+  }
+
+  #[tokio::test]
+  async fn incremental_sync_overlaps_the_high_water_mark_and_throttles() {
+    let directory = tempdir().unwrap();
+    let catalog = super::Catalog::open(directory.path().join("catalog.sqlite3"), 2)
+      .await
+      .unwrap();
+    catalog
+      .set_high_water_mark(SubmissionType::Mod, 100)
+      .await
+      .unwrap();
+    let source = FakeSource {
+      pages: Mutex::new(VecDeque::from([
+        Ok(page_with_modified(&[(11, 110), (10, 100)], false)),
+        Ok(page_with_modified(&[(9, 90)], false)),
+        Ok(page_with_modified(&[(20, 120)], true)),
+      ])),
+    };
+    let sync = CatalogSync::with_source(catalog.clone(), source);
+
+    assert_eq!(
+      sync
+        .incremental_sync(true, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Incremental
+    );
+    assert_eq!(
+      catalog
+        .cursor(SubmissionType::Mod)
+        .await
+        .unwrap()
+        .high_water_mark,
+      110
+    );
+    assert_eq!(
+      sync
+        .incremental_sync(false, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Throttled
+    );
+  }
+}

--- a/apps/desktop/src-tauri/src/providers/gamebanana/client.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/client.rs
@@ -1,4 +1,4 @@
-use super::models::{DownloadPage, IndexPage, Profile};
+use super::models::{BulkHydration, DownloadPage, IndexPage, Profile};
 use super::transport::{GameBananaTransport, TransportConfig};
 use crate::errors::Error;
 use crate::providers::{SubmissionProvider, SubmissionRef, SubmissionType};
@@ -8,6 +8,17 @@ const API_BASE: &str = "https://gamebanana.com/apiv11/";
 const DEADLOCK_GAME_ID: u64 = 20_948;
 const INDEX_PAGE_SIZE: u32 = 50;
 const MAX_INDEX_PAGE: u32 = 250;
+const MAX_BULK_ITEMS: usize = 50;
+const MAX_BULK_URL_BYTES: usize = 7_000;
+const BULK_FIELDS: &[&str] = &[
+  "name",
+  "downloads",
+  "Category().name",
+  "RootCategory().name",
+  "Nsfw().bIsNsfw()",
+  "description",
+  "text",
+];
 
 pub struct GameBananaClient {
   transport: GameBananaTransport,
@@ -52,6 +63,61 @@ impl GameBananaClient {
   ) -> Result<DownloadPage, Error> {
     let url = submission_url(submission, "DownloadPage")?;
     self.transport.get_json("download page", url, cancel).await
+  }
+
+  pub async fn bulk_hydrate(
+    &self,
+    submissions: &[SubmissionRef],
+    cancel: &CancellationToken,
+  ) -> Result<Vec<Option<BulkHydration>>, Error> {
+    let first = submissions.first().ok_or_else(|| {
+      Error::ProviderInvalidResponse("bulk hydration requires at least one submission".to_string())
+    })?;
+    if submissions.len() > MAX_BULK_ITEMS
+      || first.provider != SubmissionProvider::Gamebanana
+      || submissions.iter().any(|submission| {
+        submission.provider != SubmissionProvider::Gamebanana
+          || submission.submission_type != first.submission_type
+          || submission.submission_id.parse::<u64>().is_err()
+      })
+    {
+      return Err(Error::ProviderInvalidResponse(
+        "bulk hydration requires up to 50 GameBanana submissions of one type".to_string(),
+      ));
+    }
+
+    let mut url = reqwest::Url::parse(&format!("{API_BASE}Core/Item/Data"))
+      .map_err(|error| Error::ProviderInvalidResponse(error.to_string()))?;
+    {
+      let mut query = url.query_pairs_mut();
+      for submission in submissions {
+        query
+          .append_pair("itemtype[]", model_name(submission.submission_type))
+          .append_pair("itemid[]", &submission.submission_id);
+      }
+      for field in BULK_FIELDS {
+        query.append_pair("fields[]", field);
+      }
+    }
+    if url.as_str().len() > MAX_BULK_URL_BYTES {
+      return Err(Error::ProviderInvalidResponse(
+        "bulk hydration request exceeds the URL safety limit".to_string(),
+      ));
+    }
+
+    let value = self
+      .transport
+      .get_json::<serde_json::Value>("bulk hydration", url, cancel)
+      .await?;
+    let records = BulkHydration::parse_many(value);
+    if records.len() != submissions.len() {
+      return Err(Error::ProviderInvalidResponse(format!(
+        "bulk hydration returned {} records for {} submissions",
+        records.len(),
+        submissions.len()
+      )));
+    }
+    Ok(records)
   }
 }
 
@@ -114,7 +180,7 @@ fn model_name(submission_type: SubmissionType) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-  use super::{MAX_INDEX_PAGE, index_url, model_name, submission_url};
+  use super::{MAX_BULK_ITEMS, MAX_BULK_URL_BYTES, MAX_INDEX_PAGE, index_url, model_name, submission_url};
   use crate::providers::{SubmissionRef, SubmissionType};
 
   #[test]
@@ -129,6 +195,8 @@ mod tests {
     let local = SubmissionRef::parse_slug("local-550e8400-e29b-41d4-a716-446655440000").unwrap();
     assert!(submission_url(&local, "ProfilePage").is_err());
     assert_eq!(MAX_INDEX_PAGE, 250);
+    assert_eq!(MAX_BULK_ITEMS, 50);
+    assert_eq!(MAX_BULK_URL_BYTES, 7_000);
   }
   #[test]
   fn index_query_preserves_wire_format_and_pagination() {

--- a/apps/desktop/src-tauri/src/providers/gamebanana/mod.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalog;
 mod client;
 mod generated_hero_registry;
 mod hero_registry;
@@ -6,7 +7,7 @@ mod normalization;
 mod transport;
 
 pub use client::GameBananaClient;
-pub use models::{DownloadPage, IndexPage, Profile, SubmissionFile};
+pub use models::{BulkHydration, DownloadPage, IndexPage, Profile, SubmissionFile};
 pub use normalization::{
   DonationLink, NormalizedRequirement, NormalizedSubmission, classify_nsfw, donation_links,
   extract_map_name, normalize_profile, parse_requirements, parse_tags,

--- a/apps/desktop/src-tauri/src/providers/gamebanana/models.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/models.rs
@@ -39,11 +39,22 @@ pub struct IndexSubmission {
   #[serde(rename = "_sName")]
   pub name: String,
   #[serde(rename = "_sProfileUrl")]
+  #[serde(default)]
   pub profile_url: String,
   #[serde(rename = "_tsDateAdded", default)]
   pub date_added: Option<i64>,
   #[serde(rename = "_tsDateModified", default)]
   pub date_modified: Option<i64>,
+  #[serde(rename = "_aSubmitter", default)]
+  pub submitter: Option<Submitter>,
+  #[serde(rename = "_aRootCategory", default)]
+  pub root_category: Option<Category>,
+  #[serde(rename = "_aSubCategory", default)]
+  pub sub_category: Option<Category>,
+  #[serde(rename = "_bHasFiles", default)]
+  pub has_files: bool,
+  #[serde(rename = "_bIsObsolete", default)]
+  pub is_obsolete: bool,
 }
 
 impl IndexSubmission {
@@ -51,7 +62,7 @@ impl IndexSubmission {
     self.id > 0
       && matches!(self.model_name.as_str(), "Mod" | "Sound")
       && !self.name.trim().is_empty()
-      && self.profile_url.starts_with("https://gamebanana.com/")
+      && (self.profile_url.is_empty() || self.profile_url.starts_with("https://gamebanana.com/"))
   }
 }
 
@@ -204,9 +215,66 @@ pub struct DownloadPage {
   pub files: Vec<SubmissionFile>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BulkHydration {
+  pub name: String,
+  pub download_count: u64,
+  pub category: String,
+  pub root_category: String,
+  pub is_nsfw: bool,
+  pub description: String,
+  pub text: String,
+}
+
+impl BulkHydration {
+  pub fn parse_many(value: serde_json::Value) -> Vec<Option<Self>> {
+    match value {
+      serde_json::Value::Array(records) => records.into_iter().map(Self::from_array).collect(),
+      serde_json::Value::Object(fields) => vec![Self::from_object(&fields)],
+      _ => Vec::new(),
+    }
+  }
+
+  fn from_array(value: serde_json::Value) -> Option<Self> {
+    let values = value.as_array()?;
+    Some(Self {
+      name: values.first()?.as_str()?.to_string(),
+      download_count: values.get(1)?.as_u64()?,
+      category: values.get(2)?.as_str().unwrap_or_default().to_string(),
+      root_category: values.get(3)?.as_str().unwrap_or_default().to_string(),
+      is_nsfw: values.get(4)?.as_bool().unwrap_or_default(),
+      description: values.get(5)?.as_str().unwrap_or_default().to_string(),
+      text: values.get(6)?.as_str().unwrap_or_default().to_string(),
+    })
+  }
+
+  fn from_object(fields: &serde_json::Map<String, serde_json::Value>) -> Option<Self> {
+    Some(Self {
+      name: fields.get("name")?.as_str()?.to_string(),
+      download_count: fields.get("downloads")?.as_u64()?,
+      category: string_field(fields, "Category().name"),
+      root_category: string_field(fields, "RootCategory().name"),
+      is_nsfw: fields
+        .get("Nsfw().bIsNsfw()")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or_default(),
+      description: string_field(fields, "description"),
+      text: string_field(fields, "text"),
+    })
+  }
+}
+
+fn string_field(fields: &serde_json::Map<String, serde_json::Value>, key: &str) -> String {
+  fields
+    .get(key)
+    .and_then(serde_json::Value::as_str)
+    .unwrap_or_default()
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
-  use super::{DownloadPage, IndexPage, Profile};
+  use super::{BulkHydration, DownloadPage, IndexPage, Profile};
 
   #[test]
   fn malformed_index_records_do_not_discard_the_page() {
@@ -252,5 +320,20 @@ mod tests {
         vec![1, 3]
       );
     }
+  }
+
+  #[test]
+  fn bulk_hydration_accepts_multicall_and_single_item_shapes() {
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+      "../../../tests/fixtures/gamebanana/core-item-data.json"
+    ))
+    .unwrap();
+    let multi = BulkHydration::parse_many(fixture["modMulticall"].clone());
+    let single = BulkHydration::parse_many(fixture["sound"].clone());
+
+    assert_eq!(multi.len(), 2);
+    assert_eq!(multi[0].as_ref().unwrap().category, "Drifter");
+    assert_eq!(single.len(), 1);
+    assert_eq!(single[0].as_ref().unwrap().category, "Abilities");
   }
 }


### PR DESCRIPTION
## Description

Add a separate SQLite catalog owned by Rust so browsing can continue when GameBanana is slow or unavailable. SQL and raw upstream responses remain outside the renderer.

The catalog is keyed by provider, submission type, and submission ID. It includes FTS5 search and normalized columns for category, hero, NSFW, audio/map, popularity, and update sorting. Its schema uses an independent `user_version` migration ladder.

Initial index pages commit with a resumable cursor. Incremental refreshes overlap the stored high-water mark, and missing records are tombstoned only after a complete reconciliation snapshot. A failed refresh leaves the last usable catalog intact.

## Type of Change

- [ ] ≡ƒÉ¢ Bug fix (non-breaking change which fixes an issue)
- [x] Γ£¿ New feature (non-breaking change which adds functionality)
- [ ] ≡ƒÆÑ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ≡ƒôÜ Documentation update
- [ ] ≡ƒöº Code refactoring (no functional changes)
- [x] ≡ƒº¬ Tests (adding or updating tests)
- [ ] ≡ƒö¿ Chore (maintenance, dependency updates, etc.)

## Related Issues

- Refs #673

Maintainer-directed GameBanana direct-client migration.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted ΓÇö Tool: Codex, Used for: implementing human written plan and prototyping

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Validated with the Rust catalog schema, store, synchronization, interruption, and reconciliation tests.

## Screenshots (if applicable)

Not applicable; renderer integration arrives in #698.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [ ] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Stack 3 of 9. Based on #696; followed by #698.

Review transaction boundaries and the rule that an incomplete snapshot must never tombstone records.

## For Maintainers

- [ ] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [ ] This PR requires migration instructions

## Stack tracking

Tracked in #673 (PR 3 of 19). Based on #696. Followed by #698.

