### PR TITLE
feat(desktop): distinguish salt ingest source by username

### DIFF
--- a/apps/desktop/src-tauri/src/ingest_tool/scan_cache.rs
+++ b/apps/desktop/src-tauri/src/ingest_tool/scan_cache.rs
@@ -1,5 +1,5 @@
 use crate::ingest_tool::ingestion_cache;
-use crate::ingest_tool::utils::Salts;
+use crate::ingest_tool::utils::{CACHE_SCAN_USERNAME, LIVE_WATCHER_USERNAME, Salts};
 use memchr::{memchr, memmem};
 use notify::event::{CreateKind, ModifyKind};
 use notify::{EventKind, RecursiveMode, Watcher};
@@ -109,7 +109,7 @@ pub async fn initial_cache_dir_ingest(cache_dir: &Path) {
   scan_directory(cache_dir, &mut results);
   let salts = results
     .into_iter()
-    .filter_map(|url| Salts::from_url(&url))
+    .filter_map(|url| Salts::from_url(&url, CACHE_SCAN_USERNAME))
     .collect::<Vec<_>>();
 
   if salts.is_empty() {
@@ -158,7 +158,7 @@ pub async fn watch_cache_dir(
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         for path in event.paths {
           if let Some(url) = extract_replay_url(&path)
-            && let Some(salts) = Salts::from_url(&url)
+            && let Some(salts) = Salts::from_url(&url, LIVE_WATCHER_USERNAME)
           {
             // Check if we've already ingested this salt using the shared cache
             let is_new_metadata =

--- a/apps/desktop/src-tauri/src/ingest_tool/utils.rs
+++ b/apps/desktop/src-tauri/src/ingest_tool/utils.rs
@@ -2,6 +2,9 @@ use crate::ingest_tool::error::IngestError;
 use serde::Serialize;
 use tokio::time::{Duration, sleep};
 
+pub const CACHE_SCAN_USERNAME: &str = "Mod Manager (Cache)";
+pub const LIVE_WATCHER_USERNAME: &str = "Mod Manager (Live)";
+
 #[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Salts {
   pub match_id: u64,
@@ -12,7 +15,7 @@ pub struct Salts {
 }
 
 impl Salts {
-  pub fn from_url(url: &str) -> Option<Self> {
+  pub fn from_url(url: &str, username: &str) -> Option<Self> {
     // Expect URLs like: http://replay404.valve.net/1422450/37959196_937530290.meta.bz2 or http://replay183.valve.net/1422450/42476710_428480166.dem.bz2
     // Strip query parameters if present
     let base_url = url.split_once('?').map_or(url, |(path, _)| path);
@@ -31,7 +34,7 @@ impl Salts {
         match_id: match_str.parse().ok()?,
         metadata_salt: salt_str.parse().ok(),
         replay_salt: None,
-        username: "Mod Manager".to_string(),
+        username: username.to_string(),
       })
     } else if name.ends_with(".dem.bz2") {
       let name = name.strip_suffix(".dem.bz2")?;
@@ -42,7 +45,7 @@ impl Salts {
         match_id: match_str.parse().ok()?,
         replay_salt: salt_str.parse().ok(),
         metadata_salt: None,
-        username: "Mod Manager".to_string(),
+        username: username.to_string(),
       })
     } else {
       None
@@ -171,7 +174,7 @@ mod tests {
     ];
 
     for &(url, cluster_id, match_id, metadata_salt, replay_salt) in cases {
-      let salts = Salts::from_url(url).unwrap();
+      let salts = Salts::from_url(url, "test").unwrap();
       assert_eq!(salts.cluster_id, cluster_id);
       assert_eq!(salts.match_id, match_id);
       assert_eq!(salts.metadata_salt, metadata_salt);


### PR DESCRIPTION
## Summary

The desktop app uploads match salts to `https://api.deadlock-api.com/v1/matches/salts` from two places:

- the initial bulk scan of the Steam `appcache/httpcache` directory
- the live cache watcher that picks up salts as matches are played or spectated

Both previously sent the same `username: "Mod Manager"`. This PR makes the caller supply the username so the two sources can be distinguished on the API side:

| Source | Username |
| --- | --- |
| Initial cache scan (`initial_cache_dir_ingest`) | `Mod Manager (Cache)` |
| Live cache watcher (`watch_cache_dir`) | `Mod Manager (Live)` |

## Changes

- `Salts::from_url` now takes a `username` parameter instead of hardcoding it.
- Added `CACHE_SCAN_USERNAME` and `LIVE_WATCHER_USERNAME` constants in `ingest_tool/utils.rs`.
- Updated the two call sites in `ingest_tool/scan_cache.rs`.

## Test plan

- [x] `cargo test ingest_tool` passes (`test_extract_salts`, `test_cache_operations`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Zuvcdvo2b7xJ5wfSHUbCr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the desktop app’s salt ingestion usernames:
  - Initial cache scan: `Mod Manager (Cache)`
  - Live cache watcher: `Mod Manager (Live)`
- Updated `Salts::from_url` to accept the username as a parameter.
- Updated both cache ingestion call sites and related tests.

## Scope

- Affects the desktop app only.
- No API, bot, www, docs, shared package, database, Tauri plugin, dependency, or Rust FFI changes.
- `ingest_tool` tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->