### PR TITLE
fix(gamebanana): recover syncs and resolve imported downloads

### DIFF
--- a/.changeset/brave-otters-report.md
+++ b/.changeset/brave-otters-report.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Report failed download lookups per mod instead of aborting the whole batch update or profile import

--- a/.changeset/calm-geckos-recover.md
+++ b/.changeset/calm-geckos-recover.md
@@ -1,0 +1,8 @@
+---
+"@deadlock-mods/api": patch
+"@deadlock-mods/bot": patch
+"@deadlock-mods/desktop": patch
+"@deadlock-mods/shared": patch
+---
+
+Fix direct GameBanana downloads, catalog recovery, and policy metadata.

--- a/.changeset/swift-pandas-resolve.md
+++ b/.changeset/swift-pandas-resolve.md
@@ -1,0 +1,6 @@
+---
+"@deadlock-mods/api": patch
+"@deadlock-mods/shared": patch
+---
+
+Return partial server mod requirements when provider lookups run long instead of closing the connection

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -133,6 +133,10 @@ const main = async () => {
     port: 9000,
     fetch: app.fetch,
     maxRequestBodySize: VPK_CONSTANTS.MAX_FILE_SIZE_BYTES,
+    // Handlers that fan out to upstream providers enforce their own deadlines
+    // below this, so a slow upstream returns partial results instead of a
+    // closed connection.
+    idleTimeout: 30,
   });
 };
 

--- a/apps/api/src/services/gamebanana-submission.test.ts
+++ b/apps/api/src/services/gamebanana-submission.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  fetchGameBananaSubmission,
   fetchGameBananaSubmissionSnapshot,
   parseGameBananaSlug,
 } from "./gamebanana-submission";
@@ -41,6 +42,30 @@ describe("fetchGameBananaSubmissionSnapshot", () => {
       name: "Movement map",
       author: "Mapper",
       isMap: true,
+    });
+  });
+
+  it("keeps direct profile safety metadata", async () => {
+    const submission = await fetchGameBananaSubmission(
+      parseGameBananaSlug("42")!,
+      (() =>
+        Promise.resolve(
+          Response.json({
+            _idRow: 42,
+            _sName: "Movement map",
+            _aSubmitter: { _sName: "Mapper" },
+            _aGame: { _idRow: 20_948 },
+            _aSuperCategory: { _sName: "  " },
+            _aRootCategory: { _sName: "Maps" },
+            _aContentRatings: { nu: "Nudity" },
+          }),
+        )) as typeof fetch,
+    );
+
+    expect(submission?.mod).toMatchObject({
+      category: "Maps",
+      isMap: true,
+      isNSFW: true,
     });
   });
 

--- a/apps/api/src/services/gamebanana-submission.ts
+++ b/apps/api/src/services/gamebanana-submission.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "@deadlock-mods/common";
 import { z } from "zod";
 import type { ResolvedRequirement } from "@deadlock-mods/shared";
 import {
@@ -39,6 +40,7 @@ const profileSnapshotSchema = z
     _bIsWithheld: z.boolean().optional(),
     _bIsTrashed: z.boolean().optional(),
     _bIsObsolete: z.boolean().optional(),
+    _aContentRatings: z.record(z.string(), z.string()).optional(),
     _nLikeCount: z.number().int().optional(),
     _nDownloadCount: z.number().int().optional(),
     _tsDateAdded: z.number().int().optional(),
@@ -88,7 +90,9 @@ export const fetchGameBananaSubmission = async (
   );
   if (response.status === 404) return null;
   if (!response.ok) {
-    throw new Error(`GameBanana profile request failed (${response.status})`);
+    throw new ProviderError(
+      `GameBanana profile request failed (${response.status})`,
+    );
   }
 
   const result = profileSnapshotSchema.safeParse(await response.json());
@@ -104,10 +108,13 @@ export const fetchGameBananaSubmission = async (
     return null;
   }
   const category =
-    profile._aSuperCategory?._sName ||
-    profile._aRootCategory?._sName ||
-    profile._aCategory?._sName ||
-    "Other";
+    [
+      profile._aSuperCategory?._sName,
+      profile._aRootCategory?._sName,
+      profile._aCategory?._sName,
+    ]
+      .map((name) => name?.trim())
+      .find(Boolean) ?? "Other";
   const slug = gameBananaIdentitySlug(identity);
   const addedAt = new Date((profile._tsDateAdded ?? 0) * 1_000);
   const updatedAt = new Date(
@@ -147,7 +154,9 @@ export const fetchGameBananaSubmission = async (
       isMap,
       audioUrl: profile._aPreviewMedia?._aMetadata?._sAudioUrl ?? null,
       downloadCount: profile._nDownloadCount ?? 0,
-      isNSFW: false,
+      isNSFW: Object.keys(profile._aContentRatings ?? {}).some((rating) =>
+        ["st", "sa", "lp", "pn", "nu"].includes(rating),
+      ),
       isObsolete: profile._bIsObsolete ?? false,
       isBlacklisted: false,
       blacklistReason: null,

--- a/apps/api/src/services/server-mods-resolver.test.ts
+++ b/apps/api/src/services/server-mods-resolver.test.ts
@@ -77,4 +77,59 @@ describe("ServerModsResolver", () => {
     expect(result.resolved.at(-1)?.reason).toBe("too_many_requirements");
     expect(result.missing).toHaveLength(55);
   });
+
+  it("does not let one slow lookup stall unrelated lookups", async () => {
+    const completed: string[] = [];
+    const resolver = new ServerModsResolver(
+      async (identity) => {
+        await new Promise((resolve) =>
+          setTimeout(resolve, identity.submissionId === "1" ? 200 : 1),
+        );
+        completed.push(identity.submissionId);
+        return null;
+      },
+      () => Promise.resolve([]),
+    );
+
+    await resolver.resolve(
+      Array.from({ length: 8 }, (_, index) => ({
+        id: `required-${index + 1}`,
+        provider: "gamebanana" as const,
+        url: `https://gamebanana.com/mods/${index + 1}`,
+      })),
+    );
+
+    expect(completed).toHaveLength(8);
+    expect(completed.at(-1)).toBe("1");
+  });
+
+  it("returns partial results once the deadline elapses", async () => {
+    const resolver = new ServerModsResolver(
+      async (identity) => {
+        if (Number(identity.submissionId) > 2) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+        return null;
+      },
+      () => Promise.resolve([]),
+      50,
+    );
+
+    const startedAt = Date.now();
+    const result = await resolver.resolve(
+      Array.from({ length: 6 }, (_, index) => ({
+        id: `required-${index + 1}`,
+        provider: "gamebanana" as const,
+        url: `https://gamebanana.com/mods/${index + 1}`,
+      })),
+    );
+
+    expect(Date.now() - startedAt).toBeLessThan(400);
+    expect(result.resolved).toHaveLength(6);
+    expect(result.resolved[0]?.reason).toBe("not_found");
+    expect(result.resolved[1]?.reason).toBe("not_found");
+    expect(
+      result.resolved.filter((item) => item.reason === "timed_out").length,
+    ).toBeGreaterThan(0);
+  });
 });

--- a/apps/api/src/services/server-mods-resolver.test.ts
+++ b/apps/api/src/services/server-mods-resolver.test.ts
@@ -47,4 +47,34 @@ describe("ServerModsResolver", () => {
     });
     expect(result.missing).toHaveLength(1);
   });
+
+  it("bounds provider concurrency and leaves excess requirements unresolved", async () => {
+    let active = 0;
+    let maxActive = 0;
+    let calls = 0;
+    const resolver = new ServerModsResolver(
+      async () => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        active -= 1;
+        return null;
+      },
+      () => Promise.resolve([]),
+    );
+    const result = await resolver.resolve(
+      Array.from({ length: 55 }, (_, index) => ({
+        id: `required-${index + 1}`,
+        provider: "gamebanana" as const,
+        url: `https://gamebanana.com/mods/${index + 1}`,
+      })),
+    );
+
+    expect(calls).toBe(50);
+    expect(maxActive).toBeLessThanOrEqual(4);
+    expect(result.resolved).toHaveLength(55);
+    expect(result.resolved.at(-1)?.reason).toBe("too_many_requirements");
+    expect(result.missing).toHaveLength(55);
+  });
 });

--- a/apps/api/src/services/server-mods-resolver.ts
+++ b/apps/api/src/services/server-mods-resolver.ts
@@ -15,6 +15,9 @@ const CACHE_TTL_MS = 5 * 60 * 1_000;
 const CACHE_MAX_ENTRIES = 256;
 const RESOLVE_CONCURRENCY = 4;
 const MAX_REQUIREMENTS = 50;
+// Kept below the server's idle timeout so a slow provider yields partial
+// results instead of a closed connection.
+const RESOLVE_DEADLINE_MS = 8_000;
 
 export interface ResolvedRequirement {
   name: string;
@@ -30,7 +33,8 @@ export interface ResolvedRequirement {
     | "provider_failure"
     | "policy_blocked"
     | "too_many_requirements"
-    | "custom_provider";
+    | "custom_provider"
+    | "timed_out";
 }
 
 export const parseGameBananaSubmissionUrl = (
@@ -120,6 +124,15 @@ const applyPolicy = (
   return corrected;
 };
 
+const requirementBase = (requirement: ServerRequiredMod) => ({
+  name: requirement.id,
+  provider: requirement.provider,
+  url: requirement.url,
+  version: requirement.version,
+});
+
+const DEADLINE_REACHED = Symbol("resolve-deadline");
+
 type FetchSubmission = (
   identity: GameBananaIdentity,
 ) => Promise<DirectGameBananaSubmission | null>;
@@ -138,6 +151,7 @@ export class ServerModsResolver {
   constructor(
     private readonly fetchSubmission: FetchSubmission = fetchGameBananaSubmission,
     private readonly loadPolicy: LoadPolicy = loadPolicyRules,
+    private readonly deadlineMs: number = RESOLVE_DEADLINE_MS,
   ) {}
 
   static getInstance(): ServerModsResolver {
@@ -157,26 +171,10 @@ export class ServerModsResolver {
     }
     const rules = await this.loadPolicy();
     const bounded = required.slice(0, MAX_REQUIREMENTS);
-    const resolved: ResolvedRequirement[] = [];
-    for (
-      let offset = 0;
-      offset < bounded.length;
-      offset += RESOLVE_CONCURRENCY
-    ) {
-      resolved.push(
-        ...(await Promise.all(
-          bounded
-            .slice(offset, offset + RESOLVE_CONCURRENCY)
-            .map((requirement) => this.resolveRequirement(requirement, rules)),
-        )),
-      );
-    }
+    const resolved = await this.resolveBounded(bounded, rules);
     for (const requirement of required.slice(MAX_REQUIREMENTS)) {
       resolved.push({
-        name: requirement.id,
-        provider: requirement.provider,
-        url: requirement.url,
-        version: requirement.version,
+        ...requirementBase(requirement),
         resolved: false,
         reason: "too_many_requirements",
       });
@@ -188,16 +186,63 @@ export class ServerModsResolver {
     };
   }
 
+  /**
+   * Resolves requirements with a fixed number of workers pulling from one
+   * shared iterator, so a slow provider lookup occupies a single slot instead
+   * of stalling a whole batch. Results start out as `timed_out` and are
+   * overwritten as each lookup lands, so a deadline miss returns partial
+   * results instead of holding the response open past the server's idle
+   * timeout.
+   */
+  private async resolveBounded(
+    bounded: ServerRequiredMod[],
+    rules: PolicyRule[],
+  ): Promise<ResolvedRequirement[]> {
+    const results: ResolvedRequirement[] = bounded.map((requirement) => ({
+      ...requirementBase(requirement),
+      resolved: false,
+      reason: "timed_out",
+    }));
+    let expired = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<typeof DEADLINE_REACHED>((resolveDeadline) => {
+      timer = setTimeout(() => {
+        expired = true;
+        resolveDeadline(DEADLINE_REACHED);
+      }, this.deadlineMs);
+    });
+
+    const queue = bounded.entries();
+    const worker = async (): Promise<void> => {
+      for (const [index, requirement] of queue) {
+        if (expired) break;
+        const outcome = await Promise.race([
+          this.resolveRequirement(requirement, rules),
+          deadline,
+        ]);
+        if (outcome === DEADLINE_REACHED) break;
+        results[index] = outcome;
+      }
+    };
+
+    try {
+      await Promise.all(
+        Array.from(
+          { length: Math.min(RESOLVE_CONCURRENCY, bounded.length) },
+          () => worker(),
+        ),
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+    return results;
+  }
+
   private async resolveRequirement(
     requirement: ServerRequiredMod,
     rules: PolicyRule[],
   ): Promise<ResolvedRequirement> {
-    const base = {
-      name: requirement.id,
-      provider: requirement.provider,
-      url: requirement.url,
-      version: requirement.version,
-    };
+    const base = requirementBase(requirement);
     if (requirement.provider === "custom") {
       return { ...base, resolved: false, reason: "custom_provider" };
     }

--- a/apps/api/src/services/server-mods-resolver.ts
+++ b/apps/api/src/services/server-mods-resolver.ts
@@ -13,6 +13,8 @@ import {
 
 const CACHE_TTL_MS = 5 * 60 * 1_000;
 const CACHE_MAX_ENTRIES = 256;
+const RESOLVE_CONCURRENCY = 4;
+const MAX_REQUIREMENTS = 50;
 
 export interface ResolvedRequirement {
   name: string;
@@ -27,6 +29,7 @@ export interface ResolvedRequirement {
     | "not_found"
     | "provider_failure"
     | "policy_blocked"
+    | "too_many_requirements"
     | "custom_provider";
 }
 
@@ -103,6 +106,15 @@ const applyPolicy = (
     if (correction.isNSFW !== undefined) {
       corrected.mod.isNSFW = correction.isNSFW;
     }
+    if (correction.isObsolete !== undefined) {
+      corrected.mod.isObsolete = correction.isObsolete;
+    }
+    if (correction.metadata !== undefined) {
+      corrected.mod.metadata = {
+        ...corrected.mod.metadata,
+        ...correction.metadata,
+      };
+    }
     if (correction.tags !== undefined) corrected.mod.tags = correction.tags;
   }
   return corrected;
@@ -144,11 +156,31 @@ export class ServerModsResolver {
       return { resolved: [], installed: [], missing: [] };
     }
     const rules = await this.loadPolicy();
-    const resolved = await Promise.all(
-      required.map((requirement) =>
-        this.resolveRequirement(requirement, rules),
-      ),
-    );
+    const bounded = required.slice(0, MAX_REQUIREMENTS);
+    const resolved: ResolvedRequirement[] = [];
+    for (
+      let offset = 0;
+      offset < bounded.length;
+      offset += RESOLVE_CONCURRENCY
+    ) {
+      resolved.push(
+        ...(await Promise.all(
+          bounded
+            .slice(offset, offset + RESOLVE_CONCURRENCY)
+            .map((requirement) => this.resolveRequirement(requirement, rules)),
+        )),
+      );
+    }
+    for (const requirement of required.slice(MAX_REQUIREMENTS)) {
+      resolved.push({
+        name: requirement.id,
+        provider: requirement.provider,
+        url: requirement.url,
+        version: requirement.version,
+        resolved: false,
+        reason: "too_many_requirements",
+      });
+    }
     return {
       resolved,
       installed: [],

--- a/apps/bot/src/commands/blacklist.test.ts
+++ b/apps/bot/src/commands/blacklist.test.ts
@@ -10,6 +10,14 @@ describe("parsePolicyIdentity", () => {
     });
   });
 
+  it("accepts the canonical sound slug", () => {
+    expect(parsePolicyIdentity("snd-42")).toEqual({
+      provider: "gamebanana",
+      submissionType: "sound",
+      submissionId: "42",
+    });
+  });
+
   it("accepts both GameBanana mod and sound URLs", () => {
     expect(parsePolicyIdentity("https://gamebanana.com/mods/42")).toMatchObject(
       {

--- a/apps/bot/src/lib/policy-identity.ts
+++ b/apps/bot/src/lib/policy-identity.ts
@@ -2,11 +2,12 @@ import { ValidationError } from "@deadlock-mods/common";
 import type { PolicyIdentity } from "@deadlock-mods/database";
 
 export const parsePolicyIdentity = (input: string): PolicyIdentity => {
-  if (/^[1-9]\d*$/.test(input)) {
+  const slug = /^(snd-)?([1-9]\d*)$/.exec(input.trim());
+  if (slug?.[2]) {
     return {
       provider: "gamebanana",
-      submissionType: "mod",
-      submissionId: input,
+      submissionType: slug[1] ? "sound" : "mod",
+      submissionId: slug[2],
     };
   }
 

--- a/apps/desktop/src-tauri/src/commands/downloads.rs
+++ b/apps/desktop/src-tauri/src/commands/downloads.rs
@@ -34,26 +34,14 @@ pub async fn queue_download(
     files.len()
   );
 
-  crate::providers::SubmissionRef::parse_slug(&mod_id)
-    .map_err(|_| Error::InvalidInput("Invalid download identity".to_string()))?;
-  policy.ensure_download_allowed(&mod_id)?;
-  if files.is_empty() || files.len() > 100 {
-    return Err(Error::InvalidInput(
-      "A download must contain between 1 and 100 files".to_string(),
-    ));
-  }
-
-  let mut resolved_files = Vec::with_capacity(files.len());
-  for file in files {
-    let resolved = if file.url.starts_with("gamebanana-file://") {
-      resolve_gamebanana_file(&catalog_state, &file.url, fileserver_preference.as_deref()).await?
-    } else {
-      validate_download_file_name(&file.name)?;
-      crate::download_manager::downloader::validate_download_url(&file.url)?;
-      file
-    };
-    resolved_files.push(resolved);
-  }
+  let resolved_files = resolve_download_files(
+    &catalog_state,
+    &policy,
+    &mod_id,
+    &files,
+    fileserver_preference.as_deref(),
+  )
+  .await?;
 
   let app_local_data_dir = app_handle
     .path()
@@ -75,45 +63,44 @@ pub async fn queue_download(
   manager.queue_download(task).await
 }
 
+pub(crate) async fn resolve_download_files(
+  catalog_state: &super::gamebanana_catalog::GameBananaCatalogState,
+  policy: &super::policy::PolicyState,
+  mod_id: &str,
+  files: &[DownloadFileDto],
+  fileserver_preference: Option<&str>,
+) -> Result<Vec<DownloadFileDto>, Error> {
+  crate::providers::SubmissionRef::parse_slug(mod_id)
+    .map_err(|_| Error::InvalidInput("Invalid download identity".to_string()))?;
+  policy.ensure_download_allowed(mod_id)?;
+  if files.is_empty() || files.len() > 100 {
+    return Err(Error::InvalidInput(
+      "A download must contain between 1 and 100 files".to_string(),
+    ));
+  }
+
+  let mut resolved_files = Vec::with_capacity(files.len());
+  for file in files {
+    let resolved = if file.url.starts_with("gamebanana-file://") {
+      resolve_gamebanana_file(catalog_state, mod_id, &file.url, fileserver_preference).await?
+    } else {
+      validate_download_file_name(&file.name)?;
+      crate::download_manager::downloader::validate_download_url(&file.url)?;
+      file.clone()
+    };
+    resolved_files.push(resolved);
+  }
+
+  Ok(resolved_files)
+}
+
 async fn resolve_gamebanana_file(
-  state: &State<'_, super::gamebanana_catalog::GameBananaCatalogState>,
+  state: &super::gamebanana_catalog::GameBananaCatalogState,
+  mod_id: &str,
   token: &str,
   fileserver_preference: Option<&str>,
 ) -> Result<DownloadFileDto, Error> {
-  let parsed = reqwest::Url::parse(token)
-    .map_err(|_| Error::InvalidInput("Invalid GameBanana file token".to_string()))?;
-  if parsed.scheme() != "gamebanana-file"
-    || parsed.query().is_some()
-    || parsed.fragment().is_some()
-    || !parsed.username().is_empty()
-    || parsed.password().is_some()
-  {
-    return Err(Error::InvalidInput(
-      "Invalid GameBanana file token".to_string(),
-    ));
-  }
-  let slug = parsed
-    .host_str()
-    .ok_or_else(|| Error::InvalidInput("GameBanana file token has no submission".to_string()))?;
-  let segments = parsed
-    .path_segments()
-    .map(Iterator::collect::<Vec<_>>)
-    .ok_or_else(|| Error::InvalidInput("GameBanana file token has no file".to_string()))?;
-  let [file_id] = segments.as_slice() else {
-    return Err(Error::InvalidInput(
-      "Invalid GameBanana file token".to_string(),
-    ));
-  };
-  if file_id.is_empty() {
-    return Err(Error::InvalidInput(
-      "GameBanana file token has no file".to_string(),
-    ));
-  }
-  let submission = crate::providers::SubmissionRef::parse_slug(slug)
-    .map_err(|_| Error::InvalidInput("Invalid GameBanana submission".to_string()))?;
-  let file_id = file_id
-    .parse::<u64>()
-    .map_err(|_| Error::InvalidInput("Invalid GameBanana file identity".to_string()))?;
+  let (submission, file_id) = parse_gamebanana_file_token(mod_id, token)?;
   let page = state
     .backend()?
     .client
@@ -175,6 +162,53 @@ async fn resolve_gamebanana_file(
     size: file.size,
     md5_checksum: file.md5,
   })
+}
+
+fn parse_gamebanana_file_token(
+  mod_id: &str,
+  token: &str,
+) -> Result<(crate::providers::SubmissionRef, u64), Error> {
+  let parsed = reqwest::Url::parse(token)
+    .map_err(|_| Error::InvalidInput("Invalid GameBanana file token".to_string()))?;
+  if parsed.scheme() != "gamebanana-file"
+    || parsed.query().is_some()
+    || parsed.fragment().is_some()
+    || !parsed.username().is_empty()
+    || parsed.password().is_some()
+    || parsed.port().is_some()
+  {
+    return Err(Error::InvalidInput(
+      "Invalid GameBanana file token".to_string(),
+    ));
+  }
+  let slug = parsed
+    .host_str()
+    .ok_or_else(|| Error::InvalidInput("GameBanana file token has no submission".to_string()))?;
+  let segments = parsed
+    .path_segments()
+    .map(Iterator::collect::<Vec<_>>)
+    .ok_or_else(|| Error::InvalidInput("GameBanana file token has no file".to_string()))?;
+  let [file_id] = segments.as_slice() else {
+    return Err(Error::InvalidInput(
+      "Invalid GameBanana file token".to_string(),
+    ));
+  };
+  if file_id.is_empty() {
+    return Err(Error::InvalidInput(
+      "GameBanana file token has no file".to_string(),
+    ));
+  }
+  let submission = crate::providers::SubmissionRef::parse_slug(slug)
+    .map_err(|_| Error::InvalidInput("Invalid GameBanana submission".to_string()))?;
+  if slug != mod_id || submission.provider != crate::providers::SubmissionProvider::Gamebanana {
+    return Err(Error::InvalidInput(
+      "GameBanana file token does not match the requested submission".to_string(),
+    ));
+  }
+  let file_id = file_id
+    .parse::<u64>()
+    .map_err(|_| Error::InvalidInput("Invalid GameBanana file identity".to_string()))?;
+  Ok((submission, file_id))
 }
 
 fn validate_download_file_name(file_name: &str) -> Result<(), Error> {
@@ -557,5 +591,17 @@ mod tests {
         "accepted {name:?}"
       );
     }
+  }
+
+  #[test]
+  fn gamebanana_file_tokens_must_match_the_requested_submission() {
+    let (submission, file_id) =
+      parse_gamebanana_file_token("snd-42", "gamebanana-file://snd-42/7").unwrap();
+    assert_eq!(submission.to_slug().unwrap(), "snd-42");
+    assert_eq!(file_id, 7);
+
+    assert!(parse_gamebanana_file_token("42", "gamebanana-file://snd-42/7").is_err());
+    assert!(parse_gamebanana_file_token("42", "gamebanana-file://43/7").is_err());
+    assert!(parse_gamebanana_file_token("42", "gamebanana-file://42/7?mirror=evil").is_err());
   }
 }

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -11,9 +11,9 @@ use crate::mod_manager::vpk_manager::VpkManager;
 use crate::mod_manager::vpk_manager::staging::VpkSnapshot;
 use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use serde::{Deserialize, Serialize};
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Manager, State};
 
-use super::downloads::get_download_manager;
+use super::downloads::{get_download_manager, resolve_download_files};
 use super::fonts::{apply_font_cleanup, prepare_font_cleanup};
 use super::state::MANAGER;
 use crate::download_manager::{DownloadFileDto, DownloadTask};
@@ -217,6 +217,8 @@ pub struct InstalledModInfo {
 #[tauri::command]
 pub async fn batch_update_mods(
   app_handle: AppHandle,
+  catalog_state: State<'_, super::gamebanana_catalog::GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   mods: Vec<BatchUpdateMod>,
   profile_folder: String,
   skip_backup: bool,
@@ -237,6 +239,20 @@ pub async fn batch_update_mods(
     return Err(Error::InvalidInput(
       "No mods provided for update".to_string(),
     ));
+  }
+
+  let mut resolved_downloads = Vec::with_capacity(total_mods);
+  for mod_data in &mods {
+    resolved_downloads.push(
+      resolve_download_files(
+        &catalog_state,
+        &policy,
+        &mod_data.mod_id,
+        &mod_data.download_files,
+        None,
+      )
+      .await?,
+    );
   }
 
   let (addons_path, filename) = {
@@ -302,7 +318,7 @@ pub async fn batch_update_mods(
   let mut failed = Vec::new();
   let mut installed_mods = Vec::new();
 
-  for (index, mod_data) in mods.iter().enumerate() {
+  for (index, (mod_data, download_files)) in mods.iter().zip(resolved_downloads).enumerate() {
     let progress_pct = (index as f64 / total_mods as f64) * 100.0;
 
     app_handle
@@ -380,7 +396,7 @@ pub async fn batch_update_mods(
 
     let task = DownloadTask {
       mod_id: mod_data.mod_id.clone(),
-      files: mod_data.download_files.clone(),
+      files: download_files,
       target_dir,
       profile_folder: profile_folder_option.clone(),
       is_profile_import: false,

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -251,9 +251,11 @@ pub async fn batch_update_mods(
         &mod_data.download_files,
         None,
       )
-      .await?,
+      .await
+      .map_err(|error| format!("Failed to resolve download files: {error:?}")),
     );
   }
+  let has_updatable_mods = resolved_downloads.iter().any(Result::is_ok);
 
   let (addons_path, filename) = {
     let mut mod_manager = MANAGER.lock().unwrap();
@@ -266,7 +268,7 @@ pub async fn batch_update_mods(
     (addons_path, filename)
   };
 
-  if !skip_backup {
+  if !skip_backup && has_updatable_mods {
     log::info!("Creating addons backup before updating mods");
 
     let backup_dir = {
@@ -319,6 +321,17 @@ pub async fn batch_update_mods(
   let mut installed_mods = Vec::new();
 
   for (index, (mod_data, download_files)) in mods.iter().zip(resolved_downloads).enumerate() {
+    let download_files = match download_files {
+      Ok(files) => files,
+      Err(reason) => {
+        log::error!(
+          "Failed to resolve downloads for mod {}: {reason}",
+          mod_data.mod_id
+        );
+        failed.push((mod_data.mod_id.clone(), reason));
+        continue;
+      }
+    };
     let progress_pct = (index as f64 / total_mods as f64) * 100.0;
 
     app_handle

--- a/apps/desktop/src-tauri/src/commands/policy.rs
+++ b/apps/desktop/src-tauri/src/commands/policy.rs
@@ -230,13 +230,7 @@ impl PolicyState {
     {
       return Err(Error::Network("Policy manifest is too large".to_string()));
     }
-    let bytes = response
-      .bytes()
-      .await
-      .map_err(|error| Error::Network(error.to_string()))?;
-    if bytes.len() > MAX_POLICY_BYTES {
-      return Err(Error::Network("Policy manifest is too large".to_string()));
-    }
+    let bytes = read_bounded_response(response, MAX_POLICY_BYTES).await?;
     let next = parse_manifest(&bytes)?;
     let current_revision = self
       .manifest
@@ -254,6 +248,30 @@ impl PolicyState {
       .map_err(|_| Error::BackgroundTaskFailed("Policy lock poisoned".to_string()))? = next;
     Ok(true)
   }
+}
+
+async fn read_bounded_response(
+  mut response: reqwest::Response,
+  max_bytes: usize,
+) -> Result<Vec<u8>, Error> {
+  let mut body = Vec::with_capacity(
+    response
+      .content_length()
+      .and_then(|length| usize::try_from(length).ok())
+      .unwrap_or_default()
+      .min(max_bytes),
+  );
+  while let Some(chunk) = response
+    .chunk()
+    .await
+    .map_err(|error| Error::Network(error.to_string()))?
+  {
+    if body.len().saturating_add(chunk.len()) > max_bytes {
+      return Err(Error::Network("Policy manifest is too large".to_string()));
+    }
+    body.extend_from_slice(&chunk);
+  }
+  Ok(body)
 }
 
 fn should_replace(current_revision: u64, next_revision: u64) -> bool {

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -5,9 +5,9 @@ use crate::mod_manager::Mod;
 use crate::mod_manager::shard::{ShardIndex, ShardLocator};
 use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use serde::{Deserialize, Serialize};
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Manager, State};
 
-use super::downloads::get_download_manager;
+use super::downloads::{get_download_manager, resolve_download_files};
 use super::mods::InstalledModInfo;
 use super::state::MANAGER;
 
@@ -305,6 +305,8 @@ pub async fn show_profile_vpk_in_folder(
 #[tauri::command]
 pub async fn import_profile_batch(
   app_handle: AppHandle,
+  catalog_state: State<'_, super::gamebanana_catalog::GameBananaCatalogState>,
+  policy: State<'_, super::policy::PolicyState>,
   profile_name: String,
   _profile_description: String,
   profile_folder: String,
@@ -323,6 +325,20 @@ pub async fn import_profile_batch(
     return Err(Error::InvalidInput(
       "No mods provided for import".to_string(),
     ));
+  }
+
+  let mut resolved_downloads = Vec::with_capacity(total_mods);
+  for mod_data in &mods {
+    resolved_downloads.push(
+      resolve_download_files(
+        &catalog_state,
+        &policy,
+        &mod_data.mod_id,
+        &mod_data.download_files,
+        None,
+      )
+      .await?,
+    );
   }
 
   let final_profile_folder = if import_type == "create" {
@@ -357,7 +373,7 @@ pub async fn import_profile_batch(
 
   let mut download_results: Vec<Result<(), String>> = Vec::new();
 
-  for (index, mod_data) in mods.iter().enumerate() {
+  for (index, (mod_data, download_files)) in mods.iter().zip(resolved_downloads).enumerate() {
     app_handle
       .emit(
         "profile-import-progress",
@@ -379,7 +395,7 @@ pub async fn import_profile_batch(
 
     let task = DownloadTask {
       mod_id: mod_data.mod_id.clone(),
-      files: mod_data.download_files.clone(),
+      files: download_files,
       target_dir,
       profile_folder: Some(final_profile_folder.clone()),
       is_profile_import: true,

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -337,7 +337,8 @@ pub async fn import_profile_batch(
         &mod_data.download_files,
         None,
       )
-      .await?,
+      .await
+      .map_err(|error| format!("Failed to resolve download files: {error:?}")),
     );
   }
 
@@ -374,6 +375,19 @@ pub async fn import_profile_batch(
   let mut download_results: Vec<Result<(), String>> = Vec::new();
 
   for (index, (mod_data, download_files)) in mods.iter().zip(resolved_downloads).enumerate() {
+    // download_results stays index-aligned with mods; the install loop below zips them.
+    let download_files = match download_files {
+      Ok(files) => files,
+      Err(reason) => {
+        log::error!(
+          "Failed to resolve downloads for mod {}: {reason}",
+          mod_data.mod_id
+        );
+        download_results.push(Err(reason));
+        continue;
+      }
+    };
+
     app_handle
       .emit(
         "profile-import-progress",

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/store.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/store.rs
@@ -8,6 +8,8 @@ use diesel::sqlite::Sqlite;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+pub(super) const INCOMPLETE_SNAPSHOT: &str = "snapshot_with_invalid_records";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogRecord {
@@ -174,17 +176,26 @@ impl Catalog {
       .pool
       .run(move |connection| {
         connection.transaction::<_, Error, _>(|connection| {
-          let tombstoned = diesel::update(
-            submission::table
-              .filter(submission::is_tombstoned.eq(false))
-              .filter(
-                submission::last_seen_snapshot
-                  .is_null()
-                  .or(submission::last_seen_snapshot.ne(&snapshot_id)),
-              ),
-          )
-          .set(submission::is_tombstoned.eq(true))
-          .execute(connection)?;
+          let incomplete_snapshot = sync_state::table
+            .find(INCOMPLETE_SNAPSHOT)
+            .select(sync_state::value)
+            .first::<String>(connection)
+            .optional()?;
+          let tombstoned = if incomplete_snapshot.as_deref() == Some(snapshot_id.as_str()) {
+            0
+          } else {
+            diesel::update(
+              submission::table
+                .filter(submission::is_tombstoned.eq(false))
+                .filter(
+                  submission::last_seen_snapshot
+                    .is_null()
+                    .or(submission::last_seen_snapshot.ne(&snapshot_id)),
+                ),
+            )
+            .set(submission::is_tombstoned.eq(true))
+            .execute(connection)?
+          };
           diesel::update(sync_cursor::table)
             .set((
               sync_cursor::next_page.eq(1_i64),
@@ -192,6 +203,9 @@ impl Catalog {
               sync_cursor::snapshot_complete.eq(false),
             ))
             .execute(connection)?;
+          if incomplete_snapshot.as_deref() != Some(snapshot_id.as_str()) {
+            diesel::delete(sync_state::table.find(INCOMPLETE_SNAPSHOT)).execute(connection)?;
+          }
           Ok(tombstoned)
         })
       })

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/sync.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/sync.rs
@@ -1,4 +1,4 @@
-use super::store::{Catalog, CatalogRecord};
+use super::store::{Catalog, CatalogRecord, INCOMPLETE_SNAPSHOT};
 use crate::errors::Error;
 use crate::providers::gamebanana::hero_registry;
 use crate::providers::gamebanana::{BulkHydration, GameBananaClient, IndexPage};
@@ -97,6 +97,19 @@ impl CatalogSync {
   ) -> Result<SyncOutcome, Error> {
     let _sync_guard = self.sync_lock.lock().await;
     if force_reconcile
+      || self
+        .catalog
+        .cursor(SubmissionType::Mod)
+        .await?
+        .snapshot_id
+        .is_some()
+      || self
+        .catalog
+        .cursor(SubmissionType::Sound)
+        .await?
+        .snapshot_id
+        .is_some()
+      || self.catalog.state(INCOMPLETE_SNAPSHOT).await?.is_some()
       || self.catalog.count_visible().await? == 0
       || self.full_reconciliation_due().await?
     {
@@ -130,6 +143,15 @@ impl CatalogSync {
           .index(submission_type, page_number, false, cancel)
           .await?;
         let index_records = page.valid_records();
+        if index_records.len() != page.records.len() {
+          self
+            .catalog
+            .set_state(INCOMPLETE_SNAPSHOT, snapshot_id.clone())
+            .await?;
+          log::warn!(
+            "GameBanana index skipped invalid records; retaining unseen catalog entries for this snapshot"
+          );
+        }
         let high_water_mark = index_records
           .iter()
           .filter_map(|record| record.date_modified)
@@ -170,10 +192,12 @@ impl CatalogSync {
     }
 
     self.catalog.complete_snapshot(snapshot_id).await?;
-    self
-      .catalog
-      .set_state(LAST_FULL_SYNC_AT, unix_timestamp().to_string())
-      .await?;
+    if self.catalog.state(INCOMPLETE_SNAPSHOT).await?.is_none() {
+      self
+        .catalog
+        .set_state(LAST_FULL_SYNC_AT, unix_timestamp().to_string())
+        .await?;
+    }
     Ok(())
   }
 
@@ -528,6 +552,13 @@ mod tests {
       ])),
     };
     let sync = CatalogSync::with_source(catalog.clone(), first_source);
+    catalog
+      .set_state(
+        super::LAST_FULL_SYNC_AT,
+        super::unix_timestamp().to_string(),
+      )
+      .await
+      .unwrap();
     assert!(sync.full_sync(&CancellationToken::new()).await.is_err());
     assert_eq!(catalog.count_visible().await.unwrap(), 1);
     assert_eq!(
@@ -539,7 +570,13 @@ mod tests {
       pages: Mutex::new(VecDeque::from([Ok(page(2, true)), Ok(page(3, true))])),
     };
     let sync = CatalogSync::with_source(catalog.clone(), resumed_source);
-    sync.full_sync(&CancellationToken::new()).await.unwrap();
+    assert_eq!(
+      sync
+        .synchronize(false, false, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Full
+    );
     assert_eq!(catalog.count_visible().await.unwrap(), 3);
     assert!(
       catalog
@@ -548,6 +585,78 @@ mod tests {
         .unwrap()
         .snapshot_id
         .is_none()
+    );
+  }
+
+  #[tokio::test]
+  async fn malformed_rows_do_not_tombstone_cached_entries_after_resuming() {
+    let directory = tempdir().unwrap();
+    let catalog = super::Catalog::open(directory.path().join("catalog.sqlite3"), 2)
+      .await
+      .unwrap();
+    let initial = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::from([Ok(page(1, true)), Ok(page(4, true))])),
+      },
+    );
+    initial.full_sync(&CancellationToken::new()).await.unwrap();
+
+    let mut malformed = page(2, false);
+    malformed.records.push(serde_json::json!({
+      "_idRow": 1,
+      "_sModelName": "Mod",
+      "_sName": []
+    }));
+    let interrupted = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::from([
+          Ok(malformed),
+          Err(Error::ProviderUnavailable("offline".to_string())),
+        ])),
+      },
+    );
+    assert!(
+      interrupted
+        .full_sync(&CancellationToken::new())
+        .await
+        .is_err()
+    );
+
+    let resumed = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::from([Ok(page(3, true)), Ok(page(4, true))])),
+      },
+    );
+    resumed.full_sync(&CancellationToken::new()).await.unwrap();
+    assert_eq!(catalog.count_visible().await.unwrap(), 4);
+    assert!(
+      catalog
+        .state(super::INCOMPLETE_SNAPSHOT)
+        .await
+        .unwrap()
+        .is_some()
+    );
+
+    let clean = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::from([Ok(page(2, true)), Ok(page(4, true))])),
+      },
+    );
+    assert_eq!(
+      clean
+        .synchronize(false, false, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Full
+    );
+    assert_eq!(catalog.count_visible().await.unwrap(), 2);
+    assert_eq!(
+      catalog.state(super::INCOMPLETE_SNAPSHOT).await.unwrap(),
+      None
     );
   }
 

--- a/apps/desktop/src-tauri/src/providers/gamebanana/catalog/sync.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/catalog/sync.rs
@@ -13,6 +13,8 @@ const FULL_RECONCILIATION_INTERVAL: Duration = Duration::from_secs(7 * 24 * 60 *
 const HYDRATION_BATCH_SIZE: usize = 50;
 const LAST_INCREMENTAL_AT: &str = "last_incremental_at";
 const LAST_FULL_SYNC_AT: &str = "last_full_sync_at";
+const LAST_INCOMPLETE_SNAPSHOT_AT: &str = "last_incomplete_snapshot_at";
+const INCOMPLETE_RETRY_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 
 type SourceFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
 
@@ -96,6 +98,21 @@ impl CatalogSync {
     cancel: &CancellationToken,
   ) -> Result<SyncOutcome, Error> {
     let _sync_guard = self.sync_lock.lock().await;
+    // A completed but malformed snapshot retains cached entries. Avoid crawling
+    // the same malformed index again on every catalog request, including when
+    // the catalog is empty or its last successful full sync is overdue.
+    if !force_reconcile && self.catalog.state(INCOMPLETE_SNAPSHOT).await?.is_some() {
+      let last_attempt = self
+        .catalog
+        .state(LAST_INCOMPLETE_SNAPSHOT_AT)
+        .await?
+        .and_then(|value| value.parse::<u64>().ok());
+      if last_attempt.is_some_and(|last| {
+        unix_timestamp().saturating_sub(last) < INCOMPLETE_RETRY_INTERVAL.as_secs()
+      }) {
+        return Ok(SyncOutcome::Throttled);
+      }
+    }
     if force_reconcile
       || self
         .catalog
@@ -196,6 +213,11 @@ impl CatalogSync {
       self
         .catalog
         .set_state(LAST_FULL_SYNC_AT, unix_timestamp().to_string())
+        .await?;
+    } else {
+      self
+        .catalog
+        .set_state(LAST_INCOMPLETE_SNAPSHOT_AT, unix_timestamp().to_string())
         .await?;
     }
     Ok(())
@@ -640,6 +662,32 @@ mod tests {
         .is_some()
     );
 
+    let throttled = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::new()),
+      },
+    );
+    assert_eq!(
+      throttled
+        .synchronize(false, false, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Throttled
+    );
+    assert_eq!(
+      throttled
+        .synchronize(true, false, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Throttled
+    );
+    // Expire only the retry timestamp, without waiting in the test.
+    catalog
+      .set_state(super::LAST_INCOMPLETE_SNAPSHOT_AT, "0".to_string())
+      .await
+      .unwrap();
+
     let clean = CatalogSync::with_source(
       catalog.clone(),
       FakeSource {
@@ -658,6 +706,71 @@ mod tests {
       catalog.state(super::INCOMPLETE_SNAPSHOT).await.unwrap(),
       None
     );
+  }
+
+  #[tokio::test]
+  async fn incomplete_empty_catalog_retries_are_persisted_and_explicitly_overridable() {
+    let directory = tempdir().unwrap();
+    let catalog = super::Catalog::open(directory.path().join("catalog.sqlite3"), 2)
+      .await
+      .unwrap();
+    let mut malformed = page(1, true);
+    malformed.records = vec![serde_json::json!({"_idRow": "invalid"})];
+    let sync = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::from([Ok(malformed.clone()), Ok(malformed)])),
+      },
+    );
+    sync
+      .synchronize(false, false, &CancellationToken::new())
+      .await
+      .unwrap();
+    assert_eq!(catalog.count_visible().await.unwrap(), 0);
+    assert!(
+      catalog
+        .state(super::LAST_FULL_SYNC_AT)
+        .await
+        .unwrap()
+        .is_none()
+    );
+    drop(sync);
+    // A fresh synchronizer reads the persisted backoff and makes no request.
+    let restarted = CatalogSync::with_source(
+      catalog.clone(),
+      FakeSource {
+        pages: Mutex::new(VecDeque::from([Ok(page(2, true)), Ok(page(4, true))])),
+      },
+    );
+    assert_eq!(
+      restarted
+        .synchronize(false, false, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Throttled
+    );
+    assert_eq!(
+      restarted
+        .synchronize(false, true, &CancellationToken::new())
+        .await
+        .unwrap(),
+      super::SyncOutcome::Full
+    );
+    assert!(
+      catalog
+        .state(super::INCOMPLETE_SNAPSHOT)
+        .await
+        .unwrap()
+        .is_none()
+    );
+    assert!(
+      catalog
+        .state(super::LAST_FULL_SYNC_AT)
+        .await
+        .unwrap()
+        .is_some()
+    );
+    assert_eq!(catalog.count_visible().await.unwrap(), 2);
   }
 
   #[tokio::test]

--- a/apps/desktop/src-tauri/src/providers/gamebanana/models.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/models.rs
@@ -16,7 +16,7 @@ pub struct PageMetadata {
 pub struct IndexPage {
   #[serde(rename = "_aMetadata", default)]
   pub metadata: PageMetadata,
-  #[serde(rename = "_aRecords", default)]
+  #[serde(rename = "_aRecords")]
   pub records: Vec<serde_json::Value>,
 }
 
@@ -417,6 +417,15 @@ mod tests {
         vec![1, 3]
       );
     }
+  }
+
+  #[test]
+  fn missing_index_records_are_not_an_empty_catalog() {
+    let response = serde_json::json!({
+      "_aMetadata": {"_bIsComplete": true}
+    });
+
+    assert!(serde_json::from_value::<IndexPage>(response).is_err());
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/providers/submission_ref.rs
+++ b/apps/desktop/src-tauri/src/providers/submission_ref.rs
@@ -18,7 +18,7 @@ pub enum SubmissionType {
   Sound,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 #[ts(export, rename_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub struct SubmissionRef {
@@ -71,18 +71,55 @@ impl SubmissionRef {
   pub fn to_slug(&self) -> Result<String, ParseSubmissionRefError> {
     match (self.provider, self.submission_type) {
       (SubmissionProvider::Gamebanana, SubmissionType::Mod)
-        if is_canonical_gamebanana_id(&self.submission_id) => Ok(self.submission_id.clone()),
-      (SubmissionProvider::Gamebanana, SubmissionType::Sound)
-        if is_canonical_gamebanana_id(&self.submission_id) => {
-        Ok(format!("snd-{}", self.submission_id))
+        if is_canonical_gamebanana_id(&self.submission_id) =>
+      {
+        Ok(self.submission_id.clone())
+      }
+      (SubmissionProvider::Gamebanana, SubmissionType::Sound) => {
+        is_canonical_gamebanana_id(&self.submission_id)
+          .then(|| format!("snd-{}", self.submission_id))
+          .ok_or_else(|| self.invalid())
       }
       (SubmissionProvider::Local, SubmissionType::Mod) if is_uuid(&self.submission_id) => {
         Ok(format!("local-{}", self.submission_id.to_ascii_lowercase()))
       }
-      _ => Err(ParseSubmissionRefError {
-        slug: format!("{:?}:{:?}:{}", self.provider, self.submission_type, self.submission_id),
-      }),
+      _ => Err(self.invalid()),
     }
+  }
+
+  fn invalid(&self) -> ParseSubmissionRefError {
+    ParseSubmissionRefError {
+      slug: format!(
+        "{:?}:{:?}:{}",
+        self.provider, self.submission_type, self.submission_id
+      ),
+    }
+  }
+}
+
+impl<'de> Deserialize<'de> for SubmissionRef {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Fields {
+      provider: SubmissionProvider,
+      submission_type: SubmissionType,
+      submission_id: String,
+    }
+
+    let fields = Fields::deserialize(deserializer)?;
+    let submission = Self {
+      provider: fields.provider,
+      submission_type: fields.submission_type,
+      submission_id: fields.submission_id,
+    };
+    submission
+      .to_slug()
+      .map(|_| submission)
+      .map_err(serde::de::Error::custom)
   }
 }
 
@@ -180,6 +217,24 @@ mod tests {
       "mod-1",
     ] {
       assert!(SubmissionRef::parse_slug(slug).is_err(), "accepted {slug}");
+    }
+  }
+
+  #[test]
+  fn deserialization_rejects_invalid_provider_type_and_id_combinations() {
+    for value in [
+      serde_json::json!({
+        "provider": "local",
+        "submissionType": "sound",
+        "submissionId": "550e8400-e29b-41d4-a716-446655440000"
+      }),
+      serde_json::json!({
+        "provider": "gamebanana",
+        "submissionType": "mod",
+        "submissionId": "01"
+      }),
+    ] {
+      assert!(serde_json::from_value::<SubmissionRef>(value).is_err());
     }
   }
 }

--- a/apps/docs/content/docs/developer-docs/architecture.mdx
+++ b/apps/docs/content/docs/developer-docs/architecture.mdx
@@ -233,31 +233,26 @@ graph TD
 
 ```mermaid
 sequenceDiagram
-    participant C as Client
-    participant API as API Server
-    participant DB as PostgreSQL
+    participant UI as Desktop UI
+    participant Tauri as Tauri Backend
+    participant Catalog as Local SQLite Catalog
     participant GB as GameBanana
-    participant Cache as Redis
+    participant API as DMM API
 
-    C->>API: Request mod data
-    API->>Cache: Check cache
-    alt Cache hit
-        Cache->>API: Return cached data
-        API->>C: Return response
-    else Cache miss
-        API->>DB: Query database
-        alt Data exists
-            DB->>API: Return data
-            API->>Cache: Update cache
-            API->>C: Return response
-        else Data missing
-            API->>GB: Fetch from GameBanana
-            GB->>API: Return external data
-            API->>DB: Store data
-            API->>Cache: Update cache
-            API->>C: Return response
-        end
+    UI->>Tauri: Browse or search submissions
+    Tauri->>Catalog: Query cached metadata
+    Catalog-->>Tauri: Return page
+    Tauri-->>UI: Return results
+
+    opt Catalog refresh is due
+        Tauri->>GB: Fetch index and profile data
+        GB-->>Tauri: Return submissions
+        Tauri->>Catalog: Upsert and reconcile snapshot
     end
+
+    Tauri->>API: Refresh moderation policy
+    API-->>Tauri: Return policy manifest
+    Tauri->>Catalog: Apply policy when reading results
 ```
 
 ## Mirror Service Architecture

--- a/apps/docs/content/docs/developer-docs/architecture.mdx
+++ b/apps/docs/content/docs/developer-docs/architecture.mdx
@@ -229,7 +229,7 @@ graph TD
 - Transaction management
 - Query optimization
 
-### Data Flow Architecture
+## Desktop Catalog Data Flow
 
 ```mermaid
 sequenceDiagram

--- a/packages/shared/src/schemas/server-browser.schemas.ts
+++ b/packages/shared/src/schemas/server-browser.schemas.ts
@@ -149,6 +149,7 @@ export const ResolvedRequirementSchema = z.object({
       "policy_blocked",
       "too_many_requirements",
       "custom_provider",
+      "timed_out",
     ])
     .optional(),
   mod: ModDtoSchema.extend({

--- a/packages/shared/src/schemas/server-browser.schemas.ts
+++ b/packages/shared/src/schemas/server-browser.schemas.ts
@@ -147,6 +147,7 @@ export const ResolvedRequirementSchema = z.object({
       "not_found",
       "provider_failure",
       "policy_blocked",
+      "too_many_requirements",
       "custom_provider",
     ])
     .optional(),
@@ -163,7 +164,7 @@ export const ResolvedRequirementSchema = z.object({
 });
 
 export const ResolveModsInputSchema = z.object({
-  required_mods: z.array(ModRequirementSchema),
+  required_mods: z.array(ModRequirementSchema).max(50),
 });
 
 export const ResolveModsResponseSchema = z.object({


### PR DESCRIPTION
## Description

This follow-up fixes the problems found while reviewing the full GameBanana migration stack:

- resolve and validate GameBanana file tokens for profile imports and batch updates before replacing installed files
- resume interrupted catalog reconciliations and keep cached entries when an upstream page contains malformed rows
- preserve GameBanana NSFW and policy-corrected metadata in server mod resolution
- bound server requirement lookups and policy manifest memory usage
- reject invalid `SubmissionRef` values and accept canonical `snd-` IDs in moderation commands
- update the architecture guide to describe the local SQLite catalog

## Type of Change

- [x] ≡ƒÉ¢ Bug fix (non-breaking change which fixes an issue)
- [ ] Γ£¿ New feature (non-breaking change which adds functionality)
- [ ] ≡ƒÆÑ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ≡ƒôÜ Documentation update
- [ ] ≡ƒöº Code refactoring (no functional changes)
- [x] ≡ƒº¬ Tests (adding or updating tests)
- [ ] ≡ƒö¿ Chore (maintenance, dependency updates, etc.)

## Related Issues

- Related to #673

## AI Disclosure

- [ ] No significant AI assistance used
- [x] AI-assisted ΓÇö Tool: Codex, Used for: implementing human written plan and prototyping

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in both development and production-like environments

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [AI Policy](./AI_POLICY.md)
- [x] My code follows the style guidelines of this project (`pnpm lint` passes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] I have tested the changes on multiple platforms (if applicable)
- [x] I have generated a changeset for my changes (if applicable) - run `pnpm changeset`

## Additional Notes

This is stacked on #703 and should merge after it.

## For Maintainers

- [x] This PR requires a version bump
- [x] This PR requires documentation updates
- [x] This PR affects the public API
- [ ] This PR requires migration instructions

## Stack tracking

Tracked in #673 (PR 10 of 19). Based on #703. Followed by #694.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes GameBanana migration and resolution issues across the desktop app, API, bot, shared package, and documentation.

## Changes

- **Desktop**
  - Validates GameBanana file tokens before replacing installed files.
  - Resolves downloads per mod and reports individual failures without aborting the batch.
  - Defers destructive updates until download resolution completes.
  - Recovers interrupted catalog syncs without deleting cached entries when upstream records are malformed.
  - Limits policy manifest downloads to a fixed response size.
  - Rejects invalid `SubmissionRef` combinations.

- **API and shared package**
  - Preserves NSFW, category, obsolete, and corrected policy metadata during submission and server mod resolution.
  - Limits server requirements to 50 entries.
  - Uses bounded shared-worker concurrency and an 8-second deadline.
  - Reports unresolved requirements as `too_many_requirements` or `timed_out`.
  - Keeps partial server resolution results available to clients.

- **Bot**
  - Accepts canonical `snd-` GameBanana sound submission IDs in moderation commands.

- **Documentation**
  - Updates the architecture diagram to show the desktop Tauri backend, local SQLite catalog, GameBanana refreshes, and DMM policy retrieval.

- **Tests and release metadata**
  - Adds coverage for token validation, catalog recovery, metadata preservation, resolver concurrency, deadlines, and policy identity parsing.
  - Adds patch changesets for the API, bot, desktop, and shared packages.

No changes affect the `www` app. No database migration, Tauri plugin change, or Rust FFI boundary change is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-followup-20260909 -->
Review fixes: incomplete full catalog crawls now use a persisted six-hour retry backoff, including for an empty catalog, with an explicit reconciliation override. Tests cover throttling, expiry, persistence, and clean recovery. The desktop catalog diagram now has a matching section heading, and inherited identity serialization returns Result without a panic wrapper.

Integrated-stack validation: 363 Rust tests and 326 desktop Bun tests pass, along with workspace/E2E typechecks and formatting/lint checks.

