### PR TITLE
feat(repo): decouple moderation policy from the catalog

### DIFF
--- a/.changeset/calm-policies-travel.md
+++ b/.changeset/calm-policies-travel.md
@@ -1,0 +1,9 @@
+---
+"@deadlock-mods/api": minor
+"@deadlock-mods/bot": minor
+"@deadlock-mods/database": minor
+"@deadlock-mods/desktop": minor
+"@deadlock-mods/shared": minor
+---
+
+Add provider-identity policy rules, a versioned policy manifest, desktop enforcement, legacy-rule backfill, and Mod/Sound blacklist management.

--- a/apps/api/src/routers/v2/index.ts
+++ b/apps/api/src/routers/v2/index.ts
@@ -6,6 +6,7 @@ import { featureFlagsRouter } from "./feature-flags";
 import { fileserversRouter } from "./fileservers";
 import { kvRouter } from "./kv";
 import { modsRouter } from "./mods";
+import { policyRouter } from "./policy";
 import { profilesRouter } from "./profiles";
 import { reportsRouter } from "./reports";
 import { serversRouter } from "./servers";
@@ -19,6 +20,7 @@ export const v2Router = {
   ...fileserversRouter,
   ...kvRouter,
   ...modsRouter,
+  ...policyRouter,
   ...vpkRouter,
   ...profilesRouter,
   ...reportsRouter,

--- a/apps/api/src/routers/v2/policy.ts
+++ b/apps/api/src/routers/v2/policy.ts
@@ -1,0 +1,16 @@
+import { policyManifestSchema } from "@deadlock-mods/shared";
+import { publicProcedure } from "@/lib/orpc";
+import { getPolicyManifest } from "@/services/policy-manifest";
+
+export const policyRouter = {
+  getPolicyManifest: publicProcedure
+    .route({ method: "GET", path: "/v2/policy-manifest" })
+    .output(policyManifestSchema)
+    .handler(async ({ context }) => {
+      context.resHeaders?.set(
+        "Cache-Control",
+        "public, max-age=300, stale-if-error=86400",
+      );
+      return await getPolicyManifest();
+    }),
+};

--- a/apps/api/src/scripts/set-mod-overrides.ts
+++ b/apps/api/src/scripts/set-mod-overrides.ts
@@ -15,33 +15,13 @@
  *   pnpm --filter api set-mod-overrides -- 12345 --clear
  */
 
-import { db, ModRepository } from "@deadlock-mods/database";
-import type { ModOverrides } from "@deadlock-mods/database";
+import { db, PolicyRuleRepository } from "@deadlock-mods/database";
+import {
+  type PolicyMetadataCorrection,
+  policyMetadataCorrectionSchema,
+} from "@deadlock-mods/shared";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
-
-const ModOverridesSchema = z
-  .object({
-    name: z.string().optional(),
-    description: z.string().optional(),
-    category: z.string().optional(),
-    hero: z.string().optional(),
-    isMap: z.boolean().optional(),
-    isAudio: z.boolean().optional(),
-    isNSFW: z.boolean().optional(),
-    isObsolete: z.boolean().optional(),
-    tags: z.array(z.string()).optional(),
-    metadata: z.object({ mapName: z.string().optional() }).optional(),
-    downloads: z
-      .array(
-        z.object({
-          url: z.string().url(),
-          file: z.string(),
-        }),
-      )
-      .optional(),
-  })
-  .strict();
 
 const setModOverrides = async () => {
   const args = process.argv.slice(2);
@@ -55,45 +35,57 @@ const setModOverrides = async () => {
 
   const remoteId = args[0];
   const overridesArg = args[1];
+  const match = /^(snd-)?([1-9]\d*)$/.exec(remoteId);
+  if (!match?.[2]) {
+    console.error("remoteId must be a numeric mod ID or snd-{id} sound slug.");
+    process.exit(1);
+  }
+  const identity = {
+    provider: "gamebanana" as const,
+    submissionType: match[1] ? ("sound" as const) : ("mod" as const),
+    submissionId: match[2],
+  };
 
-  const modRepository = new ModRepository(db);
+  const policyRepository = new PolicyRuleRepository(db);
 
   try {
-    const existing =
-      await modRepository.findByRemoteIdIncludingBlacklisted(remoteId);
-    if (!existing) {
-      console.error(`Mod with remoteId "${remoteId}" not found.`);
-      process.exit(1);
-    }
+    const existing = await policyRepository.find(
+      identity,
+      "metadata_correction",
+    );
+    console.log(`Current correction: ${JSON.stringify(existing?.correction)}`);
 
-    console.log(`\nMod: ${existing.name} (remoteId: ${remoteId})`);
-    console.log(`Current overrides: ${JSON.stringify(existing.overrides)}`);
-
-    let overrides: ModOverrides | null;
+    let overrides: PolicyMetadataCorrection | null;
 
     if (overridesArg === "--clear") {
       overrides = null;
       console.log("\nClearing overrides...");
     } else {
       const parsed = JSON.parse(overridesArg);
-      const validated = ModOverridesSchema.parse(parsed);
+      const validated = policyMetadataCorrectionSchema.parse(parsed);
       overrides = validated;
       console.log(`\nSetting overrides: ${JSON.stringify(overrides)}`);
     }
 
-    const updated = await modRepository.updateByRemoteId(remoteId, {
-      overrides,
-    });
+    if (overrides) {
+      await policyRepository.upsert({
+        ...identity,
+        kind: "metadata_correction",
+        correction: overrides,
+      });
+    } else {
+      await policyRepository.delete(identity, "metadata_correction");
+    }
 
     logger
       .withMetadata({
         remoteId,
-        modName: updated.name,
-        overrides: updated.overrides,
+        submissionType: identity.submissionType,
+        submissionId: identity.submissionId,
       })
       .info("Updated mod overrides");
 
-    console.log(`\nUpdated overrides: ${JSON.stringify(updated.overrides)}`);
+    console.log("\nPolicy metadata correction updated.");
     process.exit(0);
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/apps/api/src/services/policy-manifest-builder.ts
+++ b/apps/api/src/services/policy-manifest-builder.ts
@@ -1,0 +1,33 @@
+import type { PolicyRule } from "@deadlock-mods/database";
+import type { PolicyManifest } from "@deadlock-mods/shared";
+
+export const policyRulesToManifest = (
+  rules: PolicyRule[],
+  generatedAt = new Date(),
+): PolicyManifest => ({
+  version: 1,
+  revision: rules.reduce(
+    (latest, rule) =>
+      Math.max(
+        latest,
+        (rule.updatedAt ?? rule.createdAt ?? new Date(0)).getTime(),
+      ),
+    0,
+  ),
+  generatedAt: generatedAt.toISOString(),
+  rules: rules
+    .filter((rule) => rule.active)
+    .map((rule) => ({
+      provider: rule.provider,
+      submissionType: rule.submissionType,
+      submissionId: rule.submissionId,
+      kind: rule.kind,
+      reason: rule.reason,
+      correction: rule.correction ?? null,
+      updatedAt: (
+        rule.updatedAt ??
+        rule.createdAt ??
+        new Date(0)
+      ).toISOString(),
+    })),
+});

--- a/apps/api/src/services/policy-manifest.test.ts
+++ b/apps/api/src/services/policy-manifest.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import type { PolicyRule } from "@deadlock-mods/database";
+import { policyRulesToManifest } from "./policy-manifest-builder";
+
+const rule = (updatedAt: Date): PolicyRule => ({
+  id: "policy_rule_test",
+  provider: "gamebanana",
+  submissionType: "sound",
+  submissionId: "42",
+  kind: "blacklisted",
+  active: true,
+  reason: "unsafe",
+  correction: null,
+  createdBy: "moderator",
+  createdAt: new Date("2026-08-29T12:00:00Z"),
+  updatedAt,
+});
+
+describe("policyRulesToManifest", () => {
+  it("uses the latest database update as a stable revision", () => {
+    const manifest = policyRulesToManifest(
+      [
+        rule(new Date("2026-08-30T10:00:00Z")),
+        { ...rule(new Date("2026-08-30T12:00:00Z")), submissionId: "43" },
+      ],
+      new Date("2026-08-30T13:00:00Z"),
+    );
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.revision).toBe(new Date("2026-08-30T12:00:00Z").getTime());
+    expect(manifest.generatedAt).toBe("2026-08-30T13:00:00.000Z");
+    expect(manifest.rules).toHaveLength(2);
+  });
+
+  it("advances the revision but omits deactivated rules", () => {
+    const removed = {
+      ...rule(new Date("2026-08-30T14:00:00Z")),
+      active: false,
+    };
+    const manifest = policyRulesToManifest([removed]);
+
+    expect(manifest.revision).toBe(new Date("2026-08-30T14:00:00Z").getTime());
+    expect(manifest.rules).toEqual([]);
+  });
+});

--- a/apps/api/src/services/policy-manifest.ts
+++ b/apps/api/src/services/policy-manifest.ts
@@ -1,0 +1,8 @@
+import { db, PolicyRuleRepository } from "@deadlock-mods/database";
+import type { PolicyManifest } from "@deadlock-mods/shared";
+import { policyRulesToManifest } from "./policy-manifest-builder";
+
+const policyRepository = new PolicyRuleRepository(db);
+
+export const getPolicyManifest = async (): Promise<PolicyManifest> =>
+  policyRulesToManifest(await policyRepository.listAll());

--- a/apps/bot/src/commands/blacklist.test.ts
+++ b/apps/bot/src/commands/blacklist.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { parsePolicyIdentity } from "../lib/policy-identity";
+
+describe("parsePolicyIdentity", () => {
+  it("treats a bare legacy ID as a GameBanana mod", () => {
+    expect(parsePolicyIdentity("42")).toEqual({
+      provider: "gamebanana",
+      submissionType: "mod",
+      submissionId: "42",
+    });
+  });
+
+  it("accepts both GameBanana mod and sound URLs", () => {
+    expect(parsePolicyIdentity("https://gamebanana.com/mods/42")).toMatchObject(
+      {
+        submissionType: "mod",
+        submissionId: "42",
+      },
+    );
+    expect(
+      parsePolicyIdentity("https://gamebanana.com/sounds/42"),
+    ).toMatchObject({ submissionType: "sound", submissionId: "42" });
+  });
+
+  it("rejects lookalike hosts, insecure URLs, and unknown namespaces", () => {
+    expect(() =>
+      parsePolicyIdentity("https://gamebanana.com.evil.test/mods/42"),
+    ).toThrow();
+    expect(() =>
+      parsePolicyIdentity("http://gamebanana.com/mods/42"),
+    ).toThrow();
+    expect(() =>
+      parsePolicyIdentity("https://gamebanana.com/maps/42"),
+    ).toThrow();
+  });
+});

--- a/apps/bot/src/commands/blacklist.ts
+++ b/apps/bot/src/commands/blacklist.ts
@@ -1,5 +1,8 @@
-import { ValidationError } from "@deadlock-mods/common";
-import { db, ModRepository } from "@deadlock-mods/database";
+import {
+  db,
+  type PolicyIdentity,
+  PolicyRuleRepository,
+} from "@deadlock-mods/database";
 import { Command } from "@sapphire/framework";
 import { type GuildMember } from "discord.js";
 import { logger as mainLogger } from "../lib/logger";
@@ -7,12 +10,13 @@ import {
   getBlacklistRequiredPermissionsDisplay,
   hasBlacklistPermission,
 } from "../lib/permissions";
+import { parsePolicyIdentity } from "../lib/policy-identity";
 
 const logger = mainLogger.child().withContext({
   service: "blacklist-command",
 });
 
-const modRepository = new ModRepository(db);
+const policyRepository = new PolicyRuleRepository(db);
 
 export class BlacklistCommand extends Command {
   constructor(context: Command.LoaderContext, options: Command.Options) {
@@ -31,7 +35,7 @@ export class BlacklistCommand extends Command {
             .addStringOption((option) =>
               option
                 .setName("mod_id_or_url")
-                .setDescription("GameBanana mod ID or URL")
+                .setDescription("GameBanana mod/sound ID or URL")
                 .setRequired(true),
             )
             .addStringOption((option) =>
@@ -48,7 +52,7 @@ export class BlacklistCommand extends Command {
             .addStringOption((option) =>
               option
                 .setName("mod_id_or_url")
-                .setDescription("GameBanana mod ID or URL")
+                .setDescription("GameBanana mod/sound ID or URL")
                 .setRequired(true),
             ),
         ),
@@ -72,13 +76,13 @@ export class BlacklistCommand extends Command {
 
     try {
       // Extract mod ID from URL if needed
-      const modId = this.extractModId(modIdOrUrl);
+      const identity = parsePolicyIdentity(modIdOrUrl);
 
       if (subcommand === "add") {
         const reason = interaction.options.getString("reason", true);
-        return await this.handleAdd(interaction, modId, reason);
+        return await this.handleAdd(interaction, identity, reason);
       } else if (subcommand === "remove") {
-        return await this.handleRemove(interaction, modId);
+        return await this.handleRemove(interaction, identity);
       }
     } catch (error) {
       logger
@@ -97,97 +101,70 @@ export class BlacklistCommand extends Command {
     }
   }
 
-  private extractModId(input: string): string {
-    // If it's already just a number, return it
-    if (/^\d+$/.test(input)) {
-      return input;
-    }
-
-    // Extract from GameBanana URL
-    const gamebananaMatch = input.match(/gamebanana\.com\/mods\/(\d+)/i);
-    if (gamebananaMatch) {
-      return gamebananaMatch[1];
-    }
-
-    // If we can't extract a valid ID, throw an error
-    throw new ValidationError("Invalid mod ID or URL format");
-  }
-
   private async handleAdd(
     interaction: Command.ChatInputCommandInteraction,
-    modId: string,
+    identity: PolicyIdentity,
     reason: string,
   ) {
     const { user } = interaction;
 
-    // Check if mod exists
-    const mod = await modRepository.findByRemoteIdIncludingBlacklisted(modId);
-    if (!mod) {
+    const existing = await policyRepository.find(identity, "blacklisted");
+    if (existing) {
       return interaction.reply({
-        content: `Mod with ID \`${modId}\` not found.`,
+        content: `${this.displayIdentity(identity)} is already blacklisted.`,
       });
     }
 
-    // Check if already blacklisted
-    if (mod.isBlacklisted) {
-      return interaction.reply({
-        content: `Mod \`${mod.name}\` is already blacklisted.`,
-      });
-    }
-
-    // Blacklist the mod
-    await modRepository.blacklistMod(modId, reason, user.id);
+    await policyRepository.upsert({
+      ...identity,
+      kind: "blacklisted",
+      reason,
+      createdBy: user.id,
+    });
 
     logger
       .withMetadata({
         userId: user.id,
         username: user.username,
-        modId,
-        modName: mod.name,
-        reason,
+        submissionType: identity.submissionType,
+        submissionId: identity.submissionId,
       })
       .info("Mod blacklisted");
 
     return interaction.reply({
-      content: `Successfully blacklisted mod \`${mod.name}\` (ID: \`${modId}\`)\n**Reason:** ${reason}`,
+      content: `Successfully blacklisted ${this.displayIdentity(identity)}.\n**Reason:** ${reason}`,
     });
   }
 
   private async handleRemove(
     interaction: Command.ChatInputCommandInteraction,
-    modId: string,
+    identity: PolicyIdentity,
   ) {
     const { user } = interaction;
 
-    // Check if mod exists
-    const mod = await modRepository.findByRemoteIdIncludingBlacklisted(modId);
-    if (!mod) {
+    const removed = await policyRepository.delete(identity, "blacklisted");
+    if (!removed) {
       return interaction.reply({
-        content: `Mod with ID \`${modId}\` not found.`,
+        content: `${this.displayIdentity(identity)} is not blacklisted.`,
       });
     }
-
-    // Check if not blacklisted
-    if (!mod.isBlacklisted) {
-      return interaction.reply({
-        content: `Mod \`${mod.name}\` is not blacklisted.`,
-      });
-    }
-
-    // Unblacklist the mod
-    await modRepository.unblacklistMod(modId);
 
     logger
       .withMetadata({
         userId: user.id,
         username: user.username,
-        modId,
-        modName: mod.name,
+        submissionType: identity.submissionType,
+        submissionId: identity.submissionId,
       })
       .info("Mod unblacklisted");
 
     return interaction.reply({
-      content: `Successfully removed mod \`${mod.name}\` (ID: \`${modId}\`) from blacklist.`,
+      content: `Successfully removed ${this.displayIdentity(identity)} from the blacklist.`,
     });
+  }
+
+  private displayIdentity(identity: PolicyIdentity): string {
+    const type = identity.submissionType === "sound" ? "sound" : "mod";
+    return `${type} ID \`${identity.submissionId}\``;
   }
 }

--- a/apps/bot/src/lib/policy-identity.ts
+++ b/apps/bot/src/lib/policy-identity.ts
@@ -1,0 +1,33 @@
+import { ValidationError } from "@deadlock-mods/common";
+import type { PolicyIdentity } from "@deadlock-mods/database";
+
+export const parsePolicyIdentity = (input: string): PolicyIdentity => {
+  if (/^[1-9]\d*$/.test(input)) {
+    return {
+      provider: "gamebanana",
+      submissionType: "mod",
+      submissionId: input,
+    };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new ValidationError("Invalid GameBanana ID or URL format");
+  }
+  const host = url.hostname.toLowerCase();
+  const match = url.pathname.match(/^\/(mods|sounds)\/([1-9]\d*)\/?$/i);
+  if (
+    url.protocol !== "https:" ||
+    (host !== "gamebanana.com" && !host.endsWith(".gamebanana.com")) ||
+    !match
+  ) {
+    throw new ValidationError("Invalid GameBanana ID or URL format");
+  }
+  return {
+    provider: "gamebanana",
+    submissionType: match[1]?.toLowerCase() === "sounds" ? "sound" : "mod",
+    submissionId: match[2] ?? "",
+  };
+};

--- a/apps/desktop/src-tauri/src/commands/downloads.rs
+++ b/apps/desktop/src-tauri/src/commands/downloads.rs
@@ -22,6 +22,7 @@ pub(crate) async fn get_download_manager(app_handle: AppHandle) -> &'static Down
 pub async fn queue_download(
   app_handle: AppHandle,
   catalog_state: State<'_, super::gamebanana_catalog::GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   mod_id: String,
   files: Vec<DownloadFileDto>,
   profile_folder: Option<String>,
@@ -35,6 +36,7 @@ pub async fn queue_download(
 
   crate::providers::SubmissionRef::parse_slug(&mod_id)
     .map_err(|_| Error::InvalidInput("Invalid download identity".to_string()))?;
+  policy.ensure_download_allowed(&mod_id)?;
   if files.is_empty() || files.len() > 100 {
     return Err(Error::InvalidInput(
       "A download must contain between 1 and 100 files".to_string(),

--- a/apps/desktop/src-tauri/src/commands/gamebanana_catalog/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/gamebanana_catalog/mod.rs
@@ -3,8 +3,9 @@ mod types;
 
 pub use state::GameBananaCatalogState;
 pub use types::{
-  CatalogDownloadDto, CatalogDownloadsDto, CatalogModDto, CatalogPageDto, CatalogSyncStatusDto,
-  CatalogUpdateDto, CatalogUpdatesDto, GameBananaFileserverDto, InstalledSubmissionDto,
+  CatalogDonationLinkDto, CatalogDownloadDto, CatalogDownloadsDto, CatalogModDto,
+  CatalogModMetadataDto, CatalogPageDto, CatalogSyncStatusDto, CatalogUpdateDto, CatalogUpdatesDto,
+  GameBananaFileserverDto, InstalledSubmissionDto,
 };
 
 use crate::errors::Error;
@@ -33,26 +34,29 @@ pub async fn synchronize_gamebanana_catalog(
 #[tauri::command]
 pub async fn query_gamebanana_catalog(
   state: State<'_, GameBananaCatalogState>,
-  query: CatalogQuery,
+  policy: State<'_, super::policy::PolicyState>,
+  mut query: CatalogQuery,
 ) -> Result<CatalogPageDto, Error> {
   let backend = state.backend()?;
   let stale = catalog_is_stale(&backend.catalog).await?;
-  backend
-    .catalog
-    .query(query)
-    .await
-    .and_then(|page| CatalogPageDto::from_page(page, stale))
+  query.excluded_slugs = policy.unavailable_slugs()?;
+  let mut page = CatalogPageDto::from_page(backend.catalog.query(query).await?, stale)?;
+  for item in &mut page.items {
+    policy.apply_to_mod(item)?;
+  }
+  Ok(page)
 }
 
 #[tauri::command]
 pub async fn get_gamebanana_submission_detail(
   state: State<'_, GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   remote_id: String,
 ) -> Result<CatalogModDto, Error> {
   let backend = state.backend()?;
   let submission = parse_submission(&remote_id)?;
   let cancel = CancellationToken::new();
-  match backend.client.profile(&submission, &cancel).await {
+  let mut mod_data = match backend.client.profile(&submission, &cancel).await {
     Ok(profile) => {
       let normalized =
         normalize_profile(&profile, submission.submission_type).ok_or_else(|| {
@@ -66,36 +70,45 @@ pub async fn get_gamebanana_submission_detail(
           normalized.clone(),
         )])
         .await?;
-      Ok(CatalogModDto::from_profile(&profile, normalized))
+      CatalogModDto::from_profile(&profile, normalized)
     }
     Err(provider_error) => backend
       .catalog
       .get(submission)
       .await?
       .map(CatalogModDto::from_record).transpose()?
-      .ok_or(provider_error),
+      .ok_or(provider_error)?,
+  };
+  if !policy.apply_to_mod(&mut mod_data)? {
+    return Err(Error::InvalidInput(
+      "This submission is unavailable by policy".to_string(),
+    ));
   }
+  Ok(mod_data)
 }
 
 #[tauri::command]
 pub async fn get_gamebanana_submission_files(
   state: State<'_, GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   remote_id: String,
 ) -> Result<CatalogDownloadsDto, Error> {
-  submission_files(&state, &remote_id).await
+  submission_files(&state, &policy, &remote_id).await
 }
 
 #[tauri::command]
 pub async fn resolve_gamebanana_download_candidates(
   state: State<'_, GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   remote_id: String,
 ) -> Result<CatalogDownloadsDto, Error> {
-  submission_files(&state, &remote_id).await
+  submission_files(&state, &policy, &remote_id).await
 }
 
 #[tauri::command]
 pub async fn check_gamebanana_catalog_updates(
   state: State<'_, GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   submissions: Vec<InstalledSubmissionDto>,
 ) -> Result<CatalogUpdatesDto, Error> {
   let backend = state.backend()?;
@@ -189,8 +202,12 @@ pub async fn check_gamebanana_catalog_updates(
     if (snapshot.remote_updated_at > installed.installed_at || file_updated || selected_changed)
       && let Some(record) = backend.catalog.get(submission).await?
     {
+      let mut mod_data = CatalogModDto::from_record(record)?;
+      if !policy.apply_to_mod(&mut mod_data)? || !mod_data.downloadable {
+        continue;
+      }
       updates.push(CatalogUpdateDto {
-        r#mod: CatalogModDto::from_record(record)?,
+        r#mod: mod_data,
         downloads: snapshot
           .files
           .into_iter()
@@ -237,8 +254,10 @@ pub async fn get_gamebanana_fileservers(
 
 async fn submission_files(
   state: &State<'_, GameBananaCatalogState>,
+  policy: &State<'_, super::policy::PolicyState>,
   remote_id: &str,
 ) -> Result<CatalogDownloadsDto, Error> {
+  policy.ensure_download_allowed(remote_id)?;
   let backend = state.backend()?;
   let submission = parse_submission(remote_id)?;
   let page = backend

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod live_match;
 pub mod logs;
 pub mod match_sync;
 pub mod mods;
+pub mod policy;
 pub mod profiles;
 pub mod reports;
 pub mod server_browser;

--- a/apps/desktop/src-tauri/src/commands/policy.rs
+++ b/apps/desktop/src-tauri/src/commands/policy.rs
@@ -1,0 +1,488 @@
+use super::gamebanana_catalog::{CatalogDonationLinkDto, CatalogModDto, CatalogModMetadataDto};
+use crate::errors::Error;
+use crate::providers::{SubmissionProvider, SubmissionRef, SubmissionType};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::Duration;
+use tauri::State;
+
+const POLICY_SCHEMA_VERSION: u32 = 1;
+const MAX_POLICY_BYTES: usize = 2 * 1024 * 1024;
+const MAX_POLICY_RULES: usize = 10_000;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyMetadataCorrection {
+  pub name: Option<String>,
+  pub description: Option<String>,
+  pub category: Option<String>,
+  pub hero: Option<String>,
+  pub is_map: Option<bool>,
+  pub is_audio: Option<bool>,
+  #[serde(rename = "isNSFW")]
+  pub is_nsfw: Option<bool>,
+  pub is_obsolete: Option<bool>,
+  pub tags: Option<Vec<String>>,
+  pub metadata: Option<PolicyMetadata>,
+  pub downloads: Option<Vec<PolicyDownloadCorrection>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyMetadata {
+  pub map_name: Option<String>,
+  pub donation_links: Option<Vec<PolicyDonationLink>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyDonationLink {
+  pub url: String,
+  pub platform: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyDownloadCorrection {
+  pub url: String,
+  pub file: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyRuleKind {
+  Hidden,
+  Blacklisted,
+  Takedown,
+  MetadataCorrection,
+  EmergencyDisable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyRule {
+  pub provider: SubmissionProvider,
+  pub submission_type: SubmissionType,
+  pub submission_id: String,
+  pub kind: PolicyRuleKind,
+  pub reason: Option<String>,
+  pub correction: Option<PolicyMetadataCorrection>,
+  pub updated_at: String,
+}
+
+impl PolicyRule {
+  fn submission(&self) -> SubmissionRef {
+    SubmissionRef {
+      provider: self.provider,
+      submission_type: self.submission_type,
+      submission_id: self.submission_id.clone(),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PolicyManifest {
+  pub version: u32,
+  pub revision: u64,
+  pub generated_at: String,
+  pub rules: Vec<PolicyRule>,
+}
+
+impl Default for PolicyManifest {
+  fn default() -> Self {
+    Self {
+      version: POLICY_SCHEMA_VERSION,
+      revision: 0,
+      generated_at: "1970-01-01T00:00:00Z".to_string(),
+      rules: Vec::new(),
+    }
+  }
+}
+
+pub struct PolicyState {
+  path: PathBuf,
+  manifest: RwLock<PolicyManifest>,
+  refresh_lock: tokio::sync::Mutex<()>,
+}
+
+impl PolicyState {
+  pub fn open(path: PathBuf) -> Self {
+    let manifest = load_best_manifest(&path).unwrap_or_else(|error| {
+      log::warn!("Policy cache unavailable; continuing without policy: {error}");
+      PolicyManifest::default()
+    });
+    Self {
+      path,
+      manifest: RwLock::new(manifest),
+      refresh_lock: tokio::sync::Mutex::new(()),
+    }
+  }
+
+  pub fn unavailable_slugs(&self) -> Result<Vec<String>, Error> {
+    let manifest = self
+      .manifest
+      .read()
+      .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?;
+    Ok(
+      manifest
+        .rules
+        .iter()
+        .filter(|rule| {
+          matches!(
+            rule.kind,
+            PolicyRuleKind::Hidden | PolicyRuleKind::Blacklisted | PolicyRuleKind::Takedown
+          )
+        })
+        .map(|rule| rule.submission().to_slug().map_err(|error| Error::InvalidInput(error.to_string())))
+        .collect::<Result<Vec<_>, _>>()?,
+    )
+  }
+
+  pub fn apply_to_mod(&self, mod_data: &mut CatalogModDto) -> Result<bool, Error> {
+    let manifest = self
+      .manifest
+      .read()
+      .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?;
+    let remote_id = mod_data.remote_id.clone();
+    let rules = manifest
+      .rules
+      .iter()
+      .filter(|rule| rule.submission().to_slug().is_ok_and(|slug| slug == remote_id));
+    for rule in rules {
+      match rule.kind {
+        PolicyRuleKind::Hidden | PolicyRuleKind::Blacklisted | PolicyRuleKind::Takedown => {
+          return Ok(false);
+        }
+        PolicyRuleKind::EmergencyDisable => mod_data.downloadable = false,
+        PolicyRuleKind::MetadataCorrection => {
+          if let Some(correction) = &rule.correction {
+            apply_correction(mod_data, correction);
+          }
+        }
+      }
+    }
+    Ok(true)
+  }
+
+  pub fn ensure_download_allowed(&self, slug: &str) -> Result<(), Error> {
+    let manifest = self
+      .manifest
+      .read()
+      .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?;
+    if manifest.rules.iter().any(|rule| {
+      rule.submission().to_slug().is_ok_and(|identity| identity == slug)
+        && matches!(
+          rule.kind,
+          PolicyRuleKind::Hidden
+            | PolicyRuleKind::Blacklisted
+            | PolicyRuleKind::Takedown
+            | PolicyRuleKind::EmergencyDisable
+        )
+    }) {
+      return Err(Error::InvalidInput(
+        "This submission is unavailable by policy".to_string(),
+      ));
+    }
+    Ok(())
+  }
+
+  async fn refresh(&self) -> Result<bool, Error> {
+    let _refresh_guard = self.refresh_lock.lock().await;
+    let base_url = super::state::get_api_url();
+    let url = reqwest::Url::parse(&format!(
+      "{}/api/v2/policy-manifest",
+      base_url.trim_end_matches('/')
+    ))
+    .map_err(|_| Error::Network("Invalid policy API URL".to_string()))?;
+    let client = crate::proxy::build_http_client(|builder| {
+      builder
+        .user_agent(concat!("DMM/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(20))
+        .redirect(reqwest::redirect::Policy::limited(3))
+    })?;
+    let response = client
+      .get(url)
+      .send()
+      .await
+      .map_err(|error| Error::Network(error.to_string()))?;
+    if !response.status().is_success() {
+      return Err(Error::Network(format!(
+        "Policy endpoint returned {}",
+        response.status()
+      )));
+    }
+    if response
+      .content_length()
+      .is_some_and(|length| length > MAX_POLICY_BYTES as u64)
+    {
+      return Err(Error::Network("Policy manifest is too large".to_string()));
+    }
+    let bytes = response
+      .bytes()
+      .await
+      .map_err(|error| Error::Network(error.to_string()))?;
+    if bytes.len() > MAX_POLICY_BYTES {
+      return Err(Error::Network("Policy manifest is too large".to_string()));
+    }
+    let next = parse_manifest(&bytes)?;
+    let current_revision = self
+      .manifest
+      .read()
+      .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?
+      .revision;
+    if !should_replace(current_revision, next.revision) {
+      return Ok(false);
+    }
+
+    write_manifest(&self.path, &next)?;
+    *self
+      .manifest
+      .write()
+      .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))? = next;
+    Ok(true)
+  }
+}
+
+fn should_replace(current_revision: u64, next_revision: u64) -> bool {
+  next_revision >= current_revision
+}
+
+#[tauri::command]
+pub async fn refresh_policy_manifest(state: State<'_, PolicyState>) -> Result<bool, Error> {
+  state.refresh().await
+}
+
+fn apply_correction(mod_data: &mut CatalogModDto, correction: &PolicyMetadataCorrection) {
+  if let Some(value) = &correction.name {
+    mod_data.name.clone_from(value);
+  }
+  if let Some(value) = &correction.description {
+    mod_data.description = Some(value.clone());
+  }
+  if let Some(value) = &correction.category {
+    mod_data.category.clone_from(value);
+  }
+  if let Some(value) = &correction.hero {
+    mod_data.hero = Some(value.clone());
+  }
+  if let Some(value) = correction.is_map {
+    mod_data.is_map = value;
+  }
+  if let Some(value) = correction.is_audio {
+    mod_data.is_audio = value;
+  }
+  if let Some(value) = correction.is_nsfw {
+    mod_data.is_nsfw = value;
+  }
+  if let Some(value) = correction.is_obsolete {
+    mod_data.is_obsolete = value;
+  }
+  if let Some(value) = &correction.tags {
+    mod_data.tags.clone_from(value);
+  }
+  if let Some(metadata) = &correction.metadata {
+    let current = mod_data
+      .metadata
+      .get_or_insert_with(|| CatalogModMetadataDto {
+        map_name: None,
+        donation_links: Vec::new(),
+      });
+    if let Some(map_name) = &metadata.map_name {
+      current.map_name = Some(map_name.clone());
+    }
+    if let Some(links) = &metadata.donation_links {
+      current.donation_links = links
+        .iter()
+        .map(|link| CatalogDonationLinkDto {
+          url: link.url.clone(),
+          platform: link.platform.clone(),
+        })
+        .collect();
+    }
+  }
+}
+
+fn parse_manifest(bytes: &[u8]) -> Result<PolicyManifest, Error> {
+  let manifest: PolicyManifest = serde_json::from_slice(bytes)
+    .map_err(|error| Error::InvalidInput(format!("Invalid policy manifest: {error}")))?;
+  validate_manifest(&manifest)?;
+  Ok(manifest)
+}
+
+fn validate_manifest(manifest: &PolicyManifest) -> Result<(), Error> {
+  if manifest.version != POLICY_SCHEMA_VERSION || manifest.rules.len() > MAX_POLICY_RULES {
+    return Err(Error::InvalidInput(
+      "Unsupported or oversized policy manifest".to_string(),
+    ));
+  }
+  chrono::DateTime::parse_from_rfc3339(&manifest.generated_at)
+    .map_err(|_| Error::InvalidInput("Invalid policy generation time".to_string()))?;
+  let mut identities = BTreeSet::new();
+  for rule in &manifest.rules {
+    chrono::DateTime::parse_from_rfc3339(&rule.updated_at)
+      .map_err(|_| Error::InvalidInput("Invalid policy update time".to_string()))?;
+    let submission = rule.submission();
+    if submission.provider != SubmissionProvider::Gamebanana
+      || !submission
+        .submission_id
+        .bytes()
+        .enumerate()
+        .all(|(index, byte)| byte.is_ascii_digit() && (index > 0 || byte != b'0'))
+      || submission.submission_id.is_empty()
+    {
+      return Err(Error::InvalidInput("Invalid policy identity".to_string()));
+    }
+    if !identities.insert((submission.to_slug().map_err(|error| Error::InvalidInput(error.to_string()))?, rule.kind)) {
+      return Err(Error::InvalidInput("Duplicate policy rule".to_string()));
+    }
+    if (rule.kind == PolicyRuleKind::MetadataCorrection) != rule.correction.is_some() {
+      return Err(Error::InvalidInput(
+        "Policy correction payload does not match its rule kind".to_string(),
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn load_best_manifest(path: &Path) -> Result<PolicyManifest, Error> {
+  let pending = path.with_extension("json.next");
+  let paths = [path.to_path_buf(), pending];
+  let mut candidates = paths
+    .into_iter()
+    .filter(|candidate| candidate.is_file())
+    .filter_map(|candidate| fs::read(candidate).ok())
+    .filter_map(|bytes| parse_manifest(&bytes).ok())
+    .collect::<Vec<_>>();
+  candidates.sort_by_key(|manifest| manifest.revision);
+  Ok(candidates.pop().unwrap_or_default())
+}
+
+fn write_manifest(path: &Path, manifest: &PolicyManifest) -> Result<(), Error> {
+  if let Some(parent) = path.parent() {
+    fs::create_dir_all(parent)?;
+  }
+  let pending = path.with_extension("json.next");
+  let bytes = serde_json::to_vec_pretty(manifest)
+    .map_err(|error| Error::InvalidInput(format!("Failed to encode policy: {error}")))?;
+  fs::write(&pending, bytes)?;
+  if path.exists() {
+    fs::remove_file(path)?;
+  }
+  fs::rename(pending, path)?;
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn manifest(revision: u64, kind: PolicyRuleKind) -> PolicyManifest {
+    PolicyManifest {
+      version: 1,
+      revision,
+      generated_at: "2026-08-30T12:00:00Z".to_string(),
+      rules: vec![PolicyRule {
+        provider: SubmissionProvider::Gamebanana,
+        submission_type: SubmissionType::Sound,
+        submission_id: "42".to_string(),
+        kind,
+        reason: None,
+        correction: None,
+        updated_at: "2026-08-30T12:00:00Z".to_string(),
+      }],
+    }
+  }
+
+  #[test]
+  fn malformed_pending_manifest_never_replaces_the_cached_policy() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("policy.json");
+    write_manifest(&path, &manifest(7, PolicyRuleKind::Blacklisted)).unwrap();
+    fs::write(path.with_extension("json.next"), b"not json").unwrap();
+
+    let state = PolicyState::open(path);
+    assert!(state.ensure_download_allowed("snd-42").is_err());
+  }
+
+  #[test]
+  fn crash_pending_manifest_is_used_when_it_is_newer() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("policy.json");
+    write_manifest(&path, &manifest(7, PolicyRuleKind::Blacklisted)).unwrap();
+    fs::write(
+      path.with_extension("json.next"),
+      serde_json::to_vec(&manifest(8, PolicyRuleKind::EmergencyDisable)).unwrap(),
+    )
+    .unwrap();
+
+    let state = PolicyState::open(path);
+    assert!(state.ensure_download_allowed("snd-42").is_err());
+    assert_eq!(state.manifest.read().unwrap().revision, 8);
+  }
+
+  #[test]
+  fn rejects_correction_payloads_on_non_correction_rules() {
+    let mut value = manifest(1, PolicyRuleKind::Hidden);
+    value.rules[0].correction = Some(PolicyMetadataCorrection::default());
+    assert!(validate_manifest(&value).is_err());
+  }
+
+  #[test]
+  fn older_policy_responses_cannot_replace_the_cached_revision() {
+    assert!(!should_replace(8, 7));
+    assert!(should_replace(8, 8));
+    assert!(should_replace(8, 9));
+  }
+
+  #[test]
+  fn applies_metadata_corrections_without_hiding_the_submission() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("policy.json");
+    let mut value = manifest(1, PolicyRuleKind::MetadataCorrection);
+    value.rules[0].correction = Some(PolicyMetadataCorrection {
+      name: Some("Corrected voice".to_string()),
+      is_nsfw: Some(true),
+      tags: Some(vec!["curated".to_string()]),
+      ..PolicyMetadataCorrection::default()
+    });
+    write_manifest(&path, &value).unwrap();
+    let state = PolicyState::open(path);
+    let mut mod_data = CatalogModDto {
+      id: "snd-42".to_string(),
+      remote_id: "snd-42".to_string(),
+      name: "Old voice".to_string(),
+      description: None,
+      remote_url: "https://gamebanana.com/sounds/42".to_string(),
+      category: "VOs".to_string(),
+      likes: 0,
+      author: "author".to_string(),
+      downloadable: true,
+      remote_added_at: 0,
+      remote_updated_at: 0,
+      tags: Vec::new(),
+      images: Vec::new(),
+      hero: None,
+      is_audio: true,
+      is_map: false,
+      audio_url: None,
+      download_count: 0,
+      is_nsfw: false,
+      is_obsolete: false,
+      files_updated_at: None,
+      metadata: None,
+      dependencies: Vec::new(),
+      created_at: None,
+      updated_at: None,
+    };
+
+    assert!(state.apply_to_mod(&mut mod_data).unwrap());
+    assert_eq!(mod_data.name, "Corrected voice");
+    assert!(mod_data.is_nsfw);
+    assert_eq!(mod_data.tags, ["curated"]);
+  }
+}

--- a/apps/desktop/src-tauri/src/commands/policy.rs
+++ b/apps/desktop/src-tauri/src/commands/policy.rs
@@ -127,19 +127,22 @@ impl PolicyState {
       .manifest
       .read()
       .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?;
-    Ok(
-      manifest
-        .rules
-        .iter()
-        .filter(|rule| {
-          matches!(
-            rule.kind,
-            PolicyRuleKind::Hidden | PolicyRuleKind::Blacklisted | PolicyRuleKind::Takedown
-          )
-        })
-        .map(|rule| rule.submission().to_slug().map_err(|error| Error::InvalidInput(error.to_string())))
-        .collect::<Result<Vec<_>, _>>()?,
-    )
+    manifest
+      .rules
+      .iter()
+      .filter(|rule| {
+        matches!(
+          rule.kind,
+          PolicyRuleKind::Hidden | PolicyRuleKind::Blacklisted | PolicyRuleKind::Takedown
+        )
+      })
+      .map(|rule| {
+        rule
+          .submission()
+          .to_slug()
+          .map_err(|error| Error::InvalidInput(error.to_string()))
+      })
+      .collect::<Result<Vec<_>, _>>()
   }
 
   pub fn apply_to_mod(&self, mod_data: &mut CatalogModDto) -> Result<bool, Error> {
@@ -148,10 +151,12 @@ impl PolicyState {
       .read()
       .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?;
     let remote_id = mod_data.remote_id.clone();
-    let rules = manifest
-      .rules
-      .iter()
-      .filter(|rule| rule.submission().to_slug().is_ok_and(|slug| slug == remote_id));
+    let rules = manifest.rules.iter().filter(|rule| {
+      rule
+        .submission()
+        .to_slug()
+        .is_ok_and(|slug| slug == remote_id)
+    });
     for rule in rules {
       match rule.kind {
         PolicyRuleKind::Hidden | PolicyRuleKind::Blacklisted | PolicyRuleKind::Takedown => {
@@ -174,7 +179,10 @@ impl PolicyState {
       .read()
       .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))?;
     if manifest.rules.iter().any(|rule| {
-      rule.submission().to_slug().is_ok_and(|identity| identity == slug)
+      rule
+        .submission()
+        .to_slug()
+        .is_ok_and(|identity| identity == slug)
         && matches!(
           rule.kind,
           PolicyRuleKind::Hidden
@@ -337,7 +345,12 @@ fn validate_manifest(manifest: &PolicyManifest) -> Result<(), Error> {
     {
       return Err(Error::InvalidInput("Invalid policy identity".to_string()));
     }
-    if !identities.insert((submission.to_slug().map_err(|error| Error::InvalidInput(error.to_string()))?, rule.kind)) {
+    if !identities.insert((
+      submission
+        .to_slug()
+        .map_err(|error| Error::InvalidInput(error.to_string()))?,
+      rule.kind,
+    )) {
       return Err(Error::InvalidInput("Duplicate policy rule".to_string()));
     }
     if (rule.kind == PolicyRuleKind::MetadataCorrection) != rule.correction.is_some() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -108,6 +108,12 @@ pub fn run() {
         commands::gamebanana_catalog::GameBananaCatalogState::open(catalog_path),
       );
       app.manage(catalog_state);
+      app.manage(commands::policy::PolicyState::open(
+        app
+          .path()
+          .app_local_data_dir()?
+          .join("policy-manifest-v1.json"),
+      ));
 
       {
         let mut mod_manager = commands::state::MANAGER
@@ -131,6 +137,7 @@ pub fn run() {
       commands::gamebanana_catalog::invalidate_gamebanana_catalog_state,
       commands::gamebanana_catalog::get_gamebanana_fileservers,
       commands::identity_migration::migrate_submission_identities,
+      commands::policy::refresh_policy_manifest,
       commands::game::find_steam_path,
       commands::game::set_game_path,
       commands::game::set_steam_path,

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/query.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/query.rs
@@ -39,6 +39,8 @@ pub struct CatalogQuery {
   #[ts(type = "number | null")]
   pub updated_after: Option<i64>,
   pub favorites: Vec<String>,
+  #[ts(skip)]
+  pub excluded_slugs: Vec<String>,
   pub sort: CatalogSort,
   pub page: u32,
   pub page_size: u32,
@@ -145,6 +147,9 @@ fn filtered_query<'a>(
   }
   if let Some(updated_after) = query.updated_after {
     statement = statement.filter(submission::remote_updated_at.ge(updated_after));
+  }
+  if !query.excluded_slugs.is_empty() {
+    statement = statement.filter(submission::slug.ne_all(&query.excluded_slugs));
   }
   if !query.favorites.is_empty() {
     statement = statement.filter(submission::slug.eq_any(&query.favorites));
@@ -406,5 +411,33 @@ mod tests {
       .unwrap()
       .unwrap();
     assert_eq!(sound.name, "Sound");
+  }
+
+  #[tokio::test]
+  async fn policy_exclusions_are_applied_before_counting_and_pagination() {
+    let directory = tempdir().unwrap();
+    let catalog = Catalog::open(directory.path().join("catalog.db"), 1)
+      .await
+      .unwrap();
+    catalog
+      .upsert_records(vec![
+        record("10", "Allowed", "Skins", None),
+        record("snd-10", "Hidden", "VOs", None),
+      ])
+      .await
+      .unwrap();
+
+    let page = catalog
+      .query(CatalogQuery {
+        excluded_slugs: vec!["snd-10".to_string()],
+        page_size: 1,
+        ..CatalogQuery::default()
+      })
+      .await
+      .unwrap();
+
+    assert_eq!(page.total, 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].submission.to_slug(), "10");
   }
 }

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/query.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/query.rs
@@ -438,6 +438,6 @@ mod tests {
 
     assert_eq!(page.total, 1);
     assert_eq!(page.items.len(), 1);
-    assert_eq!(page.items[0].submission.to_slug(), "10");
+    assert_eq!(page.items[0].submission.to_slug().unwrap(), "10");
   }
 }

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -91,6 +91,11 @@ const App = () => {
     }
     await initializeApiUrl();
     await syncProxyConfigToBackend();
+    void invoke("refresh_policy_manifest").catch((error) => {
+      logger
+        .withError(error)
+        .warn("Policy refresh failed; keeping the last cached policy");
+    });
     await downloadManager.init();
 
     logger.debug(

--- a/packages/database/drizzle/0054_windy_maggott.sql
+++ b/packages/database/drizzle/0054_windy_maggott.sql
@@ -1,0 +1,51 @@
+CREATE TABLE "policy_rule" (
+	"id" text PRIMARY KEY NOT NULL,
+	"provider" text NOT NULL,
+	"submission_type" text NOT NULL,
+	"submission_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"reason" text,
+	"correction" jsonb,
+	"created_by" text,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "policy_rule_identity_kind_idx" ON "policy_rule" USING btree ("provider","submission_type","submission_id","kind");--> statement-breakpoint
+CREATE INDEX "policy_rule_identity_idx" ON "policy_rule" USING btree ("provider","submission_type","submission_id");--> statement-breakpoint
+CREATE INDEX "policy_rule_updated_at_idx" ON "policy_rule" USING btree ("updated_at");--> statement-breakpoint
+INSERT INTO "policy_rule" (
+	"id", "provider", "submission_type", "submission_id", "kind", "reason",
+	"created_by", "created_at", "updated_at"
+)
+SELECT
+	'policy_rule_' || md5('blacklisted:' || "remote_id"),
+	'gamebanana',
+	CASE WHEN "is_audio" OR "remote_id" LIKE 'snd-%' THEN 'sound' ELSE 'mod' END,
+	regexp_replace("remote_id", '^snd-', ''),
+	'blacklisted',
+	"blacklist_reason",
+	"blacklisted_by",
+	COALESCE("blacklisted_at", "created_at", now()),
+	COALESCE("updated_at", "blacklisted_at", now())
+FROM "mod"
+WHERE "is_blacklisted" = true
+	AND regexp_replace("remote_id", '^snd-', '') ~ '^[1-9][0-9]*$'
+ON CONFLICT ("provider", "submission_type", "submission_id", "kind") DO NOTHING;--> statement-breakpoint
+INSERT INTO "policy_rule" (
+	"id", "provider", "submission_type", "submission_id", "kind", "correction",
+	"created_at", "updated_at"
+)
+SELECT
+	'policy_rule_' || md5('metadata_correction:' || "remote_id"),
+	'gamebanana',
+	CASE WHEN "is_audio" OR "remote_id" LIKE 'snd-%' THEN 'sound' ELSE 'mod' END,
+	regexp_replace("remote_id", '^snd-', ''),
+	'metadata_correction',
+	"overrides",
+	COALESCE("created_at", now()),
+	COALESCE("updated_at", now())
+FROM "mod"
+WHERE "overrides" IS NOT NULL
+	AND regexp_replace("remote_id", '^snd-', '') ~ '^[1-9][0-9]*$'
+ON CONFLICT ("provider", "submission_type", "submission_id", "kind") DO NOTHING;

--- a/packages/database/drizzle/0055_woozy_peter_quill.sql
+++ b/packages/database/drizzle/0055_woozy_peter_quill.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "policy_rule" ADD COLUMN "active" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+CREATE INDEX "policy_rule_active_updated_at_idx" ON "policy_rule" USING btree ("active","updated_at");

--- a/packages/database/drizzle/meta/0054_snapshot.json
+++ b/packages/database/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,3551 @@
+{
+  "id": "8bc5debf-96ce-451b-96f3-10eac1b569ec",
+  "prevId": "aeb806a3-4252-41f5-9518-6be8e4a981b7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "announcement_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "status": {
+          "name": "status",
+          "type": "announcement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_author_id_user_id_fk": {
+          "name": "announcement_author_id_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "user",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_account_id": {
+          "name": "idx_account_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_access_token_on_access_token": {
+          "name": "idx_oauth_access_token_on_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_token_on_refresh_token": {
+          "name": "idx_oauth_access_token_on_refresh_token",
+          "columns": [
+            {
+              "expression": "refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_application_user_id_user_id_fk": {
+          "name": "oauth_application_user_id_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_created_at": {
+          "name": "idx_user_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_message_session_created": {
+          "name": "idx_chat_message_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_message_session_id_chat_session_id_fk": {
+          "name": "chat_message_session_id_chat_session_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session": {
+      "name": "chat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_session_discord_channel_id": {
+          "name": "idx_chat_session_discord_channel_id",
+          "columns": [
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_chat_session_user_channel": {
+          "name": "unique_chat_session_user_channel",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair_like": {
+      "name": "crosshair_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crosshair_id": {
+          "name": "crosshair_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crosshair_like_crosshair_id_user_id_idx": {
+          "name": "crosshair_like_crosshair_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "crosshair_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_like_user_id": {
+          "name": "idx_crosshair_like_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_like_crosshair_id_crosshair_id_fk": {
+          "name": "crosshair_like_crosshair_id_crosshair_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "crosshair",
+          "columnsFrom": ["crosshair_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crosshair_like_user_id_user_id_fk": {
+          "name": "crosshair_like_user_id_user_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair": {
+      "name": "crosshair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "heroes": {
+          "name": "heroes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crosshair_created_at": {
+          "name": "idx_crosshair_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_likes": {
+          "name": "idx_crosshair_likes",
+          "columns": [
+            {
+              "expression": "likes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_downloads": {
+          "name": "idx_crosshair_downloads",
+          "columns": [
+            {
+              "expression": "downloads",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_user_id": {
+          "name": "idx_crosshair_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_user_id_user_id_fk": {
+          "name": "crosshair_user_id_user_id_fk",
+          "tableFrom": "crosshair",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_setting": {
+      "name": "custom_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_chunks": {
+      "name": "documentation_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documentation_chunks_embedding_idx": {
+          "name": "documentation_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_sync": {
+      "name": "documentation_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::json"
+        },
+        "exposed": {
+          "name": "exposed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_name_unique": {
+          "name": "feature_flags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_flag_overrides": {
+      "name": "user_feature_flag_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feature_flag_overrides_user_id_user_id_fk": {
+          "name": "user_feature_flag_overrides_user_id_user_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk": {
+          "name": "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feature_flag_overrides_user_id_feature_flag_id_unique": {
+          "name": "user_feature_flag_overrides_user_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_lock": {
+      "name": "job_lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_lock_job_name_unique": {
+          "name": "job_lock_job_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_patterns": {
+      "name": "message_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern_type": {
+          "name": "pattern_type",
+          "type": "pattern_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_text": {
+          "name": "pattern_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_patterns_embedding_idx": {
+          "name": "message_patterns_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "message_patterns_pattern_type_idx": {
+          "name": "message_patterns_pattern_type_idx",
+          "columns": [
+            {
+              "expression": "pattern_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_keywords": {
+      "name": "triage_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "triage_keywords_keyword_unique": {
+          "name": "triage_keywords_keyword_unique",
+          "nullsNotDistinct": false,
+          "columns": ["keyword"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mirrored_files": {
+      "name": "mirrored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mirrored_at": {
+          "name": "mirrored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_downloaded_at": {
+          "name": "last_downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated": {
+          "name": "last_validated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stale": {
+          "name": "is_stale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mirrored_files_last_downloaded_at": {
+          "name": "idx_mirrored_files_last_downloaded_at",
+          "columns": [
+            {
+              "expression": "last_downloaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mirrored_files_is_stale": {
+          "name": "idx_mirrored_files_is_stale",
+          "columns": [
+            {
+              "expression": "is_stale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_mod_download_id_and_mod_id": {
+          "name": "unique_mod_download_id_and_mod_id",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mirrored_files_mod_download_id_mod_download_id_fk": {
+          "name": "mirrored_files_mod_download_id_mod_download_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mirrored_files_mod_id_mod_id_fk": {
+          "name": "mirrored_files_mod_id_mod_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mirrored_files_file_hash_unique": {
+          "name": "mirrored_files_file_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_download": {
+      "name": "mod_download",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "md5_checksum": {
+          "name": "md5_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_download_mod_id_remote_id_idx": {
+          "name": "mod_download_mod_id_remote_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_download_created_at": {
+          "name": "idx_mod_download_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mod_download_mod_id_mod_id_fk": {
+          "name": "mod_download_mod_id_mod_id_fk",
+          "tableFrom": "mod_download",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod": {
+      "name": "mod",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloadable": {
+          "name": "downloadable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_added_at": {
+          "name": "remote_added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_updated_at": {
+          "name": "remote_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hero": {
+          "name": "hero",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_audio": {
+          "name": "is_audio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_map": {
+          "name": "is_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_nsfw": {
+          "name": "is_nsfw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_obsolete": {
+          "name": "is_obsolete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_trashed": {
+          "name": "is_trashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_blacklisted": {
+          "name": "is_blacklisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blacklist_reason": {
+          "name": "blacklist_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_at": {
+          "name": "blacklisted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_by": {
+          "name": "blacklisted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_updated_at": {
+          "name": "files_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mod_created_at": {
+          "name": "idx_mod_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_updated_at": {
+          "name": "idx_mod_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_blacklisted_remote_updated": {
+          "name": "idx_mod_blacklisted_remote_updated",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_active_listing": {
+          "name": "idx_mod_active_listing",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_trashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mod_remote_id_unique": {
+          "name": "mod_remote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["remote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policy_rule": {
+      "name": "policy_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction": {
+          "name": "correction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "policy_rule_identity_kind_idx": {
+          "name": "policy_rule_identity_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "policy_rule_identity_idx": {
+          "name": "policy_rule_identity_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "policy_rule_updated_at_idx": {
+          "name": "policy_rule_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hardware_id": {
+          "name": "hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_content_hash_idx": {
+          "name": "profiles_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_answer_assets": {
+      "name": "quick_answer_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "quick_answer_asset_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_answer_assets_template_sort_idx": {
+          "name": "quick_answer_assets_template_sort_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_answer_assets_attachment_idx": {
+          "name": "quick_answer_assets_attachment_idx",
+          "columns": [
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quick_answer_assets_template_id_quick_answer_templates_id_fk": {
+          "name": "quick_answer_assets_template_id_quick_answer_templates_id_fk",
+          "tableFrom": "quick_answer_assets",
+          "tableTo": "quick_answer_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_answer_templates": {
+      "name": "quick_answer_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_discord_id": {
+          "name": "created_by_discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_discord_id": {
+          "name": "updated_by_discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_answer_templates_guild_slug_idx": {
+          "name": "quick_answer_templates_guild_slug_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_answer_templates_guild_active_idx": {
+          "name": "quick_answer_templates_guild_active_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_hardware_id": {
+          "name": "reporter_hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_mod_id_reporter_hardware_id_idx": {
+          "name": "report_mod_id_reporter_hardware_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_hardware_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_mod_id": {
+          "name": "idx_report_mod_id",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_mod_id_mod_id_fk": {
+          "name": "report_mod_id_mod_id_fk",
+          "tableFrom": "report",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rss_item": {
+      "name": "rss_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gamebanana'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rss_item_link_source_idx": {
+          "name": "rss_item_link_source_idx",
+          "columns": [
+            {
+              "expression": "link",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rss_item_pub_date_idx": {
+          "name": "rss_item_pub_date_idx",
+          "columns": [
+            {
+              "expression": "pub_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_feature_flags": {
+      "name": "segment_feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_feature_flags_segment_id_segments_id_fk": {
+          "name": "segment_feature_flags_segment_id_segments_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_feature_flags_feature_flag_id_feature_flags_id_fk": {
+          "name": "segment_feature_flags_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_feature_flags_segment_id_feature_flag_id_unique": {
+          "name": "segment_feature_flags_segment_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_members": {
+      "name": "segment_members",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_members_segment_id_segments_id_fk": {
+          "name": "segment_members_segment_id_segments_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_members_user_id_user_id_fk": {
+          "name": "segment_members_user_id_user_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_members_segment_id_user_id_unique": {
+          "name": "segment_members_segment_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segments_name_unique": {
+          "name": "segments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vpk": {
+      "name": "vpk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fast_hash": {
+          "name": "fast_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sig": {
+          "name": "content_sig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vpk_version": {
+          "name": "vpk_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_multiparts": {
+          "name": "has_multiparts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_inline_data": {
+          "name": "has_inline_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merkle_root": {
+          "name": "merkle_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "vpk_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_mtime": {
+          "name": "file_mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vpk_sha256_uk": {
+          "name": "vpk_sha256_uk",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_content_sig_idx": {
+          "name": "vpk_content_sig_idx",
+          "columns": [
+            {
+              "expression": "content_sig",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_src_uk": {
+          "name": "vpk_src_uk",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_fast_size_idx": {
+          "name": "vpk_fast_size_idx",
+          "columns": [
+            {
+              "expression": "fast_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_bytes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vpk_mod_id_mod_id_fk": {
+          "name": "vpk_mod_id_mod_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vpk_mod_download_id_mod_download_id_fk": {
+          "name": "vpk_mod_download_id_mod_download_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.announcement_category": {
+      "name": "announcement_category",
+      "schema": "public",
+      "values": ["maintenance", "downtime", "info"]
+    },
+    "public.announcement_status": {
+      "name": "announcement_status",
+      "schema": "public",
+      "values": ["draft", "published", "archived"]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": ["human", "ai", "system"]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["idle", "syncing", "error"]
+    },
+    "public.pattern_type": {
+      "name": "pattern_type",
+      "schema": "public",
+      "values": ["bug_report", "help_request"]
+    },
+    "public.quick_answer_asset_kind": {
+      "name": "quick_answer_asset_kind",
+      "schema": "public",
+      "values": ["image", "video"]
+    },
+    "public.vpk_state": {
+      "name": "vpk_state",
+      "schema": "public",
+      "values": ["ok", "duplicate", "corrupt"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/0055_snapshot.json
+++ b/packages/database/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,3579 @@
+{
+  "id": "ba8b714a-e2ab-4aa8-908c-7c040ec7a9ac",
+  "prevId": "8bc5debf-96ce-451b-96f3-10eac1b569ec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement": {
+      "name": "announcement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "announcement_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "status": {
+          "name": "status",
+          "type": "announcement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_author_id_user_id_fk": {
+          "name": "announcement_author_id_user_id_fk",
+          "tableFrom": "announcement",
+          "tableTo": "user",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_account_id": {
+          "name": "idx_account_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_provider_account": {
+          "name": "idx_account_provider_account",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_access_token_on_access_token": {
+          "name": "idx_oauth_access_token_on_access_token",
+          "columns": [
+            {
+              "expression": "access_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_token_on_refresh_token": {
+          "name": "idx_oauth_access_token_on_refresh_token",
+          "columns": [
+            {
+              "expression": "refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_application_user_id_user_id_fk": {
+          "name": "oauth_application_user_id_user_id_fk",
+          "tableFrom": "oauth_application",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_client_id_oauth_application_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_application_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_application",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_created_at": {
+          "name": "idx_user_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_message": {
+      "name": "chat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_message_session_created": {
+          "name": "idx_chat_message_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_message_session_id_chat_session_id_fk": {
+          "name": "chat_message_session_id_chat_session_id_fk",
+          "tableFrom": "chat_message",
+          "tableTo": "chat_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session": {
+      "name": "chat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_session_discord_channel_id": {
+          "name": "idx_chat_session_discord_channel_id",
+          "columns": [
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_chat_session_user_channel": {
+          "name": "unique_chat_session_user_channel",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair_like": {
+      "name": "crosshair_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crosshair_id": {
+          "name": "crosshair_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crosshair_like_crosshair_id_user_id_idx": {
+          "name": "crosshair_like_crosshair_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "crosshair_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_like_user_id": {
+          "name": "idx_crosshair_like_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_like_crosshair_id_crosshair_id_fk": {
+          "name": "crosshair_like_crosshair_id_crosshair_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "crosshair",
+          "columnsFrom": ["crosshair_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crosshair_like_user_id_user_id_fk": {
+          "name": "crosshair_like_user_id_user_id_fk",
+          "tableFrom": "crosshair_like",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crosshair": {
+      "name": "crosshair",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "heroes": {
+          "name": "heroes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_crosshair_created_at": {
+          "name": "idx_crosshair_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_likes": {
+          "name": "idx_crosshair_likes",
+          "columns": [
+            {
+              "expression": "likes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_downloads": {
+          "name": "idx_crosshair_downloads",
+          "columns": [
+            {
+              "expression": "downloads",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_crosshair_user_id": {
+          "name": "idx_crosshair_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crosshair_user_id_user_id_fk": {
+          "name": "crosshair_user_id_user_id_fk",
+          "tableFrom": "crosshair",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_setting": {
+      "name": "custom_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_chunks": {
+      "name": "documentation_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documentation_chunks_embedding_idx": {
+          "name": "documentation_chunks_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_sync": {
+      "name": "documentation_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'boolean'"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::json"
+        },
+        "exposed": {
+          "name": "exposed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_name_unique": {
+          "name": "feature_flags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feature_flag_overrides": {
+      "name": "user_feature_flag_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_feature_flag_overrides_user_id_user_id_fk": {
+          "name": "user_feature_flag_overrides_user_id_user_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk": {
+          "name": "user_feature_flag_overrides_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "user_feature_flag_overrides",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feature_flag_overrides_user_id_feature_flag_id_unique": {
+          "name": "user_feature_flag_overrides_user_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_lock": {
+      "name": "job_lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_lock_job_name_unique": {
+          "name": "job_lock_job_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_patterns": {
+      "name": "message_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern_type": {
+          "name": "pattern_type",
+          "type": "pattern_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern_text": {
+          "name": "pattern_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_patterns_embedding_idx": {
+          "name": "message_patterns_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "message_patterns_pattern_type_idx": {
+          "name": "message_patterns_pattern_type_idx",
+          "columns": [
+            {
+              "expression": "pattern_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_keywords": {
+      "name": "triage_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "triage_keywords_keyword_unique": {
+          "name": "triage_keywords_keyword_unique",
+          "nullsNotDistinct": false,
+          "columns": ["keyword"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mirrored_files": {
+      "name": "mirrored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_bucket": {
+          "name": "s3_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mirrored_at": {
+          "name": "mirrored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_downloaded_at": {
+          "name": "last_downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated": {
+          "name": "last_validated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stale": {
+          "name": "is_stale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mirrored_files_last_downloaded_at": {
+          "name": "idx_mirrored_files_last_downloaded_at",
+          "columns": [
+            {
+              "expression": "last_downloaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mirrored_files_is_stale": {
+          "name": "idx_mirrored_files_is_stale",
+          "columns": [
+            {
+              "expression": "is_stale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_mod_download_id_and_mod_id": {
+          "name": "unique_mod_download_id_and_mod_id",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mirrored_files_mod_download_id_mod_download_id_fk": {
+          "name": "mirrored_files_mod_download_id_mod_download_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mirrored_files_mod_id_mod_id_fk": {
+          "name": "mirrored_files_mod_id_mod_id_fk",
+          "tableFrom": "mirrored_files",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mirrored_files_file_hash_unique": {
+          "name": "mirrored_files_file_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["file_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod_download": {
+      "name": "mod_download",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "md5_checksum": {
+          "name": "md5_checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mod_download_mod_id_remote_id_idx": {
+          "name": "mod_download_mod_id_remote_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_download_created_at": {
+          "name": "idx_mod_download_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mod_download_mod_id_mod_id_fk": {
+          "name": "mod_download_mod_id_mod_id_fk",
+          "tableFrom": "mod_download",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mod": {
+      "name": "mod",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloadable": {
+          "name": "downloadable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "remote_added_at": {
+          "name": "remote_added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_updated_at": {
+          "name": "remote_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hero": {
+          "name": "hero",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_audio": {
+          "name": "is_audio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_map": {
+          "name": "is_map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_nsfw": {
+          "name": "is_nsfw",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_obsolete": {
+          "name": "is_obsolete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_trashed": {
+          "name": "is_trashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_blacklisted": {
+          "name": "is_blacklisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blacklist_reason": {
+          "name": "blacklist_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_at": {
+          "name": "blacklisted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blacklisted_by": {
+          "name": "blacklisted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_updated_at": {
+          "name": "files_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mod_created_at": {
+          "name": "idx_mod_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_updated_at": {
+          "name": "idx_mod_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_blacklisted_remote_updated": {
+          "name": "idx_mod_blacklisted_remote_updated",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mod_active_listing": {
+          "name": "idx_mod_active_listing",
+          "columns": [
+            {
+              "expression": "is_blacklisted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_trashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mod_remote_id_unique": {
+          "name": "mod_remote_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["remote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policy_rule": {
+      "name": "policy_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correction": {
+          "name": "correction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "policy_rule_identity_kind_idx": {
+          "name": "policy_rule_identity_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "policy_rule_identity_idx": {
+          "name": "policy_rule_identity_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "policy_rule_updated_at_idx": {
+          "name": "policy_rule_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "policy_rule_active_updated_at_idx": {
+          "name": "policy_rule_active_updated_at_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hardware_id": {
+          "name": "hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_content_hash_idx": {
+          "name": "profiles_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_answer_assets": {
+      "name": "quick_answer_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "quick_answer_asset_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_answer_assets_template_sort_idx": {
+          "name": "quick_answer_assets_template_sort_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_answer_assets_attachment_idx": {
+          "name": "quick_answer_assets_attachment_idx",
+          "columns": [
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quick_answer_assets_template_id_quick_answer_templates_id_fk": {
+          "name": "quick_answer_assets_template_id_quick_answer_templates_id_fk",
+          "tableFrom": "quick_answer_assets",
+          "tableTo": "quick_answer_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quick_answer_templates": {
+      "name": "quick_answer_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_discord_id": {
+          "name": "created_by_discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_discord_id": {
+          "name": "updated_by_discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quick_answer_templates_guild_slug_idx": {
+          "name": "quick_answer_templates_guild_slug_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "quick_answer_templates_guild_active_idx": {
+          "name": "quick_answer_templates_guild_active_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_hardware_id": {
+          "name": "reporter_hardware_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_mod_id_reporter_hardware_id_idx": {
+          "name": "report_mod_id_reporter_hardware_id_idx",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_hardware_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_mod_id": {
+          "name": "idx_report_mod_id",
+          "columns": [
+            {
+              "expression": "mod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_mod_id_mod_id_fk": {
+          "name": "report_mod_id_mod_id_fk",
+          "tableFrom": "report",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rss_item": {
+      "name": "rss_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gamebanana'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rss_item_link_source_idx": {
+          "name": "rss_item_link_source_idx",
+          "columns": [
+            {
+              "expression": "link",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rss_item_pub_date_idx": {
+          "name": "rss_item_pub_date_idx",
+          "columns": [
+            {
+              "expression": "pub_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_feature_flags": {
+      "name": "segment_feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_flag_id": {
+          "name": "feature_flag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_feature_flags_segment_id_segments_id_fk": {
+          "name": "segment_feature_flags_segment_id_segments_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_feature_flags_feature_flag_id_feature_flags_id_fk": {
+          "name": "segment_feature_flags_feature_flag_id_feature_flags_id_fk",
+          "tableFrom": "segment_feature_flags",
+          "tableTo": "feature_flags",
+          "columnsFrom": ["feature_flag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_feature_flags_segment_id_feature_flag_id_unique": {
+          "name": "segment_feature_flags_segment_id_feature_flag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "feature_flag_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_members": {
+      "name": "segment_members",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segment_members_segment_id_segments_id_fk": {
+          "name": "segment_members_segment_id_segments_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "segments",
+          "columnsFrom": ["segment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_members_user_id_user_id_fk": {
+          "name": "segment_members_user_id_user_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segment_members_segment_id_user_id_unique": {
+          "name": "segment_members_segment_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["segment_id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "segments_name_unique": {
+          "name": "segments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vpk": {
+      "name": "vpk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mod_download_id": {
+          "name": "mod_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fast_hash": {
+          "name": "fast_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sig": {
+          "name": "content_sig",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vpk_version": {
+          "name": "vpk_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_multiparts": {
+          "name": "has_multiparts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_inline_data": {
+          "name": "has_inline_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merkle_root": {
+          "name": "merkle_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "vpk_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ok'"
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_mtime": {
+          "name": "file_mtime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vpk_sha256_uk": {
+          "name": "vpk_sha256_uk",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_content_sig_idx": {
+          "name": "vpk_content_sig_idx",
+          "columns": [
+            {
+              "expression": "content_sig",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_src_uk": {
+          "name": "vpk_src_uk",
+          "columns": [
+            {
+              "expression": "mod_download_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vpk_fast_size_idx": {
+          "name": "vpk_fast_size_idx",
+          "columns": [
+            {
+              "expression": "fast_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_bytes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vpk_mod_id_mod_id_fk": {
+          "name": "vpk_mod_id_mod_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod",
+          "columnsFrom": ["mod_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vpk_mod_download_id_mod_download_id_fk": {
+          "name": "vpk_mod_download_id_mod_download_id_fk",
+          "tableFrom": "vpk",
+          "tableTo": "mod_download",
+          "columnsFrom": ["mod_download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.announcement_category": {
+      "name": "announcement_category",
+      "schema": "public",
+      "values": ["maintenance", "downtime", "info"]
+    },
+    "public.announcement_status": {
+      "name": "announcement_status",
+      "schema": "public",
+      "values": ["draft", "published", "archived"]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": ["human", "ai", "system"]
+    },
+    "public.sync_status": {
+      "name": "sync_status",
+      "schema": "public",
+      "values": ["idle", "syncing", "error"]
+    },
+    "public.pattern_type": {
+      "name": "pattern_type",
+      "schema": "public",
+      "values": ["bug_report", "help_request"]
+    },
+    "public.quick_answer_asset_kind": {
+      "name": "quick_answer_asset_kind",
+      "schema": "public",
+      "values": ["image", "video"]
+    },
+    "public.vpk_state": {
+      "name": "vpk_state",
+      "schema": "public",
+      "values": ["ok", "duplicate", "corrupt"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -379,6 +379,20 @@
       "when": 1784644302365,
       "tag": "0053_legal_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1788104092427,
+      "tag": "0054_windy_maggott",
+      "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1788104327076,
+      "tag": "0055_woozy_peter_quill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -10,6 +10,7 @@ export * from "./mirrored-file.repository";
 export * from "./mod.repository";
 export * from "./mod-download.repository";
 export * from "./profile.repository";
+export * from "./policy-rule.repository";
 export * from "./quick-answer.repository";
 export * from "./reports.repository";
 export * from "./rss-item.repository";

--- a/packages/database/src/repositories/policy-rule.repository.ts
+++ b/packages/database/src/repositories/policy-rule.repository.ts
@@ -1,0 +1,95 @@
+import { and, asc, eq } from "drizzle-orm";
+import type { Database } from "../client";
+import {
+  type NewPolicyRule,
+  type PolicyProvider,
+  type PolicyRule,
+  type PolicyRuleKind,
+  type PolicySubmissionType,
+  policyRules,
+} from "../schema/policy-rules";
+
+export interface PolicyIdentity {
+  provider: PolicyProvider;
+  submissionType: PolicySubmissionType;
+  submissionId: string;
+}
+
+export class PolicyRuleRepository {
+  constructor(private readonly db: Database) {}
+
+  async listAll(): Promise<PolicyRule[]> {
+    return await this.db
+      .select()
+      .from(policyRules)
+      .orderBy(
+        asc(policyRules.provider),
+        asc(policyRules.submissionType),
+        asc(policyRules.submissionId),
+        asc(policyRules.kind),
+      );
+  }
+
+  async find(
+    identity: PolicyIdentity,
+    kind: PolicyRuleKind,
+  ): Promise<PolicyRule | null> {
+    const [rule] = await this.db
+      .select()
+      .from(policyRules)
+      .where(
+        and(
+          eq(policyRules.provider, identity.provider),
+          eq(policyRules.submissionType, identity.submissionType),
+          eq(policyRules.submissionId, identity.submissionId),
+          eq(policyRules.kind, kind),
+          eq(policyRules.active, true),
+        ),
+      )
+      .limit(1);
+    return rule ?? null;
+  }
+
+  async upsert(rule: NewPolicyRule): Promise<PolicyRule> {
+    const [saved] = await this.db
+      .insert(policyRules)
+      .values({ ...rule, active: true })
+      .onConflictDoUpdate({
+        target: [
+          policyRules.provider,
+          policyRules.submissionType,
+          policyRules.submissionId,
+          policyRules.kind,
+        ],
+        set: {
+          reason: rule.reason ?? null,
+          correction: rule.correction ?? null,
+          createdBy: rule.createdBy ?? null,
+          active: true,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    return saved;
+  }
+
+  async delete(
+    identity: PolicyIdentity,
+    kind: PolicyRuleKind,
+  ): Promise<boolean> {
+    const deleted = await this.db
+      .update(policyRules)
+      .set({ active: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(policyRules.provider, identity.provider),
+          eq(policyRules.submissionType, identity.submissionType),
+          eq(policyRules.submissionId, identity.submissionId),
+          eq(policyRules.kind, kind),
+          eq(policyRules.active, true),
+        ),
+      )
+      .returning({ id: policyRules.id });
+    return deleted.length > 0;
+  }
+}

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -10,6 +10,7 @@ export * from "./job-locks";
 export * from "./message-pattern-embeddings";
 export * from "./mirrored-files";
 export * from "./mods";
+export * from "./policy-rules";
 export * from "./profiles";
 export * from "./quick-answers";
 export * from "./relations";

--- a/packages/database/src/schema/policy-rules.ts
+++ b/packages/database/src/schema/policy-rules.ts
@@ -1,0 +1,66 @@
+import {
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { generateId, typeId } from "../extensions/typeid";
+import type { ModOverrides } from "./mods";
+import { timestamps } from "./shared/timestamps";
+
+export const policyProviders = ["gamebanana"] as const;
+export const policySubmissionTypes = ["mod", "sound"] as const;
+export const policyRuleKinds = [
+  "hidden",
+  "blacklisted",
+  "takedown",
+  "metadata_correction",
+  "emergency_disable",
+] as const;
+
+export type PolicyProvider = (typeof policyProviders)[number];
+export type PolicySubmissionType = (typeof policySubmissionTypes)[number];
+export type PolicyRuleKind = (typeof policyRuleKinds)[number];
+
+export const policyRules = pgTable(
+  "policy_rule",
+  {
+    id: typeId("id", "policy_rule")
+      .primaryKey()
+      .$defaultFn(() => generateId("policy_rule").toString()),
+    provider: text("provider", { enum: policyProviders }).notNull(),
+    submissionType: text("submission_type", {
+      enum: policySubmissionTypes,
+    }).notNull(),
+    submissionId: text("submission_id").notNull(),
+    kind: text("kind", { enum: policyRuleKinds }).notNull(),
+    active: boolean("active").notNull().default(true),
+    reason: text("reason"),
+    correction: jsonb("correction").$type<ModOverrides>(),
+    createdBy: text("created_by"),
+    ...timestamps,
+  },
+  (table) => [
+    uniqueIndex("policy_rule_identity_kind_idx").on(
+      table.provider,
+      table.submissionType,
+      table.submissionId,
+      table.kind,
+    ),
+    index("policy_rule_identity_idx").on(
+      table.provider,
+      table.submissionType,
+      table.submissionId,
+    ),
+    index("policy_rule_updated_at_idx").on(table.updatedAt),
+    index("policy_rule_active_updated_at_idx").on(
+      table.active,
+      table.updatedAt,
+    ),
+  ],
+);
+
+export type PolicyRule = typeof policyRules.$inferSelect;
+export type NewPolicyRule = typeof policyRules.$inferInsert;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ export * from "./schemas/crosshair.schemas";
 export * from "./schemas/feature-flag.schemas";
 export * from "./schemas/fileserver.schemas";
 export * from "./schemas/mod.schemas";
+export * from "./schemas/policy.schemas";
 export * from "./schemas/profile.schemas";
 export * from "./schemas/report.schemas";
 export * from "./schemas/server-browser.schemas";

--- a/packages/shared/src/schemas/policy.schemas.ts
+++ b/packages/shared/src/schemas/policy.schemas.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+export const policyProviderSchema = z.literal("gamebanana");
+export const policySubmissionTypeSchema = z.enum(["mod", "sound"]);
+export const policyRuleKindSchema = z.enum([
+  "hidden",
+  "blacklisted",
+  "takedown",
+  "metadata_correction",
+  "emergency_disable",
+]);
+
+const policyDonationLinkSchema = z
+  .object({
+    url: z.string(),
+    platform: z.string(),
+  })
+  .strict();
+
+const policyDownloadCorrectionSchema = z
+  .object({
+    url: z.string(),
+    file: z.string(),
+  })
+  .strict();
+
+export const policyMetadataCorrectionSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    category: z.string().optional(),
+    hero: z.string().optional(),
+    isMap: z.boolean().optional(),
+    isAudio: z.boolean().optional(),
+    isNSFW: z.boolean().optional(),
+    isObsolete: z.boolean().optional(),
+    tags: z.array(z.string()).optional(),
+    metadata: z
+      .object({
+        mapName: z.string().optional(),
+        donationLinks: z.array(policyDonationLinkSchema).optional(),
+      })
+      .strict()
+      .optional(),
+    downloads: z.array(policyDownloadCorrectionSchema).optional(),
+  })
+  .strict();
+
+export const policyManifestRuleSchema = z
+  .object({
+    provider: policyProviderSchema,
+    submissionType: policySubmissionTypeSchema,
+    submissionId: z.string().regex(/^[1-9]\d*$/),
+    kind: policyRuleKindSchema,
+    reason: z.string().nullable(),
+    correction: policyMetadataCorrectionSchema.nullable(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const policyManifestSchema = z
+  .object({
+    version: z.literal(1),
+    revision: z.number().int().nonnegative(),
+    generatedAt: z.string().datetime(),
+    rules: z.array(policyManifestRuleSchema),
+  })
+  .strict();
+
+export type PolicyManifest = z.infer<typeof policyManifestSchema>;
+export type PolicyManifestRule = z.infer<typeof policyManifestRuleSchema>;
+export type PolicyMetadataCorrection = z.infer<
+  typeof policyMetadataCorrectionSchema
+>;

--- a/packages/shared/src/tests/policy.schemas.spec.ts
+++ b/packages/shared/src/tests/policy.schemas.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { policyManifestSchema } from "../schemas/policy.schemas";
+
+describe("policyManifestSchema", () => {
+  it("accepts a versioned identity policy manifest", () => {
+    expect(
+      policyManifestSchema.parse({
+        version: 1,
+        revision: 42,
+        generatedAt: "2026-08-30T12:00:00.000Z",
+        rules: [
+          {
+            provider: "gamebanana",
+            submissionType: "sound",
+            submissionId: "7",
+            kind: "blacklisted",
+            reason: "malware",
+            correction: null,
+            updatedAt: "2026-08-30T11:59:00.000Z",
+          },
+        ],
+      }).rules[0]?.submissionType,
+    ).toBe("sound");
+  });
+
+  it("rejects malformed identities and unsupported schema versions", () => {
+    expect(
+      policyManifestSchema.safeParse({
+        version: 2,
+        revision: 1,
+        generatedAt: "2026-08-30T12:00:00.000Z",
+        rules: [],
+      }).success,
+    ).toBe(false);
+    expect(
+      policyManifestSchema.safeParse({
+        version: 1,
+        revision: 1,
+        generatedAt: "2026-08-30T12:00:00.000Z",
+        rules: [
+          {
+            provider: "gamebanana",
+            submissionType: "mod",
+            submissionId: "../7",
+            kind: "hidden",
+            reason: null,
+            correction: null,
+            updatedAt: "2026-08-30T12:00:00.000Z",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Move blacklists and metadata overrides out of mirrored mod rows so moderation no longer depends on infrastructure removed later in the stack. Rules are addressed by provider, submission type, and submission ID.

Add the `policy_rule` table, a deterministic versioned manifest endpoint, and atomic desktop caching. An invalid refresh cannot replace the last valid manifest, and a refresh failure does not make the local catalog unavailable. Catalog queries and downloads apply the cached policy.

Rewrite the Discord `/blacklist` command to write policy rules and accept both Mod and Sound URLs. Database migrations backfill existing blacklist and override state.

## Type of Change

- [ ] ≡ƒÉ¢ Bug fix (non-breaking change which fixes an issue)
- [x] Γ£¿ New feature (non-breaking change which adds functionality)
- [ ] ≡ƒÆÑ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ≡ƒôÜ Documentation update
- [ ] ≡ƒöº Code refactoring (no functional changes)
- [x] ≡ƒº¬ Tests (adding or updating tests)
- [ ] ≡ƒö¿ Chore (maintenance, dependency updates, etc.)

## Related Issues

- Refs #673

Maintainer-directed GameBanana direct-client migration.

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted ΓÇö Tool: Codex, Used for: implementing human written plan and prototyping

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

Validated with API manifest tests, bot command tests, shared policy-schema tests, database tests, desktop policy tests, and workspace type checking.

## Screenshots (if applicable)

Not applicable; moderation remains command-driven and the desktop filtering is not a visual redesign.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested my changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

Stack 7 of 9. Based on #700; followed by #702.

Review fail-open catalog availability versus enforcement of rules already present in the last valid manifest.

## For Maintainers

- [x] This PR requires a version bump
- [ ] This PR requires documentation updates
- [x] This PR affects the public API
- [x] This PR requires migration instructions

## Stack tracking

Tracked in #673 (PR 7 of 19). Based on #700. Followed by #702.

