### PR TITLE
feat(desktop): migrate installed sounds to namespaced IDs

### DIFF
--- a/.changeset/quiet-bananas-migrate.md
+++ b/.changeset/quiet-bananas-migrate.md
@@ -1,0 +1,6 @@
+---
+"@deadlock-mods/desktop": minor
+"@deadlock-mods/shared": minor
+---
+
+Namespace GameBanana Sound identities across persisted desktop state, installed files, deep links, and shared profile v3 imports.

--- a/apps/desktop/src-tauri/src/commands/deep_link.rs
+++ b/apps/desktop/src-tauri/src/commands/deep_link.rs
@@ -19,7 +19,7 @@ pub struct DeepLinkDebugInfo {
 
 #[tauri::command]
 pub async fn parse_deep_link(url: String) -> Result<DeepLinkData, Error> {
-  log::info!("Parsing deep link: {url}");
+  log::info!("Parsing mod installation deep link");
 
   let data_part = strip_scheme(&url).ok_or_else(|| {
     Error::InvalidInput(format!(
@@ -34,7 +34,7 @@ pub async fn parse_deep_link(url: String) -> Result<DeepLinkData, Error> {
     )
   })?;
 
-  log::info!("Parsed deep link - Download URL: {download_url}, Type: {mod_type}, Mod ID: {mod_id}");
+  log::info!("Parsed deep link for {mod_type} {mod_id}");
 
   Ok(DeepLinkData {
     download_url,

--- a/apps/desktop/src-tauri/src/commands/identity_migration.rs
+++ b/apps/desktop/src-tauri/src/commands/identity_migration.rs
@@ -1,0 +1,360 @@
+use crate::app_runtime::AppHandle;
+use crate::errors::Error;
+use crate::mod_manager::shard::{ProfileBase, UPDATE_STAGING_PREFIX};
+use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
+use crate::providers::{SubmissionProvider, SubmissionRef, SubmissionType};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+use tauri::Manager;
+
+const JOURNAL_FILE: &str = "gamebanana-identity-migration-v1.json";
+const MAX_MIGRATIONS: usize = 10_000;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityMigration {
+  from: String,
+  to: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct IdentityMigrationJournal {
+  version: u32,
+  complete: bool,
+  migrations: Vec<IdentityMigration>,
+}
+
+#[tauri::command]
+pub async fn migrate_submission_identities(
+  app_handle: AppHandle,
+  migrations: Vec<IdentityMigration>,
+) -> Result<(), Error> {
+  let app_data = app_handle
+    .path()
+    .app_local_data_dir()
+    .map_err(Error::Tauri)?;
+  let game_path = super::state::game_path()?;
+  tokio::task::spawn_blocking(move || migrate_on_disk(&app_data, &game_path, migrations))
+    .await
+    .map_err(|error| Error::BackgroundTaskFailed(error.to_string()))?
+}
+
+fn migrate_on_disk(
+  app_data: &Path,
+  game_path: &Path,
+  requested: Vec<IdentityMigration>,
+) -> Result<(), Error> {
+  let requested = validate_migrations(requested)?;
+  if requested.is_empty() {
+    return Ok(());
+  }
+
+  fs::create_dir_all(app_data)?;
+  let journal_path = app_data.join(JOURNAL_FILE);
+  let migrations = match read_journal(&journal_path)? {
+    Some(journal) => {
+      if journal.version != 1 || journal.migrations != requested {
+        return Err(Error::InvalidInput(
+          "Identity migration journal does not match persisted state".to_string(),
+        ));
+      }
+      if journal.complete {
+        return Ok(());
+      }
+      journal.migrations
+    }
+    None => {
+      write_journal(
+        &journal_path,
+        &IdentityMigrationJournal {
+          version: 1,
+          complete: false,
+          migrations: requested.clone(),
+        },
+      )?;
+      requested
+    }
+  };
+
+  migrate_mod_cache(&app_data.join("mods"), &migrations)?;
+  migrate_game_files(game_path, &migrations)?;
+  write_journal(
+    &journal_path,
+    &IdentityMigrationJournal {
+      version: 1,
+      complete: true,
+      migrations,
+    },
+  )
+}
+
+fn validate_migrations(
+  migrations: Vec<IdentityMigration>,
+) -> Result<Vec<IdentityMigration>, Error> {
+  if migrations.len() > MAX_MIGRATIONS {
+    return Err(Error::InvalidInput(
+      "Too many identity migrations".to_string(),
+    ));
+  }
+  let mut seen = BTreeSet::new();
+  let mut validated = Vec::with_capacity(migrations.len());
+  for migration in migrations {
+    let from = SubmissionRef::parse_slug(&migration.from)
+      .map_err(|_| Error::InvalidInput("Invalid legacy submission identity".to_string()))?;
+    let to = SubmissionRef::parse_slug(&migration.to)
+      .map_err(|_| Error::InvalidInput("Invalid migrated submission identity".to_string()))?;
+    if from.provider != SubmissionProvider::Gamebanana
+      || from.submission_type != SubmissionType::Mod
+      || to.provider != SubmissionProvider::Gamebanana
+      || to.submission_type != SubmissionType::Sound
+      || from.submission_id != to.submission_id
+      || !seen.insert(migration.from.clone())
+    {
+      return Err(Error::InvalidInput(
+        "Identity migration must map one GameBanana mod ID to its sound slug".to_string(),
+      ));
+    }
+    validated.push(migration);
+  }
+  validated.sort_by(|left, right| left.from.cmp(&right.from));
+  Ok(validated)
+}
+
+fn read_journal(path: &Path) -> Result<Option<IdentityMigrationJournal>, Error> {
+  if !path.exists() {
+    return Ok(None);
+  }
+  let bytes = fs::read(path)?;
+  serde_json::from_slice(&bytes)
+    .map(Some)
+    .map_err(|error| Error::InvalidInput(format!("Invalid identity migration journal: {error}")))
+}
+
+fn write_journal(path: &Path, journal: &IdentityMigrationJournal) -> Result<(), Error> {
+  let temp_path = path.with_extension("json.tmp");
+  let bytes = serde_json::to_vec_pretty(journal)
+    .map_err(|error| Error::InvalidInput(format!("Failed to encode migration journal: {error}")))?;
+  fs::write(&temp_path, bytes)?;
+  if path.exists() {
+    fs::remove_file(path)?;
+  }
+  fs::rename(temp_path, path)?;
+  Ok(())
+}
+
+fn migrate_mod_cache(mods_root: &Path, migrations: &[IdentityMigration]) -> Result<(), Error> {
+  if !mods_root.exists() {
+    return Ok(());
+  }
+  for migration in migrations {
+    rename_without_overwrite(
+      &mods_root.join(&migration.from),
+      &mods_root.join(&migration.to),
+    )?;
+  }
+  Ok(())
+}
+
+fn migrate_game_files(game_path: &Path, migrations: &[IdentityMigration]) -> Result<(), Error> {
+  let citadel = game_path.join("game").join("citadel");
+  let addons = citadel.join("addons");
+  if addons.exists() {
+    for profile in profile_bases(&addons)? {
+      migrate_profile(&profile, migrations)?;
+    }
+  }
+  migrate_fonts_conf(
+    &citadel.join("panorama").join("fonts").join("fonts.conf"),
+    migrations,
+  )
+}
+
+fn profile_bases(addons: &Path) -> Result<Vec<ProfileBase>, Error> {
+  let mut profiles = vec![ProfileBase::new(addons)?];
+  for entry in fs::read_dir(addons)? {
+    let entry = entry?;
+    let path = entry.path();
+    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+      continue;
+    };
+    if path.is_dir() && (name.starts_with("profile_") || name.starts_with("server_")) {
+      profiles.push(ProfileBase::new(path)?);
+    }
+  }
+  Ok(profiles)
+}
+
+fn migrate_profile(profile: &ProfileBase, migrations: &[IdentityMigration]) -> Result<(), Error> {
+  let manifest_path = profile.join(".dmm.json");
+  let has_manifest = manifest_path.exists() || profile.join(".dmm.json.tmp").exists();
+  let mut manifest = has_manifest
+    .then(|| ProfileVpkManifest::open_for_write(profile))
+    .transpose()?;
+
+  for migration in migrations {
+    for (_, shard) in profile.existing_shards() {
+      rename_prefixed_vpks(&shard, &migration.from, &migration.to)?;
+    }
+    if let Some(manifest) = manifest.as_mut() {
+      manifest.migrate_mod_identity(&migration.from, &migration.to)?;
+    }
+    rename_without_overwrite(
+      &profile.join(format!("{UPDATE_STAGING_PREFIX}{}", migration.from)),
+      &profile.join(format!("{UPDATE_STAGING_PREFIX}{}", migration.to)),
+    )?;
+  }
+  if let Some(manifest) = manifest {
+    manifest.save(profile)?;
+  }
+  Ok(())
+}
+
+fn rename_prefixed_vpks(directory: &Path, from: &str, to: &str) -> Result<(), Error> {
+  if !directory.exists() {
+    return Ok(());
+  }
+  let prefix = format!("{from}_");
+  for entry in fs::read_dir(directory)? {
+    let entry = entry?;
+    let path = entry.path();
+    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+      continue;
+    };
+    if path.is_file()
+      && name.to_ascii_lowercase().ends_with(".vpk")
+      && let Some(suffix) = name.strip_prefix(&prefix)
+    {
+      rename_without_overwrite(&path, &directory.join(format!("{to}_{suffix}")))?;
+    }
+  }
+  Ok(())
+}
+
+fn rename_without_overwrite(source: &Path, destination: &Path) -> Result<(), Error> {
+  if !source.exists() {
+    return Ok(());
+  }
+  if destination.exists() {
+    return Err(Error::ModInvalid(format!(
+      "Cannot migrate {} because {} already exists",
+      source.display(),
+      destination.display()
+    )));
+  }
+  fs::rename(source, destination)?;
+  Ok(())
+}
+
+fn migrate_fonts_conf(path: &Path, migrations: &[IdentityMigration]) -> Result<(), Error> {
+  if !path.exists() {
+    return Ok(());
+  }
+  let mut content = fs::read_to_string(path)?;
+  for migration in migrations {
+    for marker in [
+      "<!-- [DEADLOCK-MOD-MANAGER-FONTS-START:",
+      "<!-- [DEADLOCK-MOD-MANAGER-FONTS-END:",
+    ] {
+      content = content.replace(
+        &format!("{marker} {} -->", migration.from),
+        &format!("{marker} {} -->", migration.to),
+      );
+    }
+  }
+  fs::write(path, content)?;
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::mod_manager::shard::ShardIndex;
+  use crate::mod_manager::vpk_manifest::ProfileVpkManifestEntry;
+  use std::collections::BTreeMap;
+
+  #[test]
+  fn validates_only_matching_mod_to_sound_migrations() {
+    assert!(
+      validate_migrations(vec![IdentityMigration {
+        from: "42".to_string(),
+        to: "snd-42".to_string(),
+      }])
+      .is_ok()
+    );
+    assert!(
+      validate_migrations(vec![IdentityMigration {
+        from: "42".to_string(),
+        to: "snd-43".to_string(),
+      }])
+      .is_err()
+    );
+  }
+
+  #[test]
+  fn interrupted_disk_migration_resumes_idempotently() {
+    let root = tempfile::tempdir().unwrap();
+    let app_data = root.path().join("app-data");
+    let game_path = root.path().join("game-root");
+    let addons = game_path.join("game/citadel/addons");
+    let fonts = game_path.join("game/citadel/panorama/fonts");
+    fs::create_dir_all(app_data.join("mods/42")).unwrap();
+    fs::create_dir_all(&addons).unwrap();
+    fs::create_dir_all(&fonts).unwrap();
+    fs::write(addons.join("42_voice.vpk"), b"vpk").unwrap();
+    fs::write(
+      fonts.join("fonts.conf"),
+      "<!-- [DEADLOCK-MOD-MANAGER-FONTS-START: 42 -->\n<!-- [DEADLOCK-MOD-MANAGER-FONTS-END: 42 -->",
+    )
+    .unwrap();
+    ProfileVpkManifest {
+      version: 2,
+      mods: BTreeMap::from([(
+        "42".to_string(),
+        ProfileVpkManifestEntry {
+          shard: ShardIndex::FIRST,
+          disabled_vpks: vec!["42_voice.vpk".to_string()],
+          ..ProfileVpkManifestEntry::default()
+        },
+      )]),
+    }
+    .save(&addons)
+    .unwrap();
+    let migration = IdentityMigration {
+      from: "42".to_string(),
+      to: "snd-42".to_string(),
+    };
+    write_journal(
+      &app_data.join(JOURNAL_FILE),
+      &IdentityMigrationJournal {
+        version: 1,
+        complete: false,
+        migrations: vec![migration.clone()],
+      },
+    )
+    .unwrap();
+
+    migrate_on_disk(&app_data, &game_path, vec![migration.clone()]).unwrap();
+    migrate_on_disk(&app_data, &game_path, vec![migration]).unwrap();
+
+    assert!(app_data.join("mods/snd-42").is_dir());
+    assert!(!app_data.join("mods/42").exists());
+    assert!(addons.join("snd-42_voice.vpk").is_file());
+    let manifest = ProfileVpkManifest::load(&addons).unwrap();
+    assert!(manifest.mods.contains_key("snd-42"));
+    assert_eq!(manifest.version, 3);
+    assert!(
+      fs::read_to_string(fonts.join("fonts.conf"))
+        .unwrap()
+        .contains("snd-42")
+    );
+    assert!(
+      read_journal(&app_data.join(JOURNAL_FILE))
+        .unwrap()
+        .unwrap()
+        .complete
+    );
+  }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod game;
 mod game_process;
 pub mod gamebanana_catalog;
 pub mod gameinfo;
+pub mod identity_migration;
 pub mod ingest;
 pub mod live_match;
 pub mod logs;

--- a/apps/desktop/src-tauri/src/deep_link.rs
+++ b/apps/desktop/src-tauri/src/deep_link.rs
@@ -66,7 +66,10 @@ pub fn is_deep_link(url: &str) -> bool {
 
 #[cfg(desktop)]
 pub fn on_second_instance(app_handle: &AppHandle, argv: Vec<String>, _cwd: String) {
-  log::info!("[DeepLink] Single instance callback triggered with argv: {argv:?}");
+  log::info!(
+    "[DeepLink] Single instance callback triggered with {} argument(s)",
+    argv.len()
+  );
 
   for arg in &argv {
     if is_deep_link(arg) {
@@ -94,11 +97,15 @@ pub fn validate_mod_deep_link(data_part: &str) -> Option<(String, String, String
     return None;
   }
 
-  let download_url = parts[0].to_string();
-  let mod_type = parts[1].to_string();
+  let download_url = reqwest::Url::parse(parts[0]).ok()?;
+  let mod_type = parts[1].to_ascii_lowercase();
   let mod_id = parts[2].to_string();
 
-  if !download_url.contains(GAMEBANANA_DOMAIN) {
+  let host = download_url.host_str()?;
+  if download_url.scheme() != "https"
+    || (host != GAMEBANANA_DOMAIN && !host.ends_with(&format!(".{GAMEBANANA_DOMAIN}")))
+    || !matches!(mod_type.as_str(), "mod" | "sound")
+  {
     return None;
   }
 
@@ -106,14 +113,14 @@ pub fn validate_mod_deep_link(data_part: &str) -> Option<(String, String, String
     return None;
   }
 
-  Some((download_url, mod_type, mod_id))
+  Some((download_url.to_string(), mod_type, mod_id))
 }
 
 pub fn handle_deep_link_url(
   app_handle: &AppHandle,
   url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-  log::info!("[DeepLink] Processing deep link URL: {url}");
+  log::info!("[DeepLink] Processing deep link URL");
 
   let data_part = match strip_scheme(url) {
     Some(part) => part,
@@ -210,7 +217,10 @@ pub fn setup(app: &tauri::App<AppRuntime>) -> Result<(), Box<dyn std::error::Err
   let start_urls = app.deep_link().get_current()?;
 
   if let Some(urls) = start_urls {
-    log::info!("[DeepLink] App started with deep link URLs: {urls:?}");
+    log::info!(
+      "[DeepLink] App started with {} deep link URL(s)",
+      urls.len()
+    );
     for url in urls {
       if let Err(e) = handle_deep_link_url(handle, url.as_ref()) {
         log::error!("[DeepLink] Failed to handle startup deep link: {e}");
@@ -221,7 +231,7 @@ pub fn setup(app: &tauri::App<AppRuntime>) -> Result<(), Box<dyn std::error::Err
   let deep_link_handle = app.app_handle().clone();
   app.deep_link().on_open_url(move |event| {
     for url in event.urls() {
-      log::info!("[DeepLink] Received open URL event: {url}");
+      log::info!("[DeepLink] Received open URL event");
       if let Err(e) = handle_deep_link_url(&deep_link_handle, url.as_ref()) {
         log::error!("[DeepLink] Failed to handle open URL: {e}");
       }
@@ -233,7 +243,7 @@ pub fn setup(app: &tauri::App<AppRuntime>) -> Result<(), Box<dyn std::error::Err
 
 #[cfg(test)]
 mod tests {
-  use super::{PATH_FORGE_LAUNCH, strip_scheme};
+  use super::{PATH_FORGE_LAUNCH, strip_scheme, validate_mod_deep_link};
 
   #[test]
   fn recognises_the_forge_launch_url_the_site_fires() {
@@ -242,5 +252,19 @@ mod tests {
     let stripped =
       strip_scheme("deadlock-mod-manager://forge/launch").expect("scheme should be recognised");
     assert!(stripped.starts_with(PATH_FORGE_LAUNCH));
+  }
+
+  #[test]
+  fn validates_mod_and_sound_install_links() {
+    assert!(validate_mod_deep_link("https://gamebanana.com/mmdl/12,Mod,42").is_some());
+    let sound = validate_mod_deep_link("https://files.gamebanana.com/mmdl/13,Sound,42").unwrap();
+    assert_eq!(sound.1, "sound");
+  }
+
+  #[test]
+  fn rejects_untrusted_or_unknown_install_links() {
+    assert!(validate_mod_deep_link("https://gamebanana.com.evil.test/mmdl/12,Mod,42").is_none());
+    assert!(validate_mod_deep_link("http://gamebanana.com/mmdl/12,Mod,42").is_none());
+    assert!(validate_mod_deep_link("https://gamebanana.com/mmdl/12,Map,42").is_none());
   }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -130,6 +130,7 @@ pub fn run() {
       commands::gamebanana_catalog::inspect_gamebanana_catalog_state,
       commands::gamebanana_catalog::invalidate_gamebanana_catalog_state,
       commands::gamebanana_catalog::get_gamebanana_fileservers,
+      commands::identity_migration::migrate_submission_identities,
       commands::game::find_steam_path,
       commands::game::set_game_path,
       commands::game::set_steam_path,

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manifest.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, io::ErrorKind, path::Path};
 
 const MANIFEST_FILENAME: &str = ".dmm.json";
-const CURRENT_MANIFEST_VERSION: u32 = 2;
+const CURRENT_MANIFEST_VERSION: u32 = 3;
 
 const fn current_manifest_version() -> u32 {
   CURRENT_MANIFEST_VERSION
@@ -344,6 +344,33 @@ impl ProfileVpkManifest {
   pub fn remove_mod(&mut self, mod_id: &str) {
     self.mods.remove(mod_id);
   }
+
+  pub fn migrate_mod_identity(&mut self, from: &str, to: &str) -> Result<(), Error> {
+    if from == to {
+      return Ok(());
+    }
+
+    if self.mods.contains_key(from) && self.mods.contains_key(to) {
+      if self.mods.get(from) != self.mods.get(to) {
+        return Err(Error::ModInvalid(format!(
+          "VPK manifest contains conflicting entries for {from} and {to}"
+        )));
+      }
+      self.mods.remove(from);
+    } else if let Some(entry) = self.mods.remove(from) {
+      self.mods.insert(to.to_string(), entry);
+    }
+
+    if let Some(entry) = self.mods.get_mut(to) {
+      for file_name in &mut entry.disabled_vpks {
+        if let Some(suffix) = file_name.strip_prefix(&format!("{from}_")) {
+          *file_name = format!("{to}_{suffix}");
+        }
+      }
+    }
+    self.version = CURRENT_MANIFEST_VERSION;
+    Ok(())
+  }
 }
 
 #[cfg(test)]
@@ -445,6 +472,49 @@ mod tests {
     assert!(written.contains(&format!("\"version\": {CURRENT_MANIFEST_VERSION}")));
     assert!(written.contains("\"shard\": 1"));
     assert_eq!(ProfileVpkManifest::load(&base).unwrap(), loaded);
+  }
+
+  #[test]
+  fn v3_manifest_migrates_sound_keys_and_disabled_file_names_idempotently() {
+    let mut manifest = ProfileVpkManifest {
+      version: 2,
+      mods: BTreeMap::from([(
+        "42".to_string(),
+        ProfileVpkManifestEntry {
+          disabled_vpks: vec!["42_voice.vpk".to_string()],
+          ..ProfileVpkManifestEntry::default()
+        },
+      )]),
+    };
+
+    manifest.migrate_mod_identity("42", "snd-42").unwrap();
+    manifest.migrate_mod_identity("42", "snd-42").unwrap();
+
+    assert_eq!(manifest.version, CURRENT_MANIFEST_VERSION);
+    assert!(!manifest.mods.contains_key("42"));
+    assert_eq!(
+      manifest.mods["snd-42"].disabled_vpks,
+      vec!["snd-42_voice.vpk"]
+    );
+  }
+
+  #[test]
+  fn identity_migration_rejects_conflicting_manifest_entries() {
+    let mut manifest = ProfileVpkManifest {
+      version: 2,
+      mods: BTreeMap::from([
+        ("42".to_string(), ProfileVpkManifestEntry::default()),
+        (
+          "snd-42".to_string(),
+          ProfileVpkManifestEntry {
+            enabled: true,
+            ..ProfileVpkManifestEntry::default()
+          },
+        ),
+      ]),
+    };
+
+    assert!(manifest.migrate_mod_identity("42", "snd-42").is_err());
   }
 
   /// A manifest written by a newer build must not be silently mis-parsed into

--- a/apps/desktop/src/components/profiles/profile-import-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-import-dialog.tsx
@@ -9,12 +9,23 @@ import {
   DialogTrigger,
 } from "@deadlock-mods/ui/components/dialog";
 import { toast } from "@deadlock-mods/ui/components/sonner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deadlock-mods/ui/components/select";
 import { ImportIcon } from "@deadlock-mods/ui/icons";
 import { useMutation, useQueries } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useProfileImport } from "@/hooks/use-profile-import";
 import { getMod, getProfile } from "@/lib/api-client";
+import {
+  getProfileModCandidateIds,
+  rewriteProfileIdentities,
+} from "@/lib/profiles/import-profile-shared";
 import {
   ProfileImportForm,
   type ProfileImportFormData,
@@ -26,6 +37,9 @@ export const ProfileImportDialog = () => {
   const [importedProfile, setImportedProfile] = useState<SharedProfile | null>(
     null,
   );
+  const [legacySelections, setLegacySelections] = useState<
+    Record<number, string>
+  >({});
   const { t } = useTranslation();
   const { createProfileFromImport, importProgress } = useProfileImport();
 
@@ -33,6 +47,7 @@ export const ProfileImportDialog = () => {
     mutationFn: (profileId: string) => getProfile(profileId.trim()),
     onSuccess: (data) => {
       setImportedProfile(data);
+      setLegacySelections({});
       toast.success(t("profiles.importSuccess"));
     },
     onError: () => {
@@ -63,17 +78,56 @@ export const ProfileImportDialog = () => {
     ? importedProfile.payload.mods
     : [];
 
+  const candidateEntries = importedProfile
+    ? orderedImportedMods.flatMap((_, modIndex) =>
+        getProfileModCandidateIds(importedProfile, modIndex).map(
+          (remoteId) => ({ modIndex, remoteId }),
+        ),
+      )
+    : [];
+
   const modQueries = useQueries({
-    queries: orderedImportedMods.map((mod) => ({
-      queryKey: ["mod", mod.remoteId],
-      queryFn: () => getMod(mod.remoteId),
+    queries: candidateEntries.map(({ remoteId }) => ({
+      queryKey: ["mod", remoteId],
+      queryFn: () => getMod(remoteId),
     })),
   });
 
   const modsLoading = modQueries.some((query) => query.isPending);
-  const modsData = modQueries
-    .map((query) => query.data)
-    .filter(Boolean) as ModDto[];
+  const availableCandidates = orderedImportedMods.map((_, modIndex) =>
+    candidateEntries.flatMap((entry, queryIndex) => {
+      const mod = modQueries[queryIndex]?.data;
+      return entry.modIndex === modIndex && mod
+        ? [{ remoteId: entry.remoteId, mod }]
+        : [];
+    }),
+  );
+  const ambiguousMods = availableCandidates
+    .map((candidates, modIndex) => ({ candidates, modIndex }))
+    .filter(({ candidates }) => candidates.length > 1);
+  const resolvedIds = importedProfile
+    ? orderedImportedMods.map((mod, modIndex) => {
+        const candidates = availableCandidates[modIndex] ?? [];
+        if (candidates.length > 1) {
+          return legacySelections[modIndex] ?? mod.remoteId;
+        }
+        return (
+          candidates[0]?.remoteId ??
+          getProfileModCandidateIds(importedProfile, modIndex)[0] ??
+          mod.remoteId
+        );
+      })
+    : [];
+  const resolvedProfile = importedProfile
+    ? rewriteProfileIdentities(importedProfile, resolvedIds)
+    : null;
+  const modsData = availableCandidates.flatMap((candidates, modIndex) => {
+    const selectedId = resolvedIds[modIndex];
+    const selected = candidates.find(
+      (candidate) => candidate.remoteId === selectedId,
+    );
+    return selected ? [selected.mod] : [];
+  }) satisfies ModDto[];
 
   const onSubmit = async (values: ProfileImportFormData) => {
     const profileId = values.profileId?.trim();
@@ -88,16 +142,29 @@ export const ProfileImportDialog = () => {
 
   const handleCancel = () => {
     setImportedProfile(null);
+    setLegacySelections({});
     setOpen(false);
   };
 
   const handleCreateNewProfile = () => {
-    if (!importedProfile) return;
+    if (!resolvedProfile) return;
+    if (
+      ambiguousMods.some(
+        ({ modIndex }) => legacySelections[modIndex] === undefined,
+      )
+    ) {
+      toast.error(
+        t("profiles.legacyIdentityRequired", {
+          defaultValue: "Choose whether each ambiguous item is a mod or sound.",
+        }),
+      );
+      return;
+    }
 
     const sourceProfileId = fetchProfileMutation.variables?.trim();
 
     createProfileMutation.mutate({
-      profile: importedProfile,
+      profile: resolvedProfile,
       availableMods: modsData,
       sourceProfileId,
     });
@@ -125,15 +192,63 @@ export const ProfileImportDialog = () => {
         </DialogHeader>
 
         {importedProfile ? (
-          <ProfilePreview
-            importedProfile={importedProfile}
-            modsLoading={modsLoading}
-            modsData={modsData}
-            onCreateNew={handleCreateNewProfile}
-            onCancel={handleCancel}
-            isImporting={createProfileMutation.isPending}
-            importProgress={importProgress}
-          />
+          <>
+            {ambiguousMods.length > 0 && (
+              <div className='space-y-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-3'>
+                <p className='text-sm font-medium'>
+                  {t("profiles.legacyIdentityTitle", {
+                    defaultValue: "Choose the matching GameBanana item",
+                  })}
+                </p>
+                <p className='text-xs text-muted-foreground'>
+                  {t("profiles.legacyIdentityDescription", {
+                    defaultValue:
+                      "This older profile ID exists as both a mod and a sound.",
+                  })}
+                </p>
+                {ambiguousMods.map(({ candidates, modIndex }) => (
+                  <Select
+                    key={candidates
+                      .map((candidate) => candidate.remoteId)
+                      .join("-")}
+                    value={legacySelections[modIndex]}
+                    onValueChange={(remoteId) =>
+                      setLegacySelections((current) => ({
+                        ...current,
+                        [modIndex]: remoteId,
+                      }))
+                    }>
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={t("profiles.legacyIdentityPlaceholder", {
+                          defaultValue: "Select mod or sound",
+                        })}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {candidates.map(({ mod, remoteId }) => (
+                        <SelectItem key={remoteId} value={remoteId}>
+                          {remoteId.startsWith("snd-")
+                            ? t("profiles.submissionTypeSound")
+                            : t("profiles.submissionTypeMod")}
+                          : {mod.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ))}
+              </div>
+            )}
+            <ProfilePreview
+              importedProfile={resolvedProfile ?? importedProfile}
+              modsLoading={modsLoading}
+              modsData={modsData}
+              onCreateNew={handleCreateNewProfile}
+              onCancel={handleCancel}
+              isImporting={createProfileMutation.isPending}
+              importProgress={importProgress}
+            />
+          </>
         ) : (
           <ProfileImportForm
             onSubmit={onSubmit}

--- a/apps/desktop/src/components/profiles/profile-share-dialog.tsx
+++ b/apps/desktop/src/components/profiles/profile-share-dialog.tsx
@@ -48,10 +48,12 @@ export const ProfileShareDialog = () => {
 
       const baseModData: {
         remoteId: string;
+        submissionType: "mod" | "sound";
         fileTree?: ModFileTree;
         selectedDownloads?: ProfileModDownload[];
       } = {
         remoteId: mod.remoteId,
+        submissionType: localMod?.isAudio ? "sound" : "mod",
       };
 
       // Add file tree information if available (for any mod that has file tree data)
@@ -88,6 +90,21 @@ export const ProfileShareDialog = () => {
 
       return baseModData;
     });
+  const enabledIds = new Set(enabledMods.map((mod) => mod.remoteId));
+  const orderedIds = [...(activeProfile?.mods ?? [])]
+    .filter((mod) => enabledIds.has(mod.remoteId))
+    .sort(
+      (left, right) =>
+        (left.installOrder ?? Number.MAX_SAFE_INTEGER) -
+        (right.installOrder ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map((mod) => mod.remoteId);
+  const loadOrder = [
+    ...orderedIds,
+    ...enabledMods
+      .map((mod) => mod.remoteId)
+      .filter((remoteId) => !orderedIds.includes(remoteId)),
+  ];
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (params: {
@@ -136,9 +153,10 @@ export const ProfileShareDialog = () => {
       .info("Creating profile with enhanced mod data");
 
     const validatedProfile = profileSchema.safeParse({
-      version: "1",
+      version: "3",
       payload: {
         mods: enabledMods,
+        loadOrder,
       },
     });
 
@@ -146,7 +164,6 @@ export const ProfileShareDialog = () => {
       logger
         .withMetadata({
           profile: validatedProfile.error,
-          enabledMods,
         })
         .error("Invalid profile");
       toast.error(t("profiles.shareError"));
@@ -154,11 +171,7 @@ export const ProfileShareDialog = () => {
     }
 
     logger
-      .withMetadata({
-        validatedProfile: validatedProfile.data,
-        originalEnabledMods: enabledMods,
-        validatedMods: validatedProfile.data.payload.mods,
-      })
+      .withMetadata({ modCount: validatedProfile.data.payload.mods.length })
       .info("Profile validation successful");
 
     if (!validatedProfile || !hardwareId || !version) {
@@ -181,8 +194,8 @@ export const ProfileShareDialog = () => {
 
     logger
       .withMetadata({
-        payload: JSON.stringify(payload, null, 2),
-        profileMods: validatedProfile.data.payload.mods,
+        modCount: validatedProfile.data.payload.mods.length,
+        profileVersion: validatedProfile.data.version,
       })
       .info("Sharing profile");
 

--- a/apps/desktop/src/components/providers/app.tsx
+++ b/apps/desktop/src/components/providers/app.tsx
@@ -80,7 +80,24 @@ export const AppProvider = ({ children, ...props }: AppProviderProps) => {
       }
     };
 
+    const migrateSubmissionIdentities = async () => {
+      const { pendingIdentityMigrations, completeIdentityMigrations } =
+        usePersistedStore.getState();
+      if (pendingIdentityMigrations.length === 0) {
+        return;
+      }
+
+      await invoke("migrate_submission_identities", {
+        migrations: pendingIdentityMigrations,
+      });
+      completeIdentityMigrations();
+      logger
+        .withMetadata({ count: pendingIdentityMigrations.length })
+        .info("Completed persisted submission identity migration");
+    };
+
     Promise.all([resolveGamePath(), resolveSteamPath()])
+      .then(migrateSubmissionIdentities)
       .then(cleanupStaleServerGameinfo)
       .then(() => usePersistedStore.getState().restoreModsFromManifest())
       .catch((error) => {

--- a/apps/desktop/src/hooks/use-deep-link.ts
+++ b/apps/desktop/src/hooks/use-deep-link.ts
@@ -1,11 +1,12 @@
 import { toast } from "@deadlock-mods/ui/components/sonner";
 import { listen } from "@tauri-apps/api/event";
-import { fetch } from "@/lib/fetch";
 import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { getMod } from "@/lib/api-client";
 import { downloadManager } from "@/lib/download/manager";
 import logger from "@/lib/logger";
+import { serializeSubmissionRef } from "@/lib/mods/submission-ref";
 import { usePersistedStore } from "@/lib/store";
 import { ModStatus } from "@/types/mods";
 import useInstall from "./use-install";
@@ -16,85 +17,12 @@ type DeepLinkData = {
   mod_id: string;
 };
 
-type FileInfo = {
-  name: string;
-  size: number;
-};
-
-// Regex for GameBanana download IDs
-const GAMEBANANA_MMDL_REGEX = /\/mmdl\/(\d+)/;
-
-const getFileInfoFromHeaders = async (url: string): Promise<FileInfo> => {
-  logger.withMetadata({ url }).info("Fetching file info from headers for URL");
-
-  try {
-    // Make a HEAD request to get headers without downloading the file
-    const response = await fetch(url, {
-      method: "HEAD",
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    }
-
-    // Get file size from Content-Length header
-    const contentLength =
-      response.headers.get("content-length") ||
-      response.headers.get("Content-Length");
-    const size = contentLength ? Number.parseInt(contentLength, 10) : 0;
-
-    // Determine file extension from Content-Type header
-    const contentType =
-      response.headers.get("content-type") ||
-      response.headers.get("Content-Type") ||
-      "";
-    let extension = ".zip"; // Default fallback
-
-    if (
-      contentType.includes("application/x-rar-compressed") ||
-      contentType.includes("application/x-rar")
-    ) {
-      extension = ".rar";
-    } else if (
-      contentType.includes("application/x-7z-compressed") ||
-      contentType.includes("application/x-7z")
-    ) {
-      extension = ".7z";
-    } else if (contentType.includes("application/zip")) {
-      extension = ".zip";
-    }
-
-    // Generate filename from GameBanana download ID
-    let name = `download${extension}`;
-    if (url.includes("gamebanana.com/mmdl/")) {
-      const match = url.match(GAMEBANANA_MMDL_REGEX);
-      if (match?.[1]) {
-        name = `gamebanana-${match[1]}${extension}`;
-      }
-    }
-
-    logger
-      .withMetadata({ name, size, contentType })
-      .info("File info extracted from headers");
-    return { name, size };
-  } catch (error) {
-    logger.withError(error).error("Failed to get file info from headers");
-
-    // Fallback to URL-based extraction if header request fails
-    let name = "download.zip";
-    if (url.includes("gamebanana.com/mmdl/")) {
-      const match = url.match(GAMEBANANA_MMDL_REGEX);
-      if (match?.[1]) {
-        name = `gamebanana-${match[1]}.zip`;
-      }
-    }
-
-    return { name, size: 0 };
-  }
-};
+const GAMEBANANA_MMDL_REGEX =
+  /^https:\/\/(?:[^/]+\.)?gamebanana\.com\/mmdl\/(\d+)(?:[/?#]|$)/i;
 
 export const useDeepLink = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const {
     addLocalMod: addMod,
     setModStatus,
@@ -116,27 +44,43 @@ export const useDeepLink = () => {
         unlisten = await listen<DeepLinkData>(
           "deep-link-received",
           async (event) => {
-            const { download_url, mod_id } = event.payload;
+            const { download_url, mod_id, mod_type } = event.payload;
+            const submissionType = mod_type.toLowerCase();
+            const slug =
+              submissionType === "mod" || submissionType === "sound"
+                ? serializeSubmissionRef({
+                    provider: "gamebanana",
+                    submissionType,
+                    submissionId: mod_id,
+                  })
+                : null;
+            const fileId = download_url.match(GAMEBANANA_MMDL_REGEX)?.[1];
+
+            if (!slug || !fileId) {
+              logger.warn("Rejected invalid deep-link payload");
+              toast.error(t("mods.invalidDeepLink"));
+              return;
+            }
 
             // Prevent duplicate processing of the same mod
-            if (processingRef.current.has(mod_id)) {
+            if (processingRef.current.has(slug)) {
               logger
-                .withMetadata({ modId: mod_id })
+                .withMetadata({ remoteId: slug })
                 .warn("Already processing deep link for mod");
               return;
             }
 
-            processingRef.current.add(mod_id);
+            processingRef.current.add(slug);
             logger
-              .withMetadata({ payload: event.payload })
+              .withMetadata({ remoteId: slug, fileId })
               .info("Deep link received");
 
             try {
               // Navigate to the mod page first
-              navigate(`/mods/${mod_id}`);
+              navigate(`/mods/${slug}`);
 
               // Fetch mod details from the API
-              const modData = await getMod(mod_id);
+              const modData = await getMod(slug);
 
               // Check if mod is already installed BEFORE downloading
               const currentMods = usePersistedStore.getState().localMods;
@@ -151,21 +95,19 @@ export const useDeepLink = () => {
                   );
                 toast.success(`${modData.name} is already installed!`);
                 // Just navigate to the mod page to show it's installed
-                navigate(`/mods/${mod_id}`);
+                navigate(`/mods/${slug}`);
                 // Remove from processing set since we're done
-                processingRef.current.delete(mod_id);
+                processingRef.current.delete(slug);
                 return;
               }
 
-              // Get file info from HTTP headers
               toast.success("Preparing 1-click mod download...");
-              const fileInfo = await getFileInfoFromHeaders(download_url);
 
               const downloadFiles = [
                 {
-                  url: download_url,
-                  name: fileInfo.name,
-                  size: fileInfo.size,
+                  url: `gamebanana-file://${slug}/${fileId}`,
+                  name: `gamebanana-${fileId}.zip`,
+                  size: 0,
                   md5Checksum: null,
                   createdAt: new Date(),
                   updatedAt: new Date(),
@@ -237,7 +179,7 @@ export const useDeepLink = () => {
                           .withMetadata({ remoteId: mod.remoteId })
                           .info("Auto-installation completed for mod");
                         // Remove from processing set when fully complete
-                        processingRef.current.delete(mod_id);
+                        processingRef.current.delete(slug);
                       },
                       onError: (mod, error) => {
                         setModStatus(mod.remoteId, ModStatus.Downloaded);
@@ -249,7 +191,7 @@ export const useDeepLink = () => {
                           .withError(error)
                           .error("Auto-installation failed for mod");
                         // Remove from processing set on error
-                        processingRef.current.delete(mod_id);
+                        processingRef.current.delete(slug);
                       },
                     });
                   } catch (error) {
@@ -260,7 +202,7 @@ export const useDeepLink = () => {
                       `Downloaded but failed to install ${modData.name}. You can install it manually.`,
                     );
                     // Remove from processing set on error
-                    processingRef.current.delete(mod_id);
+                    processingRef.current.delete(slug);
                   }
                 },
                 onError: (error) => {
@@ -273,7 +215,7 @@ export const useDeepLink = () => {
                     .withError(error)
                     .error("Direct download failed for mod");
                   // Remove from processing set on error
-                  processingRef.current.delete(mod_id);
+                  processingRef.current.delete(slug);
                 },
               });
             } catch (error) {
@@ -282,7 +224,7 @@ export const useDeepLink = () => {
                 "Failed to process 1-click download. The mod may not exist or be unavailable.",
               );
               // Remove from processing set on error
-              processingRef.current.delete(mod_id);
+              processingRef.current.delete(slug);
             }
           },
         );

--- a/apps/desktop/src/lib/profiles/import-profile-shared.test.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-shared.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { profileSchema } from "@deadlock-mods/shared";
+import {
+  getProfileModCandidateIds,
+  rewriteProfileIdentities,
+} from "./import-profile-shared";
+
+describe("shared profile identities", () => {
+  it("queries both namespaces for a legacy numeric identity", () => {
+    const profile = profileSchema.parse({
+      version: "2",
+      payload: { mods: [{ remoteId: "42" }], loadOrder: ["42"] },
+    });
+
+    expect(getProfileModCandidateIds(profile, 0)).toEqual(["42", "snd-42"]);
+  });
+
+  it("uses the explicit v3 namespace", () => {
+    const profile = profileSchema.parse({
+      version: "3",
+      payload: {
+        mods: [{ remoteId: "42", submissionType: "sound" }],
+        loadOrder: ["42"],
+      },
+    });
+
+    expect(getProfileModCandidateIds(profile, 0)).toEqual(["snd-42"]);
+  });
+
+  it("rewrites download identities and load order after legacy resolution", () => {
+    const profile = profileSchema.parse({
+      version: "2",
+      payload: {
+        mods: [
+          {
+            remoteId: "42",
+            selectedDownloads: [
+              { remoteId: "42", file: "voice.zip", url: "test", size: 1 },
+            ],
+          },
+        ],
+        loadOrder: ["42"],
+      },
+    });
+
+    const rewritten = rewriteProfileIdentities(profile, ["snd-42"]);
+    expect(rewritten.payload.mods[0]?.remoteId).toBe("snd-42");
+    expect(rewritten.payload.mods[0]?.selectedDownloads?.[0]?.remoteId).toBe(
+      "snd-42",
+    );
+    expect(
+      rewritten.version === "1" ? [] : rewritten.payload.loadOrder,
+    ).toEqual(["snd-42"]);
+  });
+});

--- a/apps/desktop/src/lib/profiles/import-profile-shared.ts
+++ b/apps/desktop/src/lib/profiles/import-profile-shared.ts
@@ -1,4 +1,12 @@
-import type { ModDto, SharedProfile } from "@deadlock-mods/shared";
+import {
+  profileSchema,
+  type ModDto,
+  type SharedProfile,
+} from "@deadlock-mods/shared";
+import {
+  parseSubmissionSlug,
+  serializeSubmissionRef,
+} from "@/lib/mods/submission-ref";
 import type { AvailableImportedMod } from "@/lib/profiles/types";
 import type { LocalMod } from "@/types/mods";
 
@@ -8,6 +16,92 @@ export const sortModsByInstallOrder = (mods: LocalMod[]): LocalMod[] =>
       (left.installOrder ?? Number.MAX_SAFE_INTEGER) -
       (right.installOrder ?? Number.MAX_SAFE_INTEGER),
   );
+
+export const getProfileModCandidateIds = (
+  profile: SharedProfile,
+  modIndex: number,
+): string[] => {
+  const mod = profile.payload.mods[modIndex];
+  if (!mod) return [];
+
+  const parsed = parseSubmissionSlug(mod.remoteId);
+  if (profile.version === "3") {
+    const namespacedMod = profile.payload.mods[modIndex];
+    if (!namespacedMod) return [];
+    if (parsed?.provider === "local") return [mod.remoteId];
+
+    const submissionId = parsed?.submissionId ?? mod.remoteId;
+    const canonical = serializeSubmissionRef({
+      provider: "gamebanana",
+      submissionType: namespacedMod.submissionType,
+      submissionId,
+    });
+    return canonical ? [canonical] : [];
+  }
+
+  if (
+    parsed?.provider === "gamebanana" &&
+    parsed.submissionType === "mod" &&
+    parsed.submissionId === mod.remoteId
+  ) {
+    return [mod.remoteId, `snd-${mod.remoteId}`];
+  }
+
+  return parsed ? [mod.remoteId] : [];
+};
+
+const rewriteDownloadIdentity = <
+  T extends {
+    remoteId: string;
+    selectedDownload?: { remoteId: string };
+    selectedDownloads?: { remoteId: string }[];
+  },
+>(
+  mod: T,
+  remoteId: string,
+): T => ({
+  ...mod,
+  remoteId,
+  selectedDownload: mod.selectedDownload
+    ? { ...mod.selectedDownload, remoteId }
+    : undefined,
+  selectedDownloads: mod.selectedDownloads?.map((download) => ({
+    ...download,
+    remoteId,
+  })),
+});
+
+export const rewriteProfileIdentities = (
+  profile: SharedProfile,
+  resolvedIds: readonly string[],
+): SharedProfile => {
+  if (resolvedIds.length !== profile.payload.mods.length) {
+    throw new Error("Every imported profile mod must have a resolved identity");
+  }
+
+  const mods = profile.payload.mods.map((mod, index) =>
+    rewriteDownloadIdentity(mod, resolvedIds[index] ?? mod.remoteId),
+  );
+  if (profile.version === "1") {
+    return profileSchema.parse({ ...profile, payload: { mods } });
+  }
+
+  const identitiesByLegacyId = new Map<string, string[]>();
+  profile.payload.mods.forEach((mod, index) => {
+    const identities = identitiesByLegacyId.get(mod.remoteId) ?? [];
+    identities.push(resolvedIds[index] ?? mod.remoteId);
+    identitiesByLegacyId.set(mod.remoteId, identities);
+  });
+  const usedByLegacyId = new Map<string, number>();
+  const loadOrder = profile.payload.loadOrder.map((remoteId) => {
+    const identities = identitiesByLegacyId.get(remoteId);
+    const used = usedByLegacyId.get(remoteId) ?? 0;
+    usedByLegacyId.set(remoteId, used + 1);
+    return identities?.[used] ?? identities?.[0] ?? remoteId;
+  });
+
+  return profileSchema.parse({ ...profile, payload: { mods, loadOrder } });
+};
 
 export const resolveImportContext = (
   importedProfile: SharedProfile,

--- a/apps/desktop/src/lib/store/migrate.test.ts
+++ b/apps/desktop/src/lib/store/migrate.test.ts
@@ -108,6 +108,77 @@ describe("safeMigrate", () => {
     expect(result.heroParserIntervalSeconds).toBe(5);
   });
 
+  it("v26 namespaces sound identities across every persisted reference", () => {
+    const state = {
+      localMods: [
+        { remoteId: "42", isAudio: true, status: "installed" },
+        { remoteId: "42", isAudio: false, status: "installed" },
+        { remoteId: "99", isAudio: true, status: "installed" },
+      ],
+      hiddenHeroMods: { "42": true, "7": true },
+      favorites: ["42", "7", "snd-42"],
+      perItemNSFWOverrides: { "42": false, "7": true },
+      profiles: {
+        default: {
+          enabledMods: {
+            "42": { remoteId: "42", enabled: true },
+            "7": { remoteId: "7", enabled: true },
+          },
+          mods: [{ remoteId: "99", isAudio: true }],
+        },
+      },
+      stagedServers: {
+        server: { requiredModIds: ["42", "7", "snd-42"] },
+      },
+      scrollPositions: { "/mods/42": 120, "/mods/7": 20 },
+    };
+
+    const migrated = safeMigrate(state, 25) as typeof state & {
+      pendingIdentityMigrations: Array<{ from: string; to: string }>;
+    };
+
+    expect(migrated.localMods.map((mod) => mod.remoteId)).toEqual([
+      "snd-42",
+      "42",
+      "snd-99",
+    ]);
+    expect(migrated.hiddenHeroMods).toEqual({ "snd-42": true, "7": true });
+    expect(migrated.favorites).toEqual(["snd-42", "7"]);
+    expect(migrated.perItemNSFWOverrides).toEqual({
+      "snd-42": false,
+      "7": true,
+    });
+    expect(migrated.profiles.default.enabledMods).toEqual({
+      "snd-42": { remoteId: "snd-42", enabled: true },
+      "7": { remoteId: "7", enabled: true },
+    });
+    expect(migrated.profiles.default.mods[0].remoteId).toBe("snd-99");
+    expect(migrated.stagedServers.server.requiredModIds).toEqual([
+      "snd-42",
+      "7",
+    ]);
+    expect(migrated.scrollPositions).toEqual({
+      "/mods/snd-42": 120,
+      "/mods/7": 20,
+    });
+    expect(migrated.pendingIdentityMigrations).toEqual([
+      { from: "42", to: "snd-42" },
+      { from: "99", to: "snd-99" },
+    ]);
+  });
+
+  it("v26 preserves pending disk work when rerun after state identities changed", () => {
+    const state = {
+      localMods: [{ remoteId: "snd-42", isAudio: true }],
+      pendingIdentityMigrations: [{ from: "42", to: "snd-42" }],
+    };
+
+    expect(safeMigrate(state, 25)).toMatchObject({
+      localMods: [{ remoteId: "snd-42", isAudio: true }],
+      pendingIdentityMigrations: [{ from: "42", to: "snd-42" }],
+    });
+  });
+
   it("snapshot+revert: a malformed value that breaks one step doesn't poison later steps", () => {
     // Force the v9->v10 step to encounter a non-plain `localMods` entry. We
     // can do that by giving `localMods` a wrong shape that the guarded code
@@ -149,7 +220,7 @@ describe("safeMigrate", () => {
   it("LATEST_VERSION matches the highest step target", () => {
     const max = Math.max(...MIGRATION_STEPS.map((s) => s.to));
     expect(LATEST_VERSION).toBe(max);
-    expect(LATEST_VERSION).toBe(25);
+    expect(LATEST_VERSION).toBe(26);
   });
 
   it("v25 (themes switch): drops the leftover enabledPlugins.themes entry", () => {

--- a/apps/desktop/src/lib/store/migrate.ts
+++ b/apps/desktop/src/lib/store/migrate.ts
@@ -393,7 +393,153 @@ export const MIGRATION_STEPS: readonly MigrationStep[] = [
       delete state.enabledPlugins.themes;
     },
   },
+  {
+    to: 26,
+    label: "namespace-gamebanana-sounds",
+    apply: (state) => {
+      const soundIds = collectLegacySoundIds(state);
+      const remap = new Map(
+        [...soundIds].map((remoteId) => [remoteId, `snd-${remoteId}`]),
+      );
+
+      migrateModArray(state.localMods, remap);
+      if (isPlainObject(state.profiles)) {
+        for (const profile of Object.values(state.profiles)) {
+          if (!isPlainObject(profile)) continue;
+          migrateModArray(profile.mods, remap);
+          remapRecordKeys(profile.enabledMods, remap, true);
+        }
+      }
+
+      remapRecordKeys(state.hiddenHeroMods, remap, false);
+      remapRecordKeys(state.perItemNSFWOverrides, remap, false);
+      if (Array.isArray(state.favorites)) {
+        state.favorites = uniqueStrings(
+          state.favorites.map((value) =>
+            typeof value === "string" ? (remap.get(value) ?? value) : value,
+          ),
+        );
+      }
+      if (isPlainObject(state.stagedServers)) {
+        for (const server of Object.values(state.stagedServers)) {
+          if (!isPlainObject(server) || !Array.isArray(server.requiredModIds)) {
+            continue;
+          }
+          server.requiredModIds = uniqueStrings(
+            server.requiredModIds.map((value) =>
+              typeof value === "string" ? (remap.get(value) ?? value) : value,
+            ),
+          );
+        }
+      }
+      if (isPlainObject(state.scrollPositions)) {
+        for (const [from, to] of remap) {
+          const oldKey = `/mods/${from}`;
+          const newKey = `/mods/${to}`;
+          if (state.scrollPositions[oldKey] !== undefined) {
+            state.scrollPositions[newKey] ??= state.scrollPositions[oldKey];
+            delete state.scrollPositions[oldKey];
+          }
+        }
+      }
+
+      const pending = Array.isArray(state.pendingIdentityMigrations)
+        ? state.pendingIdentityMigrations.filter(isIdentityMigration)
+        : [];
+      const pendingBySource = new Map(
+        pending.map((migration) => [migration.from, migration]),
+      );
+      for (const [from, to] of remap) {
+        pendingBySource.set(from, { from, to });
+      }
+      if (pendingBySource.size > 0) {
+        state.pendingIdentityMigrations = [...pendingBySource.values()].sort(
+          (left, right) => left.from.localeCompare(right.from),
+        );
+      }
+    },
+  },
 ];
+
+const LEGACY_GAMEBANANA_ID = /^[1-9]\d*$/;
+
+const collectLegacySoundIds = (state: MutableState): Set<string> => {
+  const ids = new Set<string>();
+  const collect = (mods: MutableState[string]) => {
+    if (!Array.isArray(mods)) return;
+    for (const mod of mods) {
+      if (
+        isPlainObject(mod) &&
+        mod.isAudio === true &&
+        typeof mod.remoteId === "string" &&
+        LEGACY_GAMEBANANA_ID.test(mod.remoteId)
+      ) {
+        ids.add(mod.remoteId);
+      }
+    }
+  };
+  collect(state.localMods);
+  if (isPlainObject(state.profiles)) {
+    for (const profile of Object.values(state.profiles)) {
+      if (isPlainObject(profile)) collect(profile.mods);
+    }
+  }
+  return ids;
+};
+
+const migrateModArray = (
+  mods: MutableState[string],
+  remap: ReadonlyMap<string, string>,
+) => {
+  if (!Array.isArray(mods)) return;
+  for (const mod of mods) {
+    if (
+      !isPlainObject(mod) ||
+      mod.isAudio !== true ||
+      typeof mod.remoteId !== "string"
+    ) {
+      continue;
+    }
+    const migrated = remap.get(mod.remoteId);
+    if (migrated) mod.remoteId = migrated;
+  }
+};
+
+const remapRecordKeys = (
+  value: MutableState[string],
+  remap: ReadonlyMap<string, string>,
+  rewriteRemoteId: boolean,
+): void => {
+  if (!isPlainObject(value)) return;
+  for (const [from, to] of remap) {
+    if (!(from in value)) continue;
+    const entry = value[from];
+    value[to] ??= entry;
+    if (
+      rewriteRemoteId &&
+      isPlainObject(value[to]) &&
+      value[to].remoteId === from
+    ) {
+      value[to].remoteId = to;
+    }
+    delete value[from];
+  }
+};
+
+const uniqueStrings = (
+  values: MutableState[string][],
+): MutableState[string][] =>
+  values.filter(
+    (value, index) =>
+      typeof value !== "string" || values.indexOf(value) === index,
+  );
+
+const isIdentityMigration = (
+  value: MutableState[string],
+): value is { from: string; to: string } =>
+  isPlainObject(value) &&
+  typeof value.from === "string" &&
+  typeof value.to === "string";
 
 const STEP_TARGET_VERSIONS: readonly number[] = MIGRATION_STEPS.map(
   (step) => step.to,

--- a/apps/desktop/src/lib/store/slices/mods.ts
+++ b/apps/desktop/src/lib/store/slices/mods.ts
@@ -29,6 +29,11 @@ export type HeroDetectionProgress = {
   currentModName: string | null;
 };
 
+export type IdentityMigration = {
+  from: string;
+  to: string;
+};
+
 export type ModsState = {
   localMods: LocalMod[];
   modProgress: Record<string, ModProgress>;
@@ -38,6 +43,7 @@ export type ModsState = {
    * the library and can be put back from there, they are just not listed.
    */
   hiddenHeroMods: Record<string, true>;
+  pendingIdentityMigrations: IdentityMigration[];
   // Analysis dialog state
   analysisResult: AnalyzeAddonsResult | null;
   analysisDialogOpen: boolean;
@@ -91,6 +97,7 @@ export type ModsState = {
   setHeroDetection: (progress: Partial<HeroDetectionProgress>) => void;
   hideHeroMod: (remoteId: string) => void;
   restoreHeroMod: (remoteId: string) => void;
+  completeIdentityMigrations: () => void;
 };
 
 export const modsDeepMergeKeys =
@@ -103,9 +110,12 @@ export const createModsSlice: StateCreator<State, [], [], ModsState> = (
   localMods: [],
   modProgress: {},
   hiddenHeroMods: {},
+  pendingIdentityMigrations: [],
   analysisResult: null,
   analysisDialogOpen: false,
   heroDetection: { status: "idle", current: 0, total: 0, currentModName: null },
+
+  completeIdentityMigrations: () => set({ pendingIdentityMigrations: [] }),
 
   defaultSort: SortType.LAST_UPDATED,
   setDefaultSort: (sortType: SortType) => set({ defaultSort: sortType }),

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -848,6 +848,7 @@
     "vpkCount": "{{count}} VPK(s)"
   },
   "mods": {
+    "invalidDeepLink": "This 1-click download link is invalid.",
     "manageOrder": "Change Mods Order",
     "searchPlaceholder": "Search mods",
     "noPreviewAvailable": "No preview available",
@@ -2916,6 +2917,12 @@
     "importDescription": "Enter a Profile ID to import a shared profile from another user.",
     "importPreview": "Import Profile Preview",
     "importPreviewDescription": "Review the profile contents before importing. Choose how to save this profile.",
+    "legacyIdentityTitle": "Choose the matching GameBanana item",
+    "legacyIdentityDescription": "This older profile ID exists as both a mod and a sound.",
+    "legacyIdentityPlaceholder": "Select mod or sound",
+    "legacyIdentityRequired": "Choose whether each ambiguous item is a mod or sound.",
+    "submissionTypeMod": "Mod",
+    "submissionTypeSound": "Sound",
     "profileIdPlaceholder": "Enter Profile ID (e.g., abc123def456)",
     "profileIdRequired": "Profile ID is required",
     "importSuccess": "Profile imported successfully!",

--- a/packages/shared/src/schemas/profile.schemas.ts
+++ b/packages/shared/src/schemas/profile.schemas.ts
@@ -31,6 +31,12 @@ export const profileModSchema = z.object({
   fileTree: profileModFileTreeSchema.optional(),
 });
 
+export const submissionTypeSchema = z.enum(["mod", "sound"]);
+
+export const v3ProfileModSchema = profileModSchema.extend({
+  submissionType: submissionTypeSchema,
+});
+
 export const v1ProfileSchema = z.object({
   version: z.literal("1"),
   payload: z.object({
@@ -46,7 +52,20 @@ export const v2ProfileSchema = z.object({
   }),
 });
 
-export const profileSchema = z.union([v1ProfileSchema, v2ProfileSchema]);
+export const v3ProfileSchema = z.object({
+  version: z.literal("3"),
+  payload: z.object({
+    mods: z.array(v3ProfileModSchema),
+    loadOrder: z.array(z.string()),
+  }),
+});
+
+export const profileSchema = z.union([
+  v1ProfileSchema,
+  v2ProfileSchema,
+  v3ProfileSchema,
+]);
 
 export type SharedProfile = z.infer<typeof profileSchema>;
 export type ProfileModDownload = z.infer<typeof profileModDownloadSchema>;
+export type SubmissionType = z.infer<typeof submissionTypeSchema>;

--- a/packages/shared/src/tests/profile.schemas.spec.ts
+++ b/packages/shared/src/tests/profile.schemas.spec.ts
@@ -31,4 +31,32 @@ describe("profileSchema", () => {
     expect(profile.payload.mods).toHaveLength(3);
     expect(profile.payload.loadOrder).toEqual(["mod-a", "mod-b", "mod-c"]);
   });
+
+  it("parses v3 profiles with explicit submission namespaces", () => {
+    const profile = profileSchema.parse({
+      version: "3",
+      payload: {
+        mods: [
+          { remoteId: "42", submissionType: "mod" },
+          { remoteId: "snd-42", submissionType: "sound" },
+        ],
+        loadOrder: ["42", "snd-42"],
+      },
+    });
+
+    expect(profile.version).toBe("3");
+    expect(profile.payload.mods[1]).toMatchObject({
+      remoteId: "snd-42",
+      submissionType: "sound",
+    });
+  });
+
+  it("rejects v3 profiles without a submission type", () => {
+    expect(
+      profileSchema.safeParse({
+        version: "3",
+        payload: { mods: [{ remoteId: "42" }], loadOrder: ["42"] },
+      }).success,
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Description

Apply the `snd-{id}` identity from #695 to existing audio mods, closing the collision between GameBanana Mod and Sound namespaces without renaming every normal mod.

Zustand migration step 26 rewrites audio IDs across installed mods, favorites, profiles, dependencies, NSFW overrides, hidden mods, and scroll state. A journalled Rust migration renames cache directories, disabled VPK prefixes, update staging directories, and `fonts.conf` markers, resuming safely after interruption.

The local manifest moves to version 3 with slug keys. Shared profiles move to v3 with `submissionType` while retaining v1/v2 parsing; old imports search both namespaces and only require user input when both are valid. Deep links now retain their submission type.

## Type of Change

- [ ] ≡ƒÉ¢ Bug fix (non-breaking change which fixes an issue)
- [x] Γ£¿ New feature (non-breaking change which adds functionality)
- [ ] ≡ƒÆÑ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ≡ƒôÜ Documentation update
- [ ] ≡ƒöº Code refactoring (no functional changes)
- [x] ≡ƒº¬ Tests (adding or updating tests)
- [ ] ≡ƒö¿ Chore (maintenance, dependency updates, etc.)

## Related Issues

- Refs #673

Maintainer-directed GameBanana direct-client migration.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted ΓÇö Tool: Codex, Used for: implementing human written plan and prototyping

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Validated with idempotent Zustand and on-disk migration tests, manifest tests, desktop profile-import tests, and shared profile-schema tests.

## Screenshots (if applicable)

Not included; the only visible path is the existing ambiguity prompt for a legacy profile that resolves in both namespaces.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Stack 6 of 9. Based on #699; followed by #701.

This PR contains a persisted-state and filesystem migration. Review rollback and crash-resume behavior before merge.

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [ ] This PR affects the public API
- [x] This PR requires migration instructions

## Stack tracking

Tracked in #673 (PR 6 of 19). Based on #699. Followed by #701.

