### PR TITLE
test(desktop): add isolated Tauri E2E harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # testing
 coverage
+.e2e/
 
 # next.js
 .next/

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -382,7 +382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
 dependencies = [
  "atk-sys",
- "glib",
+ "glib 0.18.5",
  "libc",
 ]
 
@@ -392,10 +392,10 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -431,6 +431,58 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -742,7 +794,7 @@ checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
  "bitflags 2.11.1",
  "cairo-sys-rs",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "thiserror 1.0.69",
@@ -754,9 +806,9 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -855,7 +907,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1462,6 +1524,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
+ "tauri-plugin-wdio",
+ "tauri-plugin-wdio-webdriver",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2251,7 +2315,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "pango",
 ]
@@ -2264,7 +2328,7 @@ checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
 ]
@@ -2275,11 +2339,11 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2290,13 +2354,13 @@ checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2306,11 +2370,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
 dependencies = [
  "gdk-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2322,7 +2386,7 @@ dependencies = [
  "gdk",
  "gdkx11-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "x11",
 ]
@@ -2334,9 +2398,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
 dependencies = [
  "gdk-sys",
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -2410,8 +2474,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "gio-sys",
- "glib",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pin-project-lite",
@@ -2425,11 +2489,24 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
+dependencies = [
+ "glib-sys 0.21.5",
+ "gobject-sys 0.21.5",
+ "libc",
+ "system-deps 7.0.8",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2444,15 +2521,36 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-macros 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "memchr",
  "once_cell",
  "smallvec",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys 0.21.5",
+ "glib-macros 0.21.5",
+ "glib-sys 0.21.5",
+ "gobject-sys 0.21.5",
+ "libc",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -2470,13 +2568,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib-macros"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
+dependencies = [
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -2491,9 +2612,20 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
+dependencies = [
+ "glib-sys 0.21.5",
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -2520,7 +2652,7 @@ dependencies = [
  "gdk",
  "gdk-pixbuf",
  "gio",
- "glib",
+ "glib 0.18.5",
  "gtk-sys",
  "gtk3-macros",
  "libc",
@@ -2538,12 +2670,12 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3154,7 +3286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
 dependencies = [
  "bitflags 1.3.2",
- "glib",
+ "glib 0.18.5",
  "javascriptcore-rs-sys",
 ]
 
@@ -3164,10 +3296,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3370,7 +3502,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
 dependencies = [
- "glib",
+ "glib 0.18.5",
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
@@ -3542,6 +3674,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -4057,10 +4195,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -4116,6 +4261,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -4201,6 +4347,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,6 +4416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-javascript-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
+dependencies = [
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -4320,6 +4489,17 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4433,6 +4613,8 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "objc2-javascript-core",
+ "objc2-security",
 ]
 
 [[package]]
@@ -4581,7 +4763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pango-sys",
@@ -4593,10 +4775,10 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -5555,8 +5737,8 @@ checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
  "block2 0.6.2",
  "dispatch2",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk-sys",
  "js-sys",
  "log",
@@ -6076,6 +6258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6358,7 +6551,7 @@ checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
 dependencies = [
  "futures-channel",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "soup3-sys",
 ]
@@ -6369,11 +6562,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
 dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -6722,10 +6915,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.9",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -6802,6 +7008,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -7230,6 +7442,56 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.6.1",
+]
+
+[[package]]
+name = "tauri-plugin-wdio"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02dc512778b929292f81436727b1c1f5cd406951ce7797ea86e15746842704c"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid 1.23.1",
+]
+
+[[package]]
+name = "tauri-plugin-wdio-webdriver"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad665bda48567107b6a3d070fe6d58a98e21f3ebf52abe41308fa4d5919f61b"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "block2 0.6.2",
+ "cairo-rs",
+ "glib 0.21.5",
+ "gtk",
+ "javascriptcore-rs",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-web-kit 0.3.2",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid 1.23.1",
+ "webkit2gtk",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7744,6 +8006,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8536,10 +8799,10 @@ dependencies = [
  "gdk",
  "gdk-sys",
  "gio",
- "gio-sys",
- "glib",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk",
  "gtk-sys",
  "javascriptcore-rs",
@@ -8558,15 +8821,15 @@ dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
  "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk-sys",
  "javascriptcore-rs-sys",
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -29,3 +29,16 @@ The external provider currently cannot be required on Windows hosts with WebView
 `@wdio/tauri-service` 1.3.0 also emits a non-fatal `sessionId is required` warning while clearing its mock store after an embedded session has already closed. It does not change the WDIO exit status or leave the application running. Treat it as service noise and remove this note when the package fixes its after-session cleanup.
 
 Native Windows dialogs are outside the webview DOM and cannot be driven by WebDriver. A later harness milestone will add a narrowly scoped FlaUI helper for picker selection while keeping the app's real dialog plugin and Rust continuation in the flow. The current milestone covers isolated runtime configuration, deterministic network and filesystem worlds, synthetic VPKs, UI clicks, real IPC/Rust execution, diagnostics, and process supervision.
+
+## Roadmap
+
+| Milestone | Status | Deliverable | Exit criterion |
+| --- | --- | --- | --- |
+| M1: safe harness foundation | Complete in PR #706 | Compile-gated runtime configuration, owned worlds, root routing, fixture network, filesystem oracle, synthetic VPK builder, supervisor, doctor, and embedded-driver qualification | Ten retry-free fresh UI/IPC runs pass; intentional timeout cleanup succeeds; production cannot activate E2E mode |
+| M2: complete local-mod lifecycle | Next | Drive a synthetic VPK through a narrowly scoped FlaUI native-picker helper, the real Rust parser, import/install, enable/disable, delete, and application restart | UI state, VPK manifest, persisted store, and independent file hashes agree after every step; the final world matches its expected restored state |
+| M3: profiles and ordering | Planned | Two-profile switching plus pointer and keyboard reorder flows | Inactive profiles and protected files remain unchanged; order and profile state survive restart without mocked core IPC |
+| M4: downloads and network failures | Planned; transport foundation exists | Exercise actual Rust downloads against fixture endpoints, including variants, Range resume, pause, cancel, malformed responses, and authentication failures | Every request matches the strict journal; unexpected traffic fails; partial files and state recover correctly |
+| M5: recovery and hostile filesystem cases | Planned | Backup replace/merge, interrupted mutations, shard boundaries, collisions, Windows locks, and crash barriers | Restart recovers retained worlds and the independent oracle proves restoration without normalizing unexpected writes |
+| M6: CI and release coverage | Planned | Serial Windows PR lane, broader nightly matrix, packaged-app/native smoke, and ordinary-release exclusion checks | Clean runners reproduce required flows and ordinary builds contain no harness server, capability, control channel, or fixture policy |
+
+Keep scenarios independent and small even when they share recipes. The final routine-development gate is a composed import/download → enable → profile switch → reorder → backup → modify → restore → restart journey, supported by focused tests for each operation and failure boundary.

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -1,0 +1,31 @@
+# Desktop E2E harness
+
+This harness launches the compiled Tauri application in a disposable, owned test world. Every filesystem root exposed to DMM is redirected beneath `.e2e/worlds`, production builds reject the E2E configuration variable, and E2E builds refuse to start without a validated configuration.
+
+The default and required provider is WDIO's embedded server. The external `tauri-driver` provider remains available for transport comparison when the host supports it. This follows [Tauri's current recommendation](https://v2.tauri.app/develop/tests/webdriver/): use `@wdio/tauri-service`, whose embedded provider works without a separate platform driver.
+
+```powershell
+pnpm --filter @deadlock-mods/desktop e2e:build
+pnpm --filter @deadlock-mods/desktop e2e:doctor
+pnpm --filter @deadlock-mods/desktop e2e:test
+pnpm --filter @deadlock-mods/desktop e2e:qualify -- --provider embedded
+pnpm --filter @deadlock-mods/desktop e2e:qualify -- --provider external
+```
+
+Successful worlds are deleted after their artifacts and filesystem inventories are written. Failed worlds are retained and printed by the CLI. `--keep` retains a successful single run for inspection. Cleanup only operates on directories beneath `.e2e/worlds` whose manifest identifies the harness as owner. Each run records live changes in `artifacts/filesystem.ndjson` and writes complete before/after SHA-256 inventories for every managed root. Restoring a test means deleting its disposable world; a test never edits the developer's real installation.
+
+The fixture server records all requests to `artifacts/network.ndjson`, returns a hard failure for any unregistered fixture, and is also installed as the child process HTTP(S) proxy. Absolute-form HTTP proxy requests and HTTPS `CONNECT` tunnels are blocked, recorded, and fail the run. Every application service origin is injected as a loopback fixture URL, and the E2E-only Tauri HTTP capability allows only those validated origins. A passing run therefore has a deterministic response for every observed request and no production-service traffic.
+
+`support/vpk.ts` builds deterministic, structurally valid VPK v2 archives from small path/content recipes. Entries use the standard VPK header, CRC32 values, directory tree, and inline data section. The file-management milestone will feed these archives through DMM's real parser and Rust commands without committing large or copyrighted fixture archives.
+
+The first smoke flow uses WebDriver clicks to open Settings and the About dialog, then invokes the compile-gated `e2e_status` command to prove the UI process is connected to the real Rust backend and isolated world. It also prepares a real Steam launch request through Rust, verifies that the `record` policy writes the redacted intent to `artifacts/game-launches.ndjson`, and proves that game liveness/stop operations cannot inspect or terminate a host game in the default E2E world.
+
+## Qualification status
+
+The embedded provider passed 10 consecutive fresh-process runs on Windows/Wry with retries disabled, followed by an intentional timeout that was surfaced and torn down correctly. Fresh runs took 10.6–14.7 seconds (about 11.6 seconds on average), including world creation, application and driver startup, UI and Rust assertions, artifact capture, shutdown, and cleanup across every managed root.
+
+The external provider currently cannot be required on Windows hosts with WebView2 Runtime 150 or newer when the application runs elevated. WebView2 ignores the remote-debugging switch used by `tauri-driver`, so session creation times out even with a matching EdgeDriver. This is tracked upstream in [webdriverio/desktop-mobile#542](https://github.com/webdriverio/desktop-mobile/issues/542) with the Tauri fix in `wry#1782`. Keep embedded as the required provider until that upstream fix reaches DMM's Wry version.
+
+`@wdio/tauri-service` 1.3.0 also emits a non-fatal `sessionId is required` warning while clearing its mock store after an embedded session has already closed. It does not change the WDIO exit status or leave the application running. Treat it as service noise and remove this note when the package fixes its after-session cleanup.
+
+Native Windows dialogs are outside the webview DOM and cannot be driven by WebDriver. A later harness milestone will add a narrowly scoped FlaUI helper for picker selection while keeping the app's real dialog plugin and Rust continuation in the flow. The current milestone covers isolated runtime configuration, deterministic network and filesystem worlds, synthetic VPKs, UI clicks, real IPC/Rust execution, diagnostics, and process supervision.

--- a/apps/desktop/e2e/cli.ts
+++ b/apps/desktop/e2e/cli.ts
@@ -1,0 +1,307 @@
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createServer as createTcpServer } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { DriverProvider } from "./support/contracts";
+import { defaultBinaryPath, runE2eWorld } from "./support/supervisor";
+import { WORLDS_ROOT } from "./support/world";
+
+const argumentsList = process.argv.slice(2);
+const command = argumentsList[0] ?? "run";
+
+const valueAfter = (flag: string): string | undefined => {
+  const index = argumentsList.indexOf(flag);
+  return index >= 0 ? argumentsList[index + 1] : undefined;
+};
+
+const provider = (): DriverProvider => {
+  const value = valueAfter("--provider") ?? "embedded";
+  if (value !== "embedded" && value !== "external") {
+    throw new Error(
+      `Unsupported provider '${value}'. Use embedded or external.`,
+    );
+  }
+  return value;
+};
+
+const commandExists = (executable: string, argument: string): boolean => {
+  if (process.platform === "win32") {
+    return (
+      spawnSync("where.exe", [executable], {
+        stdio: "ignore",
+        windowsHide: true,
+      }).status === 0
+    );
+  }
+  return (
+    spawnSync(executable, [argument], {
+      stdio: "ignore",
+      windowsHide: true,
+    }).status === 0
+  );
+};
+
+const isInteractiveWindowsSession = (): boolean =>
+  process.platform === "win32" &&
+  spawnSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "if ([Environment]::UserInteractive) { exit 0 } else { exit 1 }",
+    ],
+    { stdio: "ignore", windowsHide: true },
+  ).status === 0;
+
+const hasWebView2Runtime = async (): Promise<boolean> => {
+  const roots = [process.env["ProgramFiles(x86)"], process.env.LOCALAPPDATA]
+    .filter((root): root is string => root !== undefined)
+    .map((root) => path.join(root, "Microsoft", "EdgeWebView", "Application"));
+  for (const root of roots) {
+    try {
+      const entries = await readdir(root, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        try {
+          await access(path.join(root, entry.name, "msedgewebview2.exe"));
+          return true;
+        } catch {
+          // Continue looking through installed runtime versions.
+        }
+      }
+    } catch {
+      // Continue through per-machine and per-user installation roots.
+    }
+  }
+  return false;
+};
+
+const canWriteHarnessRoot = async (): Promise<boolean> => {
+  let probeDirectory: string | undefined;
+  try {
+    await mkdir(WORLDS_ROOT, { recursive: true });
+    probeDirectory = await mkdtemp(path.join(WORLDS_ROOT, "doctor-"));
+    await writeFile(path.join(probeDirectory, "probe"), "ok");
+    await rm(probeDirectory, { recursive: true });
+    return true;
+  } catch {
+    if (probeDirectory !== undefined) {
+      await rm(probeDirectory, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+    }
+    return false;
+  }
+};
+
+const canBindLoopback = async (): Promise<boolean> =>
+  await new Promise<boolean>((resolve) => {
+    const server = createTcpServer();
+    server.once("error", () => resolve(false));
+    server.listen(0, "127.0.0.1", () => {
+      server.close((error) => resolve(error === undefined));
+    });
+  });
+
+const binaryContains = async (
+  binaryPath: string,
+  markerText: string,
+): Promise<boolean> => {
+  const marker = Buffer.from(markerText);
+  let suffix = Buffer.alloc(0);
+  for await (const chunk of createReadStream(binaryPath)) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const searchable = Buffer.concat([suffix, bytes]);
+    if (searchable.indexOf(marker) >= 0) return true;
+    suffix = searchable.subarray(
+      Math.max(0, searchable.byteLength - marker.byteLength + 1),
+    );
+  }
+  return false;
+};
+
+const doctor = async (): Promise<void> => {
+  const binaryPath = valueAfter("--binary") ?? defaultBinaryPath;
+  const selectedProvider = provider();
+  const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+  checks.push({
+    name: "platform",
+    ok: process.platform === "win32",
+    detail: `${process.platform}; milestone 1 supports Windows/Wry`,
+  });
+  checks.push({
+    name: "interactive session",
+    ok: isInteractiveWindowsSession(),
+    detail:
+      "desktop WebView automation requires an interactive Windows session",
+  });
+  const hasWebView2 = await hasWebView2Runtime();
+  checks.push({
+    name: "WebView2 Runtime",
+    ok: hasWebView2,
+    detail: hasWebView2
+      ? "msedgewebview2.exe found"
+      : "Microsoft Edge WebView2 Runtime is missing",
+  });
+  const harnessRootWritable = await canWriteHarnessRoot();
+  checks.push({
+    name: "harness root",
+    ok: harnessRootWritable,
+    detail: `${WORLDS_ROOT} write/delete access`,
+  });
+  const loopbackAvailable = await canBindLoopback();
+  checks.push({
+    name: "loopback bind",
+    ok: loopbackAvailable,
+    detail: "ephemeral TCP listener on 127.0.0.1",
+  });
+  checks.push({
+    name: "process-tree cleanup",
+    ok: process.platform === "win32" && commandExists("taskkill.exe", "/?"),
+    detail: "taskkill.exe on PATH",
+  });
+  const servicePath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "node_modules",
+    "@wdio",
+    "tauri-service",
+  );
+  let embeddedServiceExists = true;
+  try {
+    await access(servicePath);
+  } catch {
+    embeddedServiceExists = false;
+  }
+  checks.push({
+    name: "embedded WDIO service",
+    ok: embeddedServiceExists,
+    detail: embeddedServiceExists
+      ? servicePath
+      : "@wdio/tauri-service is not installed",
+  });
+  checks.push({
+    name: "pnpm",
+    ok: commandExists("pnpm", "--version"),
+    detail: "pnpm on PATH",
+  });
+  checks.push({
+    name: "cargo",
+    ok: commandExists("cargo", "--version"),
+    detail: "cargo on PATH",
+  });
+  let binaryExists = true;
+  try {
+    await access(binaryPath);
+  } catch {
+    binaryExists = false;
+  }
+  checks.push({
+    name: "E2E binary",
+    ok: binaryExists,
+    detail: binaryExists
+      ? binaryPath
+      : `${binaryPath} missing; run pnpm e2e:build`,
+  });
+  if (binaryExists) {
+    const hasHarnessMarker = await binaryContains(
+      binaryPath,
+      "e2e-harness builds require an E2E configuration",
+    );
+    checks.push({
+      name: "E2E binary feature",
+      ok: hasHarnessMarker,
+      detail: hasHarnessMarker
+        ? "binary contains the e2e-harness feature marker"
+        : "binary is not an E2E build; run pnpm e2e:build",
+    });
+  }
+  if (selectedProvider === "external") {
+    checks.push({
+      name: "tauri-driver",
+      ok: commandExists("tauri-driver", "--version"),
+      detail: "external provider requires tauri-driver on PATH",
+    });
+  }
+  for (const check of checks) {
+    console.log(`${check.ok ? "PASS" : "FAIL"} ${check.name}: ${check.detail}`);
+  }
+  if (checks.some((check) => !check.ok)) process.exitCode = 1;
+};
+
+const run = async (): Promise<void> => {
+  const result = await runE2eWorld({
+    provider: provider(),
+    runId: `local-${Date.now()}`,
+    caseId: "about-smoke",
+    attempt: 1,
+    binaryPath: valueAfter("--binary"),
+    retainPassedWorld: argumentsList.includes("--keep"),
+  });
+  console.log(
+    `${result.passed ? "PASS" : "FAIL"} in ${(result.elapsedMs / 1000).toFixed(1)}s`,
+  );
+  if (!result.passed) {
+    console.log(`Retained failure world: ${result.worldDirectory}`);
+    process.exitCode = 1;
+  } else if (argumentsList.includes("--keep")) {
+    console.log(`Retained requested world: ${result.worldDirectory}`);
+  }
+};
+
+const qualify = async (): Promise<void> => {
+  const selectedProvider = provider();
+  const runId = `qualification-${selectedProvider}-${Date.now()}`;
+  for (let attempt = 1; attempt <= 10; attempt += 1) {
+    const result = await runE2eWorld({
+      provider: selectedProvider,
+      runId,
+      caseId: "about-smoke",
+      attempt,
+      binaryPath: valueAfter("--binary"),
+    });
+    if (!result.passed) {
+      console.error(
+        `Qualification stopped at fresh run ${attempt}; retained ${result.worldDirectory}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log(
+      `Fresh run ${attempt}/10 passed in ${(result.elapsedMs / 1000).toFixed(1)}s`,
+    );
+  }
+  const timeoutResult = await runE2eWorld({
+    provider: selectedProvider,
+    runId,
+    caseId: "intentional-timeout",
+    attempt: 11,
+    binaryPath: valueAfter("--binary"),
+    intentionalTimeout: true,
+  });
+  if (!timeoutResult.passed || !timeoutResult.expectedFailureObserved) {
+    console.error(
+      `Intentional timeout did not fail as expected; retained ${timeoutResult.worldDirectory}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `PASS ${selectedProvider}: 10/10 fresh runs and intentional-timeout teardown`,
+  );
+};
+
+if (command === "doctor") await doctor();
+else if (command === "run") await run();
+else if (command === "qualify") await qualify();
+else throw new Error(`Unknown E2E command '${command}'`);

--- a/apps/desktop/e2e/specs/about.e2e.ts
+++ b/apps/desktop/e2e/specs/about.e2e.ts
@@ -1,0 +1,116 @@
+import { $, browser, expect } from "@wdio/globals";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__: {
+      invoke: <TResult, TArguments extends object = object>(
+        command: string,
+        argumentsValue?: TArguments,
+      ) => Promise<TResult>;
+    };
+  }
+}
+
+type E2eStatus = {
+  runId: string;
+  caseId: string;
+  applicationIdentity: string;
+  runtime: string;
+  roots: { world: string };
+};
+
+const persistedStateSchema = z.object({
+  state: z
+    .object({ hasCompletedOnboarding: z.boolean().optional() })
+    .optional(),
+});
+
+describe("DMM native smoke", () => {
+  it("clicks through the About UI and reaches Rust IPC", async () => {
+    const persistedState = await browser.execute(async () => {
+      const bootstrap = await window.__TAURI_INTERNALS__.invoke<{
+        stateStorePath: string;
+      }>("get_runtime_bootstrap");
+      const rid = await window.__TAURI_INTERNALS__.invoke<number | null>(
+        "plugin:store|get_store",
+        { path: bootstrap.stateStorePath },
+      );
+      if (rid === null) return null;
+      const [value, exists] = await window.__TAURI_INTERNALS__.invoke<
+        [string, boolean]
+      >("plugin:store|get", { rid, key: "local-config" });
+      if (!exists) return null;
+      return value;
+    });
+    expect(
+      persistedState === null
+        ? null
+        : persistedStateSchema.parse(JSON.parse(persistedState)).state
+            ?.hasCompletedOnboarding,
+    ).toBe(true);
+
+    const whatsNewDismiss = await $("button=Got it!");
+    if (await whatsNewDismiss.isDisplayed()) {
+      await whatsNewDismiss.click();
+    }
+
+    const settingsLink = await $('a[href="/settings"]');
+    await settingsLink.waitForClickable();
+    await settingsLink.click();
+    await expect(browser).toHaveUrl(expect.stringContaining("/settings"));
+
+    const informationTab = await $("button=Information");
+    await informationTab.scrollIntoView({ block: "center" });
+    await informationTab.waitForClickable();
+    await informationTab.click();
+    await expect(informationTab).toHaveAttribute("data-state", "active");
+    await expect($("h3=About")).toBeDisplayed();
+    await expect($("h3=Tauri")).toBeDisplayed();
+
+    const runtimeKind = await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<string>("get_runtime_kind"),
+    );
+    expect(runtimeKind).toBe("wry");
+
+    const status = await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<E2eStatus>("e2e_status"),
+    );
+    expect(status.runId).toBe(process.env.DMM_E2E_RUN_ID);
+    expect(status.caseId).toBe(process.env.DMM_E2E_CASE_ID);
+    expect(status.applicationIdentity).toContain(".e2e.");
+    expect(status.runtime).toBe(runtimeKind);
+    expect(status.roots.world).toContain(".e2e");
+
+    await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<void>("launch_game_direct", {
+        additionalArgs: "--e2e-launch-probe",
+      }),
+    );
+    expect(
+      await browser.execute(() =>
+        window.__TAURI_INTERNALS__.invoke<boolean>("is_game_running"),
+      ),
+    ).toBe(false);
+    await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<void>("stop_game"),
+    );
+
+    const launchJournal = await readFile(
+      path.join(status.roots.world, "artifacts", "game-launches.ndjson"),
+      "utf8",
+    );
+    expect(launchJournal).toContain("--e2e-launch-probe");
+    expect(launchJournal).toContain("steam.exe");
+
+    if (process.env.DMM_E2E_INTENTIONAL_TIMEOUT === "1") {
+      await browser.waitUntil(() => false, {
+        timeout: 300,
+        interval: 50,
+        timeoutMsg: "intentional harness timeout",
+      });
+    }
+  });
+});

--- a/apps/desktop/e2e/support/contracts.ts
+++ b/apps/desktop/e2e/support/contracts.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+export type ServiceName =
+  | "gamebanana"
+  | "downloads"
+  | "dmmApi"
+  | "auth"
+  | "deadlockApi"
+  | "assets";
+
+export const SERVICE_NAMES: readonly ServiceName[] = [
+  "gamebanana",
+  "downloads",
+  "dmmApi",
+  "auth",
+  "deadlockApi",
+  "assets",
+];
+
+export type DriverProvider = "embedded" | "external";
+
+export type E2eRoots = {
+  world: string;
+  game: string;
+  steam: string;
+  steamHttpCache: string;
+  appData: string;
+  appConfig: string;
+  appCache: string;
+  appLogs: string;
+  webviewData: string;
+  temporary: string;
+};
+
+export type E2eConfiguration = {
+  schemaVersion: 1;
+  runId: string;
+  caseId: string;
+  attempt: number;
+  applicationIdentity: string;
+  roots: E2eRoots;
+  endpoints: Array<{ service: ServiceName; origin: string }>;
+  networkMode: "fixture";
+  integrations: {
+    updater: "disabled" | "fixture";
+    steamDiscovery: "fixture";
+    gameLaunch: "record";
+    presence: "disabled";
+    ingestion: "disabled";
+    matchSync: "disabled";
+  };
+  ui: { language: string; width: number; height: number };
+  control: { endpoint: string; tokenFile: string };
+};
+
+export type WorldManifest = {
+  schemaVersion: 1;
+  owner: "dmm-e2e-harness";
+  createdAt: string;
+  expiresAt: string;
+  processId: number;
+  configuration: E2eConfiguration;
+};
+
+const rootsSchema = z.object({
+  world: z.string(),
+  game: z.string(),
+  steam: z.string(),
+  steamHttpCache: z.string(),
+  appData: z.string(),
+  appConfig: z.string(),
+  appCache: z.string(),
+  appLogs: z.string(),
+  webviewData: z.string(),
+  temporary: z.string(),
+});
+
+const configurationSchema = z.object({
+  schemaVersion: z.literal(1),
+  runId: z.string(),
+  caseId: z.string(),
+  attempt: z.number().int().positive(),
+  applicationIdentity: z.string(),
+  roots: rootsSchema,
+  endpoints: z.array(
+    z.object({
+      service: z.enum([
+        "gamebanana",
+        "downloads",
+        "dmmApi",
+        "auth",
+        "deadlockApi",
+        "assets",
+      ]),
+      origin: z.string(),
+    }),
+  ),
+  networkMode: z.literal("fixture"),
+  integrations: z.object({
+    updater: z.enum(["disabled", "fixture"]),
+    steamDiscovery: z.literal("fixture"),
+    gameLaunch: z.literal("record"),
+    presence: z.literal("disabled"),
+    ingestion: z.literal("disabled"),
+    matchSync: z.literal("disabled"),
+  }),
+  ui: z.object({
+    language: z.string(),
+    width: z.number(),
+    height: z.number(),
+  }),
+  control: z.object({ endpoint: z.string(), tokenFile: z.string() }),
+});
+
+export const worldManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  owner: z.literal("dmm-e2e-harness"),
+  createdAt: z.string(),
+  expiresAt: z.string(),
+  processId: z.number().int(),
+  configuration: configurationSchema,
+});

--- a/apps/desktop/e2e/support/filesystem-journal.ts
+++ b/apps/desktop/e2e/support/filesystem-journal.ts
@@ -1,0 +1,38 @@
+import { watch } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+type FilesystemEvent = {
+  at: string;
+  root: string;
+  event: "rename" | "change";
+  path: string;
+};
+
+export const startFilesystemJournal = (
+  roots: Record<string, string>,
+  artifactsDirectory: string,
+): { close: () => Promise<void> } => {
+  const events: FilesystemEvent[] = [];
+  const watchers = Object.entries(roots).map(([name, root]) =>
+    watch(root, { recursive: true }, (event, fileName) => {
+      events.push({
+        at: new Date().toISOString(),
+        root: name,
+        event,
+        path: fileName?.toString().replaceAll("\\", "/") ?? "",
+      });
+    }),
+  );
+  return {
+    close: async () => {
+      for (const watcher of watchers) watcher.close();
+      await mkdir(artifactsDirectory, { recursive: true });
+      await writeFile(
+        path.join(artifactsDirectory, "filesystem.ndjson"),
+        events.map((event) => JSON.stringify(event)).join("\n") +
+          (events.length > 0 ? "\n" : ""),
+      );
+    },
+  };
+};

--- a/apps/desktop/e2e/support/fixture-server.test.ts
+++ b/apps/desktop/e2e/support/fixture-server.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { request } from "node:http";
+import { connect } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { startFixtureServer } from "./fixture-server";
+
+const proxyRequest = async (
+  origin: string,
+  method: "CONNECT" | "GET",
+  target: string,
+): Promise<number> => {
+  const fixtureUrl = new URL(origin);
+  if (method === "CONNECT") {
+    return await new Promise<number>((resolve, reject) => {
+      const socket = connect(Number(fixtureUrl.port), fixtureUrl.hostname);
+      socket.once("error", reject);
+      socket.once("data", (data) => {
+        const match = data.toString().match(/^HTTP\/1\.1 (\d{3})/);
+        socket.destroy();
+        resolve(Number(match?.[1] ?? 0));
+      });
+      socket.once("connect", () => {
+        socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+      });
+    });
+  }
+  return await new Promise<number>((resolve, reject) => {
+    const outgoing = request(
+      {
+        host: fixtureUrl.hostname,
+        port: fixtureUrl.port,
+        method,
+        path: target,
+      },
+      (response) => {
+        response.resume();
+        response.once("end", () => resolve(response.statusCode ?? 0));
+      },
+    );
+    outgoing.once("error", reject);
+    outgoing.end();
+  });
+};
+
+describe("fixture network", () => {
+  it("serves registered responses and journals matched and unmatched requests", async () => {
+    const artifacts = await mkdtemp(
+      path.join(os.tmpdir(), "dmm-network-test-"),
+    );
+    const server = await startFixtureServer([
+      {
+        method: "GET",
+        path: "/api/mods",
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: '[{"id":42}]',
+      },
+    ]);
+    try {
+      const matched = await fetch(
+        `${server.origin}/api/mods?sort=new&access_token=query-secret`,
+        {
+          headers: {
+            authorization: "Bearer header-secret",
+            authentication: "alternate-auth-secret",
+            cookie: "session=cookie-secret",
+            "x-api-key": "api-key-secret",
+            "x-access-token": "access-header-secret",
+            "x-refresh-token": "refresh-header-secret",
+          },
+        },
+      );
+      expect(await matched.json()).toEqual([{ id: 42 }]);
+      const unmatched = await fetch(`${server.origin}/unexpected`, {
+        method: "POST",
+        body: "payload",
+      });
+      expect(unmatched.status).toBe(501);
+      expect(server.unmatchedRequests()).toHaveLength(1);
+      expect(server.unmatchedRequests()[0]?.url).toBe("/unexpected");
+    } finally {
+      await server.close(artifacts);
+    }
+    const journal = await readFile(
+      path.join(artifacts, "network.ndjson"),
+      "utf8",
+    );
+    expect(journal).toContain("%5BREDACTED%5D");
+    expect(journal).toContain('"authorization":"[REDACTED]"');
+    expect(journal).not.toContain("query-secret");
+    expect(journal).not.toContain("header-secret");
+    expect(journal).not.toContain("cookie-secret");
+    expect(journal).not.toContain("api-key-secret");
+    expect(journal).not.toContain("alternate-auth-secret");
+    expect(journal).not.toContain("access-header-secret");
+    expect(journal).not.toContain("refresh-header-secret");
+    expect(journal).toContain('"bodyBytes":7');
+    await rm(artifacts, { recursive: true, force: true });
+  });
+
+  it("blocks and records HTTP and HTTPS proxy attempts", async () => {
+    const artifacts = await mkdtemp(path.join(os.tmpdir(), "dmm-proxy-test-"));
+    const server = await startFixtureServer([
+      {
+        method: "GET",
+        path: "/allowed",
+        status: 200,
+        body: "{}",
+      },
+    ]);
+    try {
+      expect(
+        await proxyRequest(server.origin, "GET", "http://example.test/allowed"),
+      ).toBe(502);
+      expect(
+        await proxyRequest(server.origin, "CONNECT", "example.test:443"),
+      ).toBe(502);
+      expect(server.unmatchedRequests().map((entry) => entry.method)).toEqual([
+        "GET",
+        "CONNECT",
+      ]);
+    } finally {
+      await server.close(artifacts);
+      await rm(artifacts, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/e2e/support/fixture-server.ts
+++ b/apps/desktop/e2e/support/fixture-server.ts
@@ -1,0 +1,178 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type FixtureRequest = {
+  at: string;
+  method: string;
+  url: string;
+  headers: Record<string, string | string[]>;
+  bodyBytes: number;
+};
+
+export type FixtureRoute = {
+  method: string;
+  path: string;
+  status: number;
+  headers?: Record<string, string>;
+  body: string;
+};
+
+export type FixtureServer = {
+  origin: string;
+  unmatchedRequests: () => readonly FixtureRequest[];
+  close: (artifactsDirectory?: string) => Promise<void>;
+};
+
+const isSensitiveHeader = (name: string): boolean =>
+  /(?:authorization|authentication|cookie|token|secret|password|api[-_]?key)/i.test(
+    name,
+  );
+
+const redactUrl = (value: string): string => {
+  const absolute = /^https?:\/\//i.test(value);
+  const url = new URL(value, "http://127.0.0.1");
+  for (const name of [...url.searchParams.keys()]) {
+    if (
+      /(?:token|secret|password|authorization|api[_-]?key|code)/i.test(name)
+    ) {
+      url.searchParams.set(name, "[REDACTED]");
+    }
+  }
+  return absolute ? url.toString() : `${url.pathname}${url.search}${url.hash}`;
+};
+
+const headersFrom = (
+  request: IncomingMessage,
+): Record<string, string | string[]> => {
+  const headers: Record<string, string | string[]> = {};
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (value !== undefined) {
+      headers[name] = isSensitiveHeader(name) ? "[REDACTED]" : value;
+    }
+  }
+  return headers;
+};
+
+const respond = (
+  response: ServerResponse,
+  status: number,
+  body: string,
+  headers: Record<string, string> = { "content-type": "application/json" },
+): void => {
+  response.writeHead(status, headers);
+  response.end(body);
+};
+
+export const startFixtureServer = async (
+  routes: readonly FixtureRoute[] = [],
+): Promise<FixtureServer> => {
+  const journal: FixtureRequest[] = [];
+  const unmatched: FixtureRequest[] = [];
+  const server = createServer(async (request, response) => {
+    let bodyBytes = 0;
+    for await (const chunk of request) {
+      bodyBytes += Buffer.isBuffer(chunk)
+        ? chunk.byteLength
+        : Buffer.byteLength(chunk);
+    }
+    const record: FixtureRequest = {
+      at: new Date().toISOString(),
+      method: request.method ?? "GET",
+      url: redactUrl(request.url ?? "/"),
+      headers: headersFrom(request),
+      bodyBytes,
+    };
+    journal.push(record);
+
+    if (request.url === "/__health") {
+      respond(response, 200, JSON.stringify({ ok: true }));
+      return;
+    }
+    if (request.url?.startsWith("/__control")) {
+      respond(response, 200, JSON.stringify({ ok: true }));
+      return;
+    }
+    if (/^https?:\/\//i.test(record.url)) {
+      unmatched.push(record);
+      respond(
+        response,
+        502,
+        JSON.stringify({
+          error: "E2E fixture proxy blocked external transport",
+          method: record.method,
+          url: record.url,
+        }),
+      );
+      return;
+    }
+    const requestPath = new URL(request.url ?? "/", "http://127.0.0.1")
+      .pathname;
+    const route = routes.find(
+      (candidate) =>
+        candidate.method.toUpperCase() === record.method.toUpperCase() &&
+        candidate.path === requestPath,
+    );
+    if (route) {
+      respond(response, route.status, route.body, route.headers);
+      return;
+    }
+    unmatched.push(record);
+    respond(
+      response,
+      501,
+      JSON.stringify({
+        error: "No deterministic fixture registered",
+        method: record.method,
+        url: record.url,
+      }),
+    );
+  });
+  server.on("connect", (request, socket) => {
+    socket.on("error", () => {
+      // A blocked HTTPS client commonly resets the denied tunnel. The request
+      // remains recorded and the reset must not crash the supervisor.
+    });
+    const record: FixtureRequest = {
+      at: new Date().toISOString(),
+      method: "CONNECT",
+      url: redactUrl(request.url ?? "/"),
+      headers: headersFrom(request),
+      bodyBytes: 0,
+    };
+    journal.push(record);
+    unmatched.push(record);
+    socket.end(
+      "HTTP/1.1 502 E2E fixture proxy blocked external transport\r\n\r\n",
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Fixture server did not bind a TCP port");
+  }
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    unmatchedRequests: () => unmatched,
+    close: async (artifactsDirectory) => {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+      if (artifactsDirectory === undefined) return;
+      await mkdir(artifactsDirectory, { recursive: true });
+      await writeFile(
+        path.join(artifactsDirectory, "network.ndjson"),
+        journal.map((record) => JSON.stringify(record)).join("\n") +
+          (journal.length > 0 ? "\n" : ""),
+      );
+    },
+  };
+};

--- a/apps/desktop/e2e/support/supervisor.ts
+++ b/apps/desktop/e2e/support/supervisor.ts
@@ -1,0 +1,303 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { DriverProvider } from "./contracts";
+import { startFilesystemJournal } from "./filesystem-journal";
+import { startFixtureServer, type FixtureRoute } from "./fixture-server";
+import {
+  collectFileInventory,
+  createWorld,
+  removeOwnedWorld,
+  REPOSITORY_ROOT,
+} from "./world";
+
+const desktopRoot = path.join(REPOSITORY_ROOT, "apps", "desktop");
+const WDIO_PROCESS_TIMEOUT_MS = 120_000;
+export const defaultBinaryPath = path.join(
+  desktopRoot,
+  "target",
+  "debug",
+  process.platform === "win32"
+    ? "deadlock-mod-manager.exe"
+    : "deadlock-mod-manager",
+);
+
+type RunOptions = {
+  provider: DriverProvider;
+  runId: string;
+  caseId: string;
+  attempt: number;
+  binaryPath?: string;
+  retainPassedWorld?: boolean;
+  intentionalTimeout?: boolean;
+  fixtureRoutes?: readonly FixtureRoute[];
+};
+
+export type RunResult = {
+  passed: boolean;
+  expectedFailureObserved: boolean;
+  exitCode: number;
+  worldDirectory: string;
+  elapsedMs: number;
+  unexpectedRequests: number;
+};
+
+const startupFixtureRoutes: readonly FixtureRoute[] = [
+  {
+    method: "GET",
+    path: "/",
+    status: 200,
+    body: '{"status":"ok","db":{"alive":true},"redis":{"alive":true,"configured":false},"version":"e2e","spec":"e2e"}',
+  },
+  { method: "GET", path: "/api/v2/feature-flags", status: 200, body: "[]" },
+  { method: "GET", path: "/api/v2/announcements", status: 200, body: "[]" },
+  { method: "GET", path: "/custom-settings", status: 200, body: "[]" },
+  {
+    method: "GET",
+    path: "/api/v2/relays/health",
+    status: 200,
+    body: '{"relays":[]}',
+  },
+  { method: "GET", path: "/health", status: 200, body: '{"status":"ok"}' },
+  {
+    method: "GET",
+    path: "/api/v2/policy-manifest",
+    status: 200,
+    body: '{"version":1,"revision":0,"generatedAt":"1970-01-01T00:00:00Z","rules":[]}',
+  },
+  {
+    method: "GET",
+    path: "/apiv11/Mod/Index",
+    status: 200,
+    body: '{"_aMetadata":{"_nRecordCount":0,"_nPerpage":50,"_bIsComplete":true},"_aRecords":[]}',
+  },
+  {
+    method: "GET",
+    path: "/apiv11/Sound/Index",
+    status: 200,
+    body: '{"_aMetadata":{"_nRecordCount":0,"_nPerpage":50,"_bIsComplete":true},"_aRecords":[]}',
+  },
+];
+
+const spawnWdio = async (
+  environment: NodeJS.ProcessEnv,
+  outputPath: string,
+): Promise<{ exitCode: number; output: string }> => {
+  const wdioEntry = path.join(
+    desktopRoot,
+    "node_modules",
+    "@wdio",
+    "cli",
+    "bin",
+    "wdio.js",
+  );
+  const child = spawn(
+    process.execPath,
+    [wdioEntry, "run", "e2e/wdio.conf.ts"],
+    {
+      cwd: desktopRoot,
+      env: environment,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    },
+  );
+  let output = "";
+  let supervisorTerminated = false;
+  child.stdout.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    process.stdout.write(text);
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    output += text;
+    process.stderr.write(text);
+  });
+  const terminateForSignal = (signal: NodeJS.Signals): void => {
+    supervisorTerminated = true;
+    const message = `\nE2E supervisor received ${signal}; terminating WDIO process tree\n`;
+    output += message;
+    process.stderr.write(message);
+    terminateProcessTree(child);
+  };
+  const onInterrupt = (): void => terminateForSignal("SIGINT");
+  const onTermination = (): void => terminateForSignal("SIGTERM");
+  process.once("SIGINT", onInterrupt);
+  process.once("SIGTERM", onTermination);
+
+  let exitCode: number;
+  try {
+    exitCode = await new Promise<number>((resolve, reject) => {
+      const deadline = setTimeout(() => {
+        supervisorTerminated = true;
+        const message = `\nE2E supervisor exceeded ${WDIO_PROCESS_TIMEOUT_MS}ms; terminating WDIO process tree\n`;
+        output += message;
+        process.stderr.write(message);
+        terminateProcessTree(child);
+      }, WDIO_PROCESS_TIMEOUT_MS);
+      child.once("error", (error) => {
+        clearTimeout(deadline);
+        reject(error);
+      });
+      child.once("exit", (code) => {
+        clearTimeout(deadline);
+        resolve(code ?? 1);
+      });
+    });
+  } finally {
+    process.removeListener("SIGINT", onInterrupt);
+    process.removeListener("SIGTERM", onTermination);
+  }
+  await writeFile(outputPath, output);
+  return { exitCode: supervisorTerminated ? 1 : exitCode, output };
+};
+
+const terminateProcessTree = (child: ChildProcess): void => {
+  if (child.pid === undefined || child.exitCode !== null) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill.exe", ["/pid", String(child.pid), "/t", "/f"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  }
+  if (child.exitCode === null) child.kill("SIGKILL");
+};
+
+export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
+  const startedAt = Date.now();
+  let fixtureServer: Awaited<ReturnType<typeof startFixtureServer>> | undefined;
+  let world: Awaited<ReturnType<typeof createWorld>> | undefined;
+  let filesystemJournal: ReturnType<typeof startFilesystemJournal> | undefined;
+  let resourcesClosed = false;
+  const closeResources = async (): Promise<void> => {
+    if (resourcesClosed) return;
+    resourcesClosed = true;
+    const results = await Promise.allSettled([
+      ...(filesystemJournal === undefined ? [] : [filesystemJournal.close()]),
+      ...(fixtureServer === undefined
+        ? []
+        : [fixtureServer.close(world?.artifactsDirectory)]),
+    ]);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        "Failed to close E2E resources",
+      );
+    }
+  };
+
+  try {
+    fixtureServer = await startFixtureServer([
+      ...(options.fixtureRoutes ?? []),
+      ...startupFixtureRoutes,
+    ]);
+    world = await createWorld({
+      runId: options.runId,
+      caseId: options.caseId,
+      attempt: options.attempt,
+      fixtureOrigin: fixtureServer.origin,
+    });
+    const roots = world.configuration.roots;
+    const inventoryRoots = {
+      game: roots.game,
+      steam: roots.steam,
+      steamHttpCache: roots.steamHttpCache,
+      appData: roots.appData,
+      appConfig: roots.appConfig,
+      appCache: roots.appCache,
+      appLogs: roots.appLogs,
+      webviewData: roots.webviewData,
+      temporary: roots.temporary,
+    };
+    const before = Object.fromEntries(
+      await Promise.all(
+        Object.entries(inventoryRoots).map(async ([name, root]) => [
+          name,
+          await collectFileInventory(root),
+        ]),
+      ),
+    );
+    await mkdir(world.artifactsDirectory, { recursive: true });
+    await writeFile(
+      path.join(world.artifactsDirectory, "files-before.json"),
+      JSON.stringify(before, null, 2),
+    );
+    filesystemJournal = startFilesystemJournal(
+      inventoryRoots,
+      world.artifactsDirectory,
+    );
+
+    const proxyBypass = "127.0.0.1,localhost";
+    const wdioResult = await spawnWdio(
+      {
+        ...process.env,
+        DMM_E2E_CONFIG: world.configPath,
+        DMM_E2E_BINARY: path.resolve(options.binaryPath ?? defaultBinaryPath),
+        DMM_E2E_PROVIDER: options.provider,
+        DMM_E2E_ARTIFACTS: world.artifactsDirectory,
+        DMM_E2E_RUN_ID: world.configuration.runId,
+        DMM_E2E_CASE_ID: world.configuration.caseId,
+        DMM_E2E_INTENTIONAL_TIMEOUT: options.intentionalTimeout ? "1" : "0",
+        HTTP_PROXY: fixtureServer.origin,
+        HTTPS_PROXY: fixtureServer.origin,
+        ALL_PROXY: fixtureServer.origin,
+        NO_PROXY: proxyBypass,
+        no_proxy: proxyBypass,
+      },
+      path.join(world.artifactsDirectory, "wdio.log"),
+    );
+    await closeResources();
+    const after = Object.fromEntries(
+      await Promise.all(
+        Object.entries(inventoryRoots).map(async ([name, root]) => [
+          name,
+          await collectFileInventory(root),
+        ]),
+      ),
+    );
+    await writeFile(
+      path.join(world.artifactsDirectory, "files-after.json"),
+      JSON.stringify(after, null, 2),
+    );
+
+    const unexpectedRequests = fixtureServer.unmatchedRequests().length;
+    const expectedFailureObserved =
+      options.intentionalTimeout === true &&
+      wdioResult.exitCode !== 0 &&
+      wdioResult.output.includes("intentional harness timeout");
+    const passed =
+      unexpectedRequests === 0 &&
+      (options.intentionalTimeout === true
+        ? expectedFailureObserved
+        : wdioResult.exitCode === 0);
+    const result: RunResult = {
+      passed,
+      expectedFailureObserved,
+      exitCode: wdioResult.exitCode,
+      worldDirectory: world.directory,
+      elapsedMs: Date.now() - startedAt,
+      unexpectedRequests,
+    };
+    await writeFile(
+      path.join(world.artifactsDirectory, "result.json"),
+      JSON.stringify(result, null, 2),
+    );
+    if (passed && options.retainPassedWorld !== true) {
+      await removeOwnedWorld(world.directory);
+    }
+    return result;
+  } catch (runError) {
+    try {
+      await closeResources();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [runError, cleanupError],
+        "E2E run failed and resource cleanup also failed", { cause: cleanupError },
+      );
+    }
+    throw runError;
+  }
+};

--- a/apps/desktop/e2e/support/vpk.test.ts
+++ b/apps/desktop/e2e/support/vpk.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { buildSyntheticVpk, type VpkRecipeEntry } from "./vpk";
+
+const recipe: readonly VpkRecipeEntry[] = [
+  { path: "materials/heroes/test.vtex_c", contents: "texture" },
+  { path: "scripts/test.txt", contents: "script" },
+];
+
+describe("synthetic VPK recipes", () => {
+  it("writes a deterministic, inline VPK v2 archive", () => {
+    const first = buildSyntheticVpk(recipe);
+    const second = buildSyntheticVpk([...recipe].toReversed());
+    expect(first).toEqual(second);
+    expect(first.readUInt32LE(0)).toBe(0x55aa1234);
+    expect(first.readUInt32LE(4)).toBe(2);
+    expect(first.readUInt32LE(8)).toBeGreaterThan(0);
+    expect(first.readUInt32LE(12)).toBe("texturescript".length);
+    expect(first.includes(Buffer.from("materials/heroes\0"))).toBe(true);
+  });
+
+  it("rejects paths that could escape an archive recipe", () => {
+    expect(() =>
+      buildSyntheticVpk([{ path: "../outside.txt", contents: "bad" }]),
+    ).toThrow("Unsafe VPK recipe path");
+  });
+
+  it("rejects duplicate normalized paths", () => {
+    expect(() =>
+      buildSyntheticVpk([
+        { path: "scripts/test.txt", contents: "first" },
+        { path: "SCRIPTS\\TEST.TXT", contents: "second" },
+      ]),
+    ).toThrow("Duplicate VPK recipe path");
+  });
+});

--- a/apps/desktop/e2e/support/vpk.ts
+++ b/apps/desktop/e2e/support/vpk.ts
@@ -1,0 +1,158 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const VPK_SIGNATURE = 0x55aa1234;
+const VPK_VERSION = 2;
+const INLINE_ARCHIVE_INDEX = 0x7fff;
+const ENTRY_TERMINATOR = 0xffff;
+
+export type VpkRecipeEntry = {
+  path: string;
+  contents: string | Uint8Array;
+};
+
+type PackedEntry = {
+  normalizedPath: string;
+  extension: string;
+  directory: string;
+  filename: string;
+  crc32: number;
+  offset: number;
+  contents: Uint8Array;
+};
+
+const crcTable = new Uint32Array(256);
+for (let index = 0; index < crcTable.length; index += 1) {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  crcTable[index] = value >>> 0;
+}
+
+const crc32 = (contents: Uint8Array): number => {
+  let value = 0xffffffff;
+  for (const byte of contents)
+    value = crcTable[(value ^ byte) & 0xff] ^ (value >>> 8);
+  return (value ^ 0xffffffff) >>> 0;
+};
+
+const cString = (value: string): Buffer => Buffer.from(`${value}\0`, "utf8");
+const u16 = (value: number): Buffer => {
+  const buffer = Buffer.allocUnsafe(2);
+  buffer.writeUInt16LE(value);
+  return buffer;
+};
+const u32 = (value: number): Buffer => {
+  const buffer = Buffer.allocUnsafe(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+};
+
+const parseEntry = (entry: VpkRecipeEntry, offset: number): PackedEntry => {
+  const normalized = entry.path.replaceAll("\\", "/").toLowerCase();
+  if (
+    normalized.startsWith("/") ||
+    normalized.includes("../") ||
+    normalized.includes("\0") ||
+    /^[a-z]:\//.test(normalized)
+  ) {
+    throw new Error(`Unsafe VPK recipe path '${entry.path}'`);
+  }
+  const extension = path.posix.extname(normalized).slice(1);
+  const filename = path.posix.basename(normalized, `.${extension}`);
+  if (extension.length === 0 || filename.length === 0) {
+    throw new Error(
+      `VPK recipe path needs a filename and extension: '${entry.path}'`,
+    );
+  }
+  const parent = path.posix.dirname(normalized);
+  const contents =
+    typeof entry.contents === "string"
+      ? Buffer.from(entry.contents)
+      : entry.contents;
+  return {
+    normalizedPath: normalized,
+    extension,
+    directory: parent === "." ? " " : parent,
+    filename,
+    crc32: crc32(contents),
+    offset,
+    contents,
+  };
+};
+
+export const buildSyntheticVpk = (
+  recipe: readonly VpkRecipeEntry[],
+): Buffer => {
+  if (recipe.length === 0)
+    throw new Error("A synthetic VPK needs at least one entry");
+  const sorted = [...recipe].sort((left, right) =>
+    left.path.localeCompare(right.path),
+  );
+  const packed: PackedEntry[] = [];
+  const normalizedPaths = new Set<string>();
+  let offset = 0;
+  for (const entry of sorted) {
+    const parsed = parseEntry(entry, offset);
+    if (normalizedPaths.has(parsed.normalizedPath)) {
+      throw new Error(`Duplicate VPK recipe path '${entry.path}'`);
+    }
+    normalizedPaths.add(parsed.normalizedPath);
+    packed.push(parsed);
+    offset += parsed.contents.byteLength;
+  }
+
+  const treeParts: Buffer[] = [];
+  const extensions = [
+    ...new Set(packed.map((entry) => entry.extension)),
+  ].sort();
+  for (const extension of extensions) {
+    treeParts.push(cString(extension));
+    const byExtension = packed.filter((entry) => entry.extension === extension);
+    const directories = [
+      ...new Set(byExtension.map((entry) => entry.directory)),
+    ].sort();
+    for (const directory of directories) {
+      treeParts.push(cString(directory));
+      for (const entry of byExtension.filter(
+        (candidate) => candidate.directory === directory,
+      )) {
+        treeParts.push(
+          cString(entry.filename),
+          u32(entry.crc32),
+          u16(0),
+          u16(INLINE_ARCHIVE_INDEX),
+          u32(entry.offset),
+          u32(entry.contents.byteLength),
+          u16(ENTRY_TERMINATOR),
+        );
+      }
+      treeParts.push(Buffer.from([0]));
+    }
+    treeParts.push(Buffer.from([0]));
+  }
+  treeParts.push(Buffer.from([0]));
+  const tree = Buffer.concat(treeParts);
+  const data = Buffer.concat(
+    packed.map((entry) => Buffer.from(entry.contents)),
+  );
+  const header = Buffer.concat([
+    u32(VPK_SIGNATURE),
+    u32(VPK_VERSION),
+    u32(tree.byteLength),
+    u32(data.byteLength),
+    u32(0),
+    u32(0),
+    u32(0),
+  ]);
+  return Buffer.concat([header, tree, data]);
+};
+
+export const writeSyntheticVpk = async (
+  outputPath: string,
+  recipe: readonly VpkRecipeEntry[],
+): Promise<void> => {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, buildSyntheticVpk(recipe));
+};

--- a/apps/desktop/e2e/support/world.test.ts
+++ b/apps/desktop/e2e/support/world.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import { access, readFile, writeFile } from "node:fs/promises";
+import {
+  assertOwnedWorld,
+  collectFileInventory,
+  createWorld,
+  removeOwnedWorld,
+} from "./world";
+
+const worlds: string[] = [];
+
+afterEach(async () => {
+  for (const world of worlds.splice(0)) {
+    await removeOwnedWorld(world);
+  }
+});
+
+describe("isolated E2E worlds", () => {
+  it("creates every configured path beneath an owned world", async () => {
+    const world = await createWorld({
+      runId: "unit-run",
+      caseId: "world-contract",
+      attempt: 1,
+      fixtureOrigin: "http://127.0.0.1:43123",
+    });
+    worlds.push(world.directory);
+    const manifest = await assertOwnedWorld(world.directory);
+    expect(manifest.configuration.roots.world).toBe(
+      path.resolve(world.directory),
+    );
+    expect(
+      Object.values(manifest.configuration.roots).every((root) =>
+        root.startsWith(world.directory),
+      ),
+    ).toBe(true);
+    const state = await readFile(
+      path.join(world.configuration.roots.appData, "state.json"),
+      "utf8",
+    );
+    expect(state).toContain("hasCompletedOnboarding");
+    await access(path.join(world.configuration.roots.steam, "steam.exe"));
+  });
+
+  it("records content changes with relative paths and hashes", async () => {
+    const world = await createWorld({
+      runId: "unit-run",
+      caseId: "inventory",
+      attempt: 1,
+      fixtureOrigin: "http://127.0.0.1:43123",
+    });
+    worlds.push(world.directory);
+    const before = await collectFileInventory(world.configuration.roots.game);
+    await writeFile(
+      path.join(world.configuration.roots.game, "change.txt"),
+      "changed",
+    );
+    const after = await collectFileInventory(world.configuration.roots.game);
+    expect(before["change.txt"]).toBeUndefined();
+    expect(after["change.txt"]).toMatch(/^7:/);
+  });
+
+  it("refuses cleanup when the ownership marker was changed", async () => {
+    const world = await createWorld({
+      runId: "unit-run",
+      caseId: "ownership",
+      attempt: 1,
+      fixtureOrigin: "http://127.0.0.1:43123",
+    });
+    worlds.push(world.directory);
+    const manifest = await readFile(world.manifestPath, "utf8");
+    await writeFile(
+      world.manifestPath,
+      manifest.replace("dmm-e2e-harness", "someone-else"),
+    );
+    await expect(removeOwnedWorld(world.directory)).rejects.toThrow("unowned");
+    await writeFile(world.manifestPath, manifest);
+  });
+});

--- a/apps/desktop/e2e/support/world.ts
+++ b/apps/desktop/e2e/support/world.ts
@@ -1,0 +1,244 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import {
+  type E2eConfiguration,
+  type E2eRoots,
+  SERVICE_NAMES,
+  type WorldManifest,
+  worldManifestSchema,
+} from "./contracts";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const REPOSITORY_ROOT = path.resolve(HERE, "../../../..");
+export const WORLDS_ROOT = path.join(REPOSITORY_ROOT, ".e2e", "worlds");
+
+const safeId = (value: string): string => {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  if (normalized.length === 0) {
+    throw new Error(`Cannot make a safe E2E identifier from '${value}'`);
+  }
+  return normalized;
+};
+
+const makeRoots = (world: string): E2eRoots => ({
+  world,
+  game: path.join(world, "game-install"),
+  steam: path.join(world, "steam"),
+  steamHttpCache: path.join(world, "steam-http-cache"),
+  appData: path.join(world, "app-data"),
+  appConfig: path.join(world, "app-config"),
+  appCache: path.join(world, "app-cache"),
+  appLogs: path.join(world, "app-logs"),
+  webviewData: path.join(world, "webview-data"),
+  temporary: path.join(world, "temporary"),
+});
+
+const initialPersistedState = (): string =>
+  JSON.stringify({
+    state: {
+      hasCompletedOnboarding: true,
+      autoUpdateEnabled: false,
+      ingestToolEnabled: false,
+      telemetrySettings: {
+        analyticsEnabled: false,
+        hasSeenTelemetryPrompt: true,
+      },
+    },
+    version: 26,
+  });
+
+const writeInitialFilesystem = async (roots: E2eRoots): Promise<void> => {
+  await Promise.all(
+    Object.values(roots).map((directory) =>
+      mkdir(directory, { recursive: true }),
+    ),
+  );
+  const addons = path.join(roots.game, "game", "citadel", "addons");
+  await mkdir(addons, { recursive: true });
+  await writeFile(
+    path.join(roots.game, "game", "citadel", "gameinfo.gi"),
+    'GameInfo\n{\n  game "Deadlock"\n}\n',
+  );
+  await mkdir(path.join(roots.steam, "steamapps"), { recursive: true });
+  await Promise.all([
+    writeFile(path.join(roots.steam, "steam.exe"), "E2E launch sentinel"),
+    writeFile(path.join(roots.steam, "steam.sh"), "#!/bin/sh\nexit 97\n"),
+  ]);
+  await writeFile(
+    path.join(roots.steam, "steamapps", "libraryfolders.vdf"),
+    `"libraryfolders"\n{\n  "0"\n  {\n    "path" "${roots.steam.replaceAll("\\", "\\\\")}"\n  }\n}\n`,
+  );
+  await writeFile(
+    path.join(roots.appData, "state.json"),
+    JSON.stringify({ "local-config": initialPersistedState() }, null, 2),
+  );
+};
+
+export type CreatedWorld = {
+  directory: string;
+  configPath: string;
+  manifestPath: string;
+  artifactsDirectory: string;
+  configuration: E2eConfiguration;
+};
+
+export const createWorld = async (options: {
+  runId: string;
+  caseId: string;
+  attempt: number;
+  fixtureOrigin: string;
+}): Promise<CreatedWorld> => {
+  const runId = safeId(options.runId);
+  const caseId = safeId(options.caseId);
+  const nonce = createHash("sha256")
+    .update(`${process.pid}:${Date.now()}:${Math.random()}`)
+    .digest("hex")
+    .slice(0, 10);
+  const directory = path.resolve(
+    WORLDS_ROOT,
+    `${runId}-${caseId}-${options.attempt}-${nonce}`,
+  );
+  const roots = makeRoots(directory);
+  await writeInitialFilesystem(roots);
+
+  const artifactsDirectory = path.join(directory, "artifacts");
+  await mkdir(artifactsDirectory, { recursive: true });
+  const tokenFile = path.join(directory, "control-token");
+  await writeFile(
+    tokenFile,
+    createHash("sha256").update(`${nonce}:${Date.now()}`).digest("hex"),
+  );
+
+  const configuration: E2eConfiguration = {
+    schemaVersion: 1,
+    runId,
+    caseId,
+    attempt: options.attempt,
+    applicationIdentity: `dev.stormix.deadlock-mod-manager.e2e.${nonce}`,
+    roots,
+    endpoints: SERVICE_NAMES.map((service) => ({
+      service,
+      origin: options.fixtureOrigin,
+    })),
+    networkMode: "fixture",
+    integrations: {
+      updater: "disabled",
+      steamDiscovery: "fixture",
+      gameLaunch: "record",
+      presence: "disabled",
+      ingestion: "disabled",
+      matchSync: "disabled",
+    },
+    ui: { language: "en", width: 1280, height: 800 },
+    control: { endpoint: `${options.fixtureOrigin}/__control`, tokenFile },
+  };
+  const configPath = path.join(directory, "e2e-config.json");
+  await writeFile(configPath, JSON.stringify(configuration, null, 2));
+
+  const manifestPath = path.join(directory, "world-manifest.json");
+  const manifest: WorldManifest = {
+    schemaVersion: 1,
+    owner: "dmm-e2e-harness",
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    processId: process.pid,
+    configuration,
+  };
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return {
+    directory,
+    configPath,
+    manifestPath,
+    artifactsDirectory,
+    configuration,
+  };
+};
+
+export const assertOwnedWorld = async (
+  directory: string,
+): Promise<WorldManifest> => {
+  const resolved = path.resolve(directory);
+  const relative = path.relative(path.resolve(WORLDS_ROOT), resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to manage world outside ${WORLDS_ROOT}`);
+  }
+  const manifestText = await readFile(
+    path.join(resolved, "world-manifest.json"),
+    "utf8",
+  );
+  let manifest: WorldManifest;
+  try {
+    manifest = worldManifestSchema.parse(JSON.parse(manifestText));
+  } catch {
+    throw new Error(`Refusing to manage unowned E2E world ${resolved}`);
+  }
+  if (
+    manifest.owner !== "dmm-e2e-harness" ||
+    manifest.configuration.roots.world !== resolved
+  ) {
+    throw new Error(`Refusing to manage unowned E2E world ${resolved}`);
+  }
+  return manifest;
+};
+
+export const removeOwnedWorld = async (directory: string): Promise<void> => {
+  await assertOwnedWorld(directory);
+  await rm(path.resolve(directory), {
+    recursive: true,
+    force: false,
+    maxRetries: 20,
+    retryDelay: 250,
+  });
+};
+
+export const collectFileInventory = async (
+  root: string,
+): Promise<Record<string, string>> => {
+  const inventory: Record<string, string> = {};
+  const isMissingEntry = (error: Error): boolean =>
+    "code" in error && error.code === "ENOENT";
+  const visit = async (directory: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (error instanceof Error && isMissingEntry(error)) return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolute);
+      } else if (entry.isFile()) {
+        try {
+          const metadata = await stat(absolute);
+          const hash = createHash("sha256");
+          await pipeline(createReadStream(absolute), hash);
+          const digest = hash.digest("hex");
+          inventory[path.relative(root, absolute).replaceAll("\\", "/")] =
+            `${metadata.size}:${digest}`;
+        } catch (error) {
+          if (error instanceof Error && isMissingEntry(error)) continue;
+          throw error;
+        }
+      }
+    }
+  };
+  await visit(root);
+  return inventory;
+};

--- a/apps/desktop/e2e/wdio.conf.ts
+++ b/apps/desktop/e2e/wdio.conf.ts
@@ -1,0 +1,79 @@
+import path from "node:path";
+
+interface TauriCapability {
+  browserName: "tauri";
+  "tauri:options": {
+    application: string;
+    args: string[];
+  };
+}
+
+type TauriWdioConfig = Omit<WebdriverIO.Config, "capabilities"> & {
+  capabilities: TauriCapability[];
+};
+
+const requiredEnvironment = (name: string): string => {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0)
+    throw new Error(`${name} is required`);
+  return value;
+};
+
+const provider = requiredEnvironment("DMM_E2E_PROVIDER");
+if (provider !== "embedded" && provider !== "external") {
+  throw new Error(`Unsupported DMM_E2E_PROVIDER '${provider}'`);
+}
+const binaryPath = path.resolve(requiredEnvironment("DMM_E2E_BINARY"));
+const artifacts = path.resolve(requiredEnvironment("DMM_E2E_ARTIFACTS"));
+
+export const config: TauriWdioConfig = {
+  runner: "local",
+  specs: ["./specs/about.e2e.ts"],
+  maxInstances: 1,
+  capabilities: [
+    {
+      browserName: "tauri",
+      "tauri:options": {
+        application: binaryPath,
+        args: ["--disable-auto-update"],
+      },
+    },
+  ],
+  services: [
+    [
+      "@wdio/tauri-service",
+      {
+        appBinaryPath: binaryPath,
+        appArgs: ["--disable-auto-update"],
+        driverProvider: provider,
+        autoInstallTauriDriver: false,
+        // v1.3.0 performs this preflight before branching on the provider.
+        // Keeping it enabled prevents an embedded run from aborting on the
+        // machine-global EdgeDriver that only the external provider needs.
+        autoDownloadEdgeDriver: true,
+        captureBackendLogs: true,
+        captureFrontendLogs: false,
+        startTimeout: 60_000,
+        statusPollTimeout: 5_000,
+      },
+    ],
+  ],
+  logLevel: "warn",
+  bail: 0,
+  waitforTimeout: 15_000,
+  connectionRetryTimeout: 60_000,
+  connectionRetryCount: 0,
+  framework: "mocha",
+  reporters: [["spec", { addConsoleLogs: true }]],
+  mochaOpts: { ui: "bdd", timeout: 45_000 },
+  afterTest: async (
+    test: { title: string },
+    _context: object,
+    result: { passed: boolean },
+  ): Promise<void> => {
+    if (!result.passed) {
+      const name = test.title.replace(/[^a-z0-9_-]+/gi, "-").toLowerCase();
+      await browser.saveScreenshot(path.join(artifacts, `${name}.png`));
+    }
+  },
+};

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,7 +23,13 @@
     "cef:cleanup": "bun scripts/cef-patch.ts cleanup",
     "format:rust": "cd src-tauri && rustfmt",
     "generate-types": "cd src-tauri && cargo test --lib export_bindings --quiet && cd .. && pnpm exec oxfmt src/types/generated --write",
-    "generate:gamebanana-heroes": "bun scripts/generate-gamebanana-hero-registry.ts"
+    "generate:gamebanana-heroes": "bun scripts/generate-gamebanana-hero-registry.ts",
+    "e2e:build": "cross-env VITE_DMM_E2E_HARNESS=1 pnpm tauri build --debug --no-bundle --features e2e-harness --config src-tauri/tauri.e2e.conf.json",
+    "e2e:doctor": "tsx e2e/cli.ts doctor",
+    "e2e:test": "tsx e2e/cli.ts run",
+    "e2e:qualify": "tsx e2e/cli.ts qualify",
+    "e2e:test:world": "bun test ./e2e",
+    "e2e:check-types": "tsgo --noEmit --skipLibCheck -p tsconfig.e2e.json"
   },
   "dependencies": {
     "@deadlock-mods/common": "workspace:*",
@@ -94,17 +100,27 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.1",
+    "@types/mocha": "10.0.10",
     "@types/node": "^20.19.37",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "catalog:",
     "@vitejs/plugin-react": "^5.2.0",
+    "@wdio/cli": "9.31.5",
+    "@wdio/globals": "9.31.3",
+    "@wdio/local-runner": "9.31.5",
+    "@wdio/mocha-framework": "9.31.5",
+    "@wdio/spec-reporter": "9.31.2",
+    "@wdio/tauri-plugin": "1.3.0",
+    "@wdio/tauri-service": "1.3.0",
     "autoprefixer": "^10.4.27",
     "dotenv-cli": "^7.4.4",
     "postcss": "^8.5.11",
     "tailwind-scrollbar": "^3.1.0",
+    "tsx": "4.21.0",
     "typescript": "catalog:",
     "unplugin-fonts": "^1.4.0",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "webdriverio": "9.31.5"
   }
 }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [features]
 default = ["tauri-wry"]
 tauri-wry = ["tauri/wry"]
+e2e-harness = ["dep:tauri-plugin-wdio", "dep:tauri-plugin-wdio-webdriver"]
 
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }
@@ -27,6 +28,8 @@ tauri = { version = "2.11.1", default-features = false, features = [
   "dynamic-acl",
 ] }
 tauri-plugin-mcp-bridge = "0.11.1"
+tauri-plugin-wdio = { version = "1.3.0", optional = true }
+tauri-plugin-wdio-webdriver = { version = "1.3.0", optional = true }
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-http = "2.5.9"
 serde = { version = "1", features = ["derive"] }

--- a/apps/desktop/src-tauri/src/commands/app.rs
+++ b/apps/desktop/src-tauri/src/commands/app.rs
@@ -11,6 +11,41 @@ pub struct FilesystemWritableStatus {
   pub gameinfo_writable: bool,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBootstrap {
+  pub mode: &'static str,
+  pub state_store_path: String,
+  pub app_data_path: Option<String>,
+  pub endpoints: Vec<crate::runtime_environment::ServiceEndpoint>,
+  pub integrations: Option<crate::runtime_environment::IntegrationPolicy>,
+}
+
+#[tauri::command]
+pub fn get_runtime_bootstrap() -> RuntimeBootstrap {
+  let environment = crate::runtime_environment::current();
+  RuntimeBootstrap {
+    mode: if environment.e2e().is_some() {
+      "e2e"
+    } else {
+      "production"
+    },
+    state_store_path: crate::runtime_environment::state_store_path()
+      .to_string_lossy()
+      .into_owned(),
+    app_data_path: environment
+      .e2e()
+      .map(|configuration| configuration.roots.app_data.to_string_lossy().into_owned()),
+    endpoints: environment
+      .e2e()
+      .map(|configuration| configuration.endpoints.clone())
+      .unwrap_or_default(),
+    integrations: environment
+      .e2e()
+      .map(|configuration| configuration.integrations),
+  }
+}
+
 #[tauri::command]
 pub async fn set_api_url(api_url: String) -> Result<(), Error> {
   log::info!("Setting API URL to: {api_url}");

--- a/apps/desktop/src-tauri/src/commands/auth.rs
+++ b/apps/desktop/src-tauri/src/commands/auth.rs
@@ -7,7 +7,7 @@ pub async fn store_auth_token(app_handle: AppHandle, token: String) -> Result<()
   log::info!("Storing authentication token");
 
   let store = app_handle
-    .store("state.json")
+    .store(crate::runtime_environment::state_store_path())
     .map_err(|e| Error::InvalidInput(format!("Failed to access store: {e}")))?;
 
   store.set("auth_token", serde_json::json!(token));
@@ -24,7 +24,7 @@ pub async fn get_auth_token(app_handle: AppHandle) -> Result<Option<String>, Err
   log::debug!("Retrieving authentication token");
 
   let store = app_handle
-    .store("state.json")
+    .store(crate::runtime_environment::state_store_path())
     .map_err(|e| Error::InvalidInput(format!("Failed to access store: {e}")))?;
 
   let token = store.get("auth_token");
@@ -46,7 +46,7 @@ pub async fn clear_auth_token(app_handle: AppHandle) -> Result<(), Error> {
   log::info!("Clearing authentication token");
 
   let store = app_handle
-    .store("state.json")
+    .store(crate::runtime_environment::state_store_path())
     .map_err(|e| Error::InvalidInput(format!("Failed to access store: {e}")))?;
 
   let _ = store.delete("auth_token");

--- a/apps/desktop/src-tauri/src/commands/downloads.rs
+++ b/apps/desktop/src-tauri/src/commands/downloads.rs
@@ -5,7 +5,6 @@ use crate::mod_manager::ModFileTree;
 use futures::future::join_all;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
-use tauri::Manager;
 use tauri::State;
 
 use super::mods::InstalledModInfo;
@@ -43,10 +42,8 @@ pub async fn queue_download(
   )
   .await?;
 
-  let app_local_data_dir = app_handle
-    .path()
-    .app_local_data_dir()
-    .map_err(Error::Tauri)?;
+  let app_local_data_dir =
+    crate::runtime_environment::app_local_data_dir(&app_handle).map_err(Error::Tauri)?;
 
   let target_dir = app_local_data_dir.join("mods").join(&mod_id);
 

--- a/apps/desktop/src-tauri/src/commands/e2e.rs
+++ b/apps/desktop/src-tauri/src/commands/e2e.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+
+use crate::runtime_environment::{E2eRoots, FixtureOnly, ServiceEndpoint};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct E2eStatus {
+  schema_version: u32,
+  run_id: String,
+  case_id: String,
+  attempt: u32,
+  application_identity: String,
+  runtime: &'static str,
+  roots: E2eRoots,
+  endpoints: Vec<ServiceEndpoint>,
+  network_mode: FixtureOnly,
+}
+
+#[tauri::command]
+pub fn e2e_status() -> Result<E2eStatus, String> {
+  let configuration = crate::runtime_environment::current()
+    .e2e()
+    .ok_or_else(|| "E2E runtime is not active".to_string())?;
+
+  Ok(E2eStatus {
+    schema_version: configuration.schema_version,
+    run_id: configuration.run_id.clone(),
+    case_id: configuration.case_id.clone(),
+    attempt: configuration.attempt,
+    application_identity: configuration.application_identity.clone(),
+    runtime: if cfg!(feature = "cef") { "cef" } else { "wry" },
+    roots: configuration.roots.clone(),
+    endpoints: configuration.endpoints.clone(),
+    network_mode: configuration.network_mode,
+  })
+}

--- a/apps/desktop/src-tauri/src/commands/forge.rs
+++ b/apps/desktop/src-tauri/src/commands/forge.rs
@@ -2,7 +2,6 @@ use crate::app_runtime::AppHandle;
 use crate::errors::Error;
 use crate::forge_bridge;
 use std::path::{Component, Path, PathBuf};
-use tauri::Manager;
 
 #[tauri::command]
 pub async fn start_forge_bridge(app_handle: AppHandle) -> Result<u16, Error> {
@@ -24,9 +23,7 @@ pub async fn place_forge_payload(
   destination: String,
 ) -> Result<(), Error> {
   let staged = forge_bridge::peek_staged(&path)?;
-  let mods_root = app_handle
-    .path()
-    .app_local_data_dir()
+  let mods_root = crate::runtime_environment::app_local_data_dir(&app_handle)
     .map_err(Error::Tauri)?
     .join("mods");
   let destination = contained_destination(&mods_root, &destination)?;

--- a/apps/desktop/src-tauri/src/commands/game.rs
+++ b/apps/desktop/src-tauri/src/commands/game.rs
@@ -14,6 +14,10 @@ use super::state::MANAGER;
 const GAME_LAUNCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 async fn await_launched_game(monitor: SteamUriLaunchMonitor) -> Result<(), Error> {
+  if monitor.was_recorded() {
+    return monitor.wait().await;
+  }
+
   let launcher = monitor.wait();
   let game = wait_for_game_start(GAME_START_TIMEOUT, GAME_LAUNCH_POLL_INTERVAL, pending());
   tokio::pin!(launcher, game);
@@ -42,6 +46,14 @@ async fn await_launched_game(monitor: SteamUriLaunchMonitor) -> Result<(), Error
 #[tauri::command]
 pub async fn find_game_path() -> Result<String, Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
+  if crate::runtime_environment::is_e2e_active() {
+    let configuration = crate::runtime_environment::current()
+      .e2e()
+      .expect("active E2E runtime has a configuration");
+    let game_path = mod_manager.set_game_path(configuration.roots.game.clone())?;
+    mod_manager.set_steam_path(configuration.roots.steam.clone())?;
+    return Ok(game_path.to_string_lossy().into_owned());
+  }
   match (mod_manager.find_steam(), mod_manager.find_game()) {
     (Ok(_), Ok(game_path)) => {
       log::info!("Found game at: {game_path:?}");
@@ -62,6 +74,8 @@ pub async fn find_game_path() -> Result<String, Error> {
 pub async fn set_game_path(path: String) -> Result<String, Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
   let path_buf = PathBuf::from(&path);
+  crate::runtime_environment::ensure_e2e_managed_path(&path_buf)
+    .map_err(Error::UnauthorizedPath)?;
   let game_path = mod_manager.set_game_path(path_buf)?;
   log::info!("Game path manually set to: {game_path:?}");
   Ok(game_path.to_string_lossy().to_string())
@@ -70,6 +84,13 @@ pub async fn set_game_path(path: String) -> Result<String, Error> {
 #[tauri::command]
 pub async fn find_steam_path() -> Result<String, Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
+  if crate::runtime_environment::is_e2e_active() {
+    let configuration = crate::runtime_environment::current()
+      .e2e()
+      .expect("active E2E runtime has a configuration");
+    let steam_path = mod_manager.set_steam_path(configuration.roots.steam.clone())?;
+    return Ok(steam_path.to_string_lossy().into_owned());
+  }
   let steam_path = mod_manager.find_steam_path()?;
   log::info!("Found Steam at: {steam_path:?}");
   Ok(steam_path.to_string_lossy().to_string())
@@ -79,6 +100,8 @@ pub async fn find_steam_path() -> Result<String, Error> {
 pub async fn set_steam_path(path: String) -> Result<String, Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
   let path_buf = PathBuf::from(&path);
+  crate::runtime_environment::ensure_e2e_managed_path(&path_buf)
+    .map_err(Error::UnauthorizedPath)?;
   let steam_path = mod_manager.set_steam_path(path_buf)?;
   log::info!("Steam path manually set to: {steam_path:?}");
   Ok(steam_path.to_string_lossy().to_string())
@@ -87,6 +110,13 @@ pub async fn set_steam_path(path: String) -> Result<String, Error> {
 #[tauri::command]
 pub async fn clear_steam_path() -> Result<(), Error> {
   let mut mod_manager = MANAGER.lock().unwrap();
+  if crate::runtime_environment::is_e2e_active() {
+    let configuration = crate::runtime_environment::current()
+      .e2e()
+      .expect("active E2E runtime has a configuration");
+    mod_manager.set_steam_path(configuration.roots.steam.clone())?;
+    return Ok(());
+  }
   mod_manager.clear_steam_path();
   Ok(())
 }
@@ -154,12 +184,18 @@ pub async fn launch_game_direct(additional_args: String) -> Result<(), Error> {
 
 #[tauri::command]
 pub async fn stop_game() -> Result<(), Error> {
+  if crate::runtime_environment::records_game_launches() {
+    return Ok(());
+  }
   let mut mod_manager = MANAGER.lock().unwrap();
   mod_manager.stop_game()
 }
 
 #[tauri::command]
 pub async fn is_game_running() -> Result<bool, Error> {
+  if crate::runtime_environment::records_game_launches() {
+    return Ok(false);
+  }
   let mut mod_manager = MANAGER.lock().unwrap();
   mod_manager.is_game_running()
 }

--- a/apps/desktop/src-tauri/src/commands/identity_migration.rs
+++ b/apps/desktop/src-tauri/src/commands/identity_migration.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
-use tauri::Manager;
 
 const JOURNAL_FILE: &str = "gamebanana-identity-migration-v1.json";
 const MAX_MIGRATIONS: usize = 10_000;
@@ -32,10 +31,8 @@ pub async fn migrate_submission_identities(
   app_handle: AppHandle,
   migrations: Vec<IdentityMigration>,
 ) -> Result<(), Error> {
-  let app_data = app_handle
-    .path()
-    .app_local_data_dir()
-    .map_err(Error::Tauri)?;
+  let app_data =
+    crate::runtime_environment::app_local_data_dir(&app_handle).map_err(Error::Tauri)?;
   let game_path = super::state::game_path()?;
   tokio::task::spawn_blocking(move || migrate_on_disk(&app_data, &game_path, migrations))
     .await

--- a/apps/desktop/src-tauri/src/commands/ingest.rs
+++ b/apps/desktop/src-tauri/src/commands/ingest.rs
@@ -15,6 +15,9 @@ pub struct IngestStatus {
 
 #[tauri::command]
 pub async fn trigger_cache_scan() -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   log::info!("Triggering cache scan");
 
   let cache_dir = ingest_tool::get_cache_directory()
@@ -29,6 +32,9 @@ pub async fn trigger_cache_scan() -> Result<(), Error> {
 
 #[tauri::command]
 pub async fn start_cache_watcher() -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   log::info!("Starting cache watcher");
 
   let cache_dir = ingest_tool::get_cache_directory()
@@ -95,6 +101,15 @@ pub async fn stop_cache_watcher() -> Result<(), Error> {
 
 #[tauri::command]
 pub async fn get_ingest_status() -> Result<IngestStatus, Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    let configuration = crate::runtime_environment::current()
+      .e2e()
+      .expect("active E2E runtime has a configuration");
+    return Ok(IngestStatus {
+      is_running: false,
+      cache_directory: Some(configuration.roots.steam_http_cache.display().to_string()),
+    });
+  }
   let is_running = INGEST_WATCHER_RUNNING.load(Ordering::Relaxed);
   let cache_directory = ingest_tool::get_cache_directory().map(|p| p.display().to_string());
 
@@ -106,6 +121,9 @@ pub async fn get_ingest_status() -> Result<IngestStatus, Error> {
 
 #[tauri::command]
 pub async fn initialize_ingest_tool() -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   log::info!("Initializing ingest tool on startup");
 
   if INGEST_WATCHER_RUNNING.load(Ordering::Relaxed) {

--- a/apps/desktop/src-tauri/src/commands/match_sync.rs
+++ b/apps/desktop/src-tauri/src/commands/match_sync.rs
@@ -5,6 +5,15 @@ use crate::match_sync::{self, LocalMatch, MatchSyncStatusDto};
 
 #[tauri::command]
 pub async fn get_match_sync_status(app_handle: AppHandle) -> Result<MatchSyncStatusDto, Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(MatchSyncStatusDto {
+      enabled: false,
+      consent_accepted: false,
+      full_sync_running: false,
+      session_fetches: 0,
+      accounts: Vec::new(),
+    });
+  }
   Ok(match_sync::status(&app_handle)?)
 }
 
@@ -16,17 +25,26 @@ pub async fn get_local_match_history(
   app_handle: AppHandle,
   account_id: u32,
 ) -> Result<Vec<LocalMatch>, Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(Vec::new());
+  }
   Ok(match_sync::recent_local_matches(&app_handle, account_id).await)
 }
 
 #[tauri::command]
 pub async fn set_match_sync_consent(app_handle: AppHandle, accepted: bool) -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   match_sync::set_consent(&app_handle, accepted)?;
   Ok(())
 }
 
 #[tauri::command]
 pub async fn set_match_sync_enabled(app_handle: AppHandle, enabled: bool) -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   match_sync::set_enabled(&app_handle, enabled)?;
   // Enabling starts (and disabling stops) the game-exit detect-only watcher.
   game_presence::sync_monitoring_watcher(&app_handle);
@@ -35,12 +53,18 @@ pub async fn set_match_sync_enabled(app_handle: AppHandle, enabled: bool) -> Res
 
 #[tauri::command]
 pub async fn start_full_match_sync(app_handle: AppHandle) -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   match_sync::spawn_full_sync(app_handle)?;
   Ok(())
 }
 
 #[tauri::command]
 pub async fn cancel_full_match_sync() -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   match_sync::cancel_full_sync();
   Ok(())
 }
@@ -49,6 +73,9 @@ pub async fn cancel_full_match_sync() -> Result<(), Error> {
 // game-exit watcher iff the user previously opted in. A no-op otherwise.
 #[tauri::command]
 pub async fn resume_match_sync_monitoring(app_handle: AppHandle) -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(());
+  }
   // Startup-only cleanup of persisted state for accounts removed from Steam entirely.
   match_sync::prune_forgotten_accounts(&app_handle);
   match_sync::start_background_worker(app_handle.clone());

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -8,6 +8,8 @@ pub mod backups;
 pub mod deadworks_content;
 pub mod deep_link;
 pub mod downloads;
+#[cfg(feature = "e2e-harness")]
+pub mod e2e;
 pub mod folders;
 pub mod fonts;
 pub mod forge;

--- a/apps/desktop/src-tauri/src/commands/mods.rs
+++ b/apps/desktop/src-tauri/src/commands/mods.rs
@@ -11,7 +11,7 @@ use crate::mod_manager::vpk_manager::VpkManager;
 use crate::mod_manager::vpk_manager::staging::VpkSnapshot;
 use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use serde::{Deserialize, Serialize};
-use tauri::{Emitter, Manager, State};
+use tauri::{Emitter, State};
 
 use super::downloads::{get_download_manager, resolve_download_files};
 use super::fonts::{apply_font_cleanup, prepare_font_cleanup};
@@ -354,10 +354,8 @@ pub async fn batch_update_mods(
       )
       .ok();
 
-    let app_local_data_dir = app_handle
-      .path()
-      .app_local_data_dir()
-      .map_err(Error::Tauri)?;
+    let app_local_data_dir =
+      crate::runtime_environment::app_local_data_dir(&app_handle).map_err(Error::Tauri)?;
     let target_dir = app_local_data_dir.join("mods").join(&mod_data.mod_id);
 
     let task = DownloadTask {
@@ -446,8 +444,7 @@ pub async fn batch_update_mods(
   let mut vpk_mappings = Vec::new();
   if !succeeded.is_empty() {
     let mut mod_manager = MANAGER.lock().unwrap();
-    if let Err(error) = mod_manager.reorder_all_mods_for_profile(profile_folder_option.clone())
-    {
+    if let Err(error) = mod_manager.reorder_all_mods_for_profile(profile_folder_option.clone()) {
       log::warn!("Post-batch reorder failed: {error}");
     }
     if let Ok(addons_path) = mod_manager.get_addons_path(profile_folder_option.as_deref())

--- a/apps/desktop/src-tauri/src/commands/profiles.rs
+++ b/apps/desktop/src-tauri/src/commands/profiles.rs
@@ -5,7 +5,7 @@ use crate::mod_manager::Mod;
 use crate::mod_manager::shard::{ShardIndex, ShardLocator};
 use crate::mod_manager::vpk_manifest::ProfileVpkManifest;
 use serde::{Deserialize, Serialize};
-use tauri::{Emitter, Manager, State};
+use tauri::{Emitter, State};
 
 use super::downloads::{get_download_manager, resolve_download_files};
 use super::mods::InstalledModInfo;
@@ -401,10 +401,8 @@ pub async fn import_profile_batch(
       )
       .ok();
 
-    let app_local_data_dir = app_handle
-      .path()
-      .app_local_data_dir()
-      .map_err(Error::Tauri)?;
+    let app_local_data_dir =
+      crate::runtime_environment::app_local_data_dir(&app_handle).map_err(Error::Tauri)?;
     let target_dir = app_local_data_dir.join("mods").join(&mod_data.mod_id);
 
     let task = DownloadTask {

--- a/apps/desktop/src-tauri/src/commands/state.rs
+++ b/apps/desktop/src-tauri/src/commands/state.rs
@@ -42,6 +42,14 @@ pub(crate) fn game_path() -> Result<PathBuf, Error> {
 }
 
 pub fn get_api_url() -> String {
+  if let Some(configuration) = crate::runtime_environment::current().e2e()
+    && let Some(endpoint) = configuration
+      .endpoints
+      .iter()
+      .find(|endpoint| endpoint.service == crate::runtime_environment::ServiceName::DmmApi)
+  {
+    return endpoint.origin.clone();
+  }
   match API_URL.lock() {
     Ok(url) => url.clone(),
     Err(_) => {

--- a/apps/desktop/src-tauri/src/commands/steam_user.rs
+++ b/apps/desktop/src-tauri/src/commands/steam_user.rs
@@ -8,6 +8,9 @@ use crate::steam_user::{self, SteamAccountDto};
 /// runs on the blocking pool instead of a runtime thread.
 #[tauri::command]
 pub async fn get_steam_accounts() -> Result<Vec<SteamAccountDto>, Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    return Ok(Vec::new());
+  }
   let accounts = tauri::async_runtime::spawn_blocking(steam_user::list_accounts)
     .await
     .unwrap_or_else(|e| {

--- a/apps/desktop/src-tauri/src/game_presence.rs
+++ b/apps/desktop/src-tauri/src/game_presence.rs
@@ -184,6 +184,12 @@ fn spawn_watcher(app_handle: &AppHandle, presence_enabled: bool) -> Result<(), E
 }
 
 pub(crate) fn ensure_watcher(app_handle: &AppHandle) -> Result<(), Error> {
+  if crate::runtime_environment::is_e2e_active() {
+    PRESENCE_DESIRED.store(false, Ordering::Relaxed);
+    MONITORING_DESIRED.store(false, Ordering::Relaxed);
+    stop_current(Some(app_handle));
+    return Ok(());
+  }
   let _guard = COORDINATOR_LOCK
     .lock()
     .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod mod_manager;
 pub mod providers;
 pub mod proxy;
 mod reports;
+pub mod runtime_environment;
 mod steam_user;
 mod updater_channel;
 mod utils;
@@ -33,16 +34,21 @@ use tauri_plugin_store::StoreExt;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+  runtime_environment::initialize().expect("failed to initialize runtime environment");
+  runtime_environment::configure_process();
+
   #[cfg(debug_assertions)]
   {
-    if let Err(e) = dotenvy::dotenv() {
-      if e.not_found() {
-        log::debug!("No .env file found, continuing without it");
+    if runtime_environment::current().e2e().is_none() {
+      if let Err(e) = dotenvy::dotenv() {
+        if e.not_found() {
+          log::debug!("No .env file found, continuing without it");
+        } else {
+          log::warn!("Failed to load .env file: {e}");
+        }
       } else {
-        log::warn!("Failed to load .env file: {e}");
+        log::info!("Loaded environment variables from .env file");
       }
-    } else {
-      log::info!("Loaded environment variables from .env file");
     }
   }
 
@@ -51,21 +57,36 @@ pub fn run() {
 
   #[cfg(all(debug_assertions, desktop))]
   {
-    builder = builder.plugin(
-      tauri_plugin_mcp_bridge::Builder::new()
-        .bind_address("127.0.0.1")
-        .build(),
-    );
+    if runtime_environment::current().e2e().is_none() {
+      builder = builder.plugin(
+        tauri_plugin_mcp_bridge::Builder::new()
+          .bind_address("127.0.0.1")
+          .build(),
+      );
+    }
   }
 
   #[cfg(desktop)]
   {
-    builder = builder.plugin(tauri_plugin_single_instance::init(
-      deep_link::on_second_instance,
-    ));
+    if runtime_environment::current().e2e().is_none() {
+      builder = builder.plugin(tauri_plugin_single_instance::init(
+        deep_link::on_second_instance,
+      ));
+    }
   }
   let mut context: tauri::Context<app_runtime::AppRuntime> = tauri::generate_context!();
+  runtime_environment::apply_to_context(&mut context);
   updater_channel::apply_to_context(&mut context);
+
+  let log_file_target = runtime_environment::current()
+    .e2e()
+    .map(|configuration| TargetKind::Folder {
+      path: configuration.roots.app_logs.clone(),
+      file_name: Some("deadlock-mod-manager".into()),
+    })
+    .unwrap_or(TargetKind::LogDir {
+      file_name: Some("deadlock-mod-manager".into()),
+    });
 
   builder = builder
     .plugin(tauri_plugin_deep_link::init())
@@ -82,43 +103,80 @@ pub fn run() {
         .clear_targets()
         .targets([
           Target::new(TargetKind::Stdout),
-          Target::new(TargetKind::LogDir {
-            file_name: Some("deadlock-mod-manager".into()),
-          }),
+          Target::new(log_file_target),
         ])
         .max_file_size(1_000_000)
         .level(log::LevelFilter::Info)
         .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
         .filter(|metadata| metadata.target() != "tracing")
         .build(),
-    )
-    .plugin(tauri_plugin_machine_uid::init());
+    );
+
+  if runtime_environment::current().e2e().is_none() {
+    builder = builder.plugin(tauri_plugin_machine_uid::init());
+  }
+
+  #[cfg(feature = "e2e-harness")]
+  {
+    // tauri-plugin-wdio installs a fallback logger during setup. Register it
+    // after the application logger so the plugin observes the existing logger
+    // instead of preventing tauri-plugin-log from initializing.
+    builder = builder.plugin(tauri_plugin_wdio::init());
+    if std::env::var("WDIO_EMBEDDED_SERVER").as_deref() == Ok("true") {
+      builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
+    }
+  }
 
   builder
     .manage(game_presence::DiscordState::new())
     .setup(|app| {
-      let _store = app.store("state.json")?;
-      deep_link::setup(app)?;
+      #[cfg(feature = "e2e-harness")]
+      {
+        let capability = tauri::ipc::CapabilityBuilder::new("e2e-wdio")
+          .window("main")
+          .permission("wdio:default")
+          .permission_scoped(
+            "http:default",
+            runtime_environment::current()
+              .e2e()
+              .expect("e2e-harness builds require an E2E configuration")
+              .endpoints
+              .iter()
+              .map(|endpoint| serde_json::json!({ "url": format!("{}/**", endpoint.origin) }))
+              .collect(),
+            Vec::<serde_json::Value>::new(),
+          );
+        let capability = if std::env::var("WDIO_EMBEDDED_SERVER").as_deref() == Ok("true") {
+          capability.permission("wdio-webdriver:default")
+        } else {
+          capability
+        };
+        app.add_capability(capability)?;
+      }
 
-      let catalog_path = app
-        .path()
-        .app_local_data_dir()?
-        .join("gamebanana-catalog.db");
+      let _store = app.store(runtime_environment::state_store_path())?;
+      if runtime_environment::current().e2e().is_none() {
+        deep_link::setup(app)?;
+      }
+
+      let catalog_path =
+        runtime_environment::app_local_data_dir(app.handle())?.join("gamebanana-catalog.db");
       let catalog_state = tauri::async_runtime::block_on(
         commands::gamebanana_catalog::GameBananaCatalogState::open(catalog_path),
       );
       app.manage(catalog_state);
       app.manage(commands::policy::PolicyState::open(
-        app
-          .path()
-          .app_local_data_dir()?
-          .join("policy-manifest-v1.json"),
+        runtime_environment::app_local_data_dir(app.handle())?.join("policy-manifest-v1.json"),
       ));
 
       {
         let mut mod_manager = commands::state::MANAGER
           .lock()
           .map_err(|e| format!("Failed to acquire mod manager lock: {e}"))?;
+        if let Some(configuration) = runtime_environment::current().e2e() {
+          mod_manager.set_steam_path(configuration.roots.steam.clone())?;
+          mod_manager.set_game_path(configuration.roots.game.clone())?;
+        }
         mod_manager.set_app_handle(app.handle().clone());
       }
 
@@ -178,6 +236,7 @@ pub fn run() {
       commands::gameinfo::open_gameinfo_editor,
       commands::app::set_language,
       commands::app::set_api_url,
+      commands::app::get_runtime_bootstrap,
       commands::app::is_auto_update_disabled,
       commands::app::get_runtime_kind,
       flatpak::is_flatpak,
@@ -311,7 +370,9 @@ pub fn run() {
       proxy::get_proxy_config,
       proxy::test_proxy_connection,
       updater_channel::get_update_channel,
-      updater_channel::set_update_channel
+      updater_channel::set_update_channel,
+      #[cfg(feature = "e2e-harness")]
+      commands::e2e::e2e_status
     ])
     .run(context)
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/logs/log_manager.rs
+++ b/apps/desktop/src-tauri/src/logs/log_manager.rs
@@ -3,7 +3,6 @@ use crate::errors::Error;
 use crate::logs::crash_dumps;
 use crate::utils;
 use serde::{Deserialize, Serialize};
-use tauri::Manager;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LogFileInfo {
@@ -22,9 +21,7 @@ pub struct LogInfo {
 pub async fn get_log_info(app_handle: &AppHandle) -> Result<LogInfo, Error> {
   log::info!("Getting log info");
 
-  let log_dir = app_handle
-    .path()
-    .app_log_dir()
+  let log_dir = crate::runtime_environment::app_log_dir(app_handle)
     .map_err(|e| Error::InvalidInput(format!("Failed to get log directory: {e}")))?;
 
   let mut files = Vec::new();
@@ -67,9 +64,7 @@ pub async fn get_log_info(app_handle: &AppHandle) -> Result<LogInfo, Error> {
 pub fn open_logs_folder(app_handle: &AppHandle) -> Result<(), Error> {
   log::info!("Opening logs folder");
 
-  let log_dir = app_handle
-    .path()
-    .app_log_dir()
+  let log_dir = crate::runtime_environment::app_log_dir(app_handle)
     .map_err(|e| Error::InvalidInput(format!("Failed to get log directory: {e}")))?;
 
   if !log_dir.exists() {
@@ -83,9 +78,7 @@ pub fn open_logs_folder(app_handle: &AppHandle) -> Result<(), Error> {
 pub fn open_log_file(app_handle: &AppHandle) -> Result<(), Error> {
   log::info!("Opening latest log file");
 
-  let log_dir = app_handle
-    .path()
-    .app_log_dir()
+  let log_dir = crate::runtime_environment::app_log_dir(app_handle)
     .map_err(|e| Error::InvalidInput(format!("Failed to get log directory: {e}")))?;
 
   let main_log = log_dir.join("deadlock-mod-manager.log");
@@ -115,9 +108,7 @@ pub async fn get_logs_for_ai(
   let include_crash = log_source == "crash" || log_source == "combined";
 
   if include_dmm {
-    let log_dir = app_handle
-      .path()
-      .app_log_dir()
+    let log_dir = crate::runtime_environment::app_log_dir(app_handle)
       .map_err(|e| Error::InvalidInput(format!("Failed to get log directory: {e}")))?;
 
     let main_log = log_dir.join("deadlock-mod-manager.log");

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -123,6 +123,11 @@ fn main() {
   let _ = fix_path_env::fix();
 
   desktop_lib::cli::get_cli_args();
+  if let Err(error) = desktop_lib::runtime_environment::initialize() {
+    eprintln!("[E2E] Refusing to start: {error}");
+    std::process::exit(2);
+  }
+  desktop_lib::runtime_environment::configure_process();
 
   #[cfg(target_os = "linux")]
   {

--- a/apps/desktop/src-tauri/src/mod_manager/manager.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager.rs
@@ -19,7 +19,6 @@ use std::{
   collections::{BTreeMap, HashSet},
   path::{Component, Path, PathBuf},
 };
-use tauri::Manager;
 
 mod gameinfo;
 mod lifecycle;
@@ -64,8 +63,11 @@ impl ModManager {
       app_handle: None,
     };
 
-    // Try to find the game path on initialization
-    if let Err(e) = manager.find_game() {
+    // Harness worlds are configured explicitly during Tauri setup. Never scan
+    // the host for Steam or Deadlock when an isolated runtime is active.
+    if !crate::runtime_environment::is_e2e_active()
+      && let Err(e) = manager.find_game()
+    {
       log::warn!("Failed to find game path during initialization: {e:?}");
     }
 
@@ -324,7 +326,7 @@ impl ModManager {
       .app_handle
       .as_ref()
       .ok_or(Error::AppHandleNotInitialized)?;
-    app_handle.path().app_local_data_dir().map_err(Error::Tauri)
+    crate::runtime_environment::app_local_data_dir(app_handle).map_err(Error::Tauri)
   }
 
   pub fn get_mods_store_path(&self) -> Result<std::path::PathBuf, Error> {

--- a/apps/desktop/src-tauri/src/mod_manager/steam_uri_launcher.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/steam_uri_launcher.rs
@@ -26,6 +26,7 @@ pub(crate) struct SteamUriLaunchRequest {
 #[derive(Debug)]
 pub(crate) struct SteamUriLaunchMonitor {
   task: JoinHandle<Result<(), Error>>,
+  recorded: bool,
 }
 
 impl SteamUriLaunchRequest {
@@ -46,6 +47,17 @@ impl SteamUriLaunchRequest {
   }
 
   pub(crate) fn spawn(self) -> Result<SteamUriLaunchMonitor, Error> {
+    if crate::runtime_environment::records_game_launches() {
+      crate::runtime_environment::record_game_launch(&self.program, &redacted_steam_uri(&self.uri))
+        .map_err(|error| {
+          Error::GameLaunchFailed(format!("failed to record E2E game launch: {error}"))
+        })?;
+      return Ok(SteamUriLaunchMonitor {
+        task: tokio::spawn(async { Ok(()) }),
+        recorded: true,
+      });
+    }
+
     let mut child = Command::new(&self.program)
       .arg(&self.uri)
       .stdout(Stdio::null())
@@ -80,7 +92,10 @@ impl SteamUriLaunchRequest {
       outcome
     });
 
-    Ok(SteamUriLaunchMonitor { task })
+    Ok(SteamUriLaunchMonitor {
+      task,
+      recorded: false,
+    })
   }
 
   #[cfg(test)]
@@ -95,6 +110,10 @@ impl SteamUriLaunchRequest {
 }
 
 impl SteamUriLaunchMonitor {
+  pub(crate) fn was_recorded(&self) -> bool {
+    self.recorded
+  }
+
   pub(crate) async fn wait(self) -> Result<(), Error> {
     self.task.await.map_err(|error| {
       Error::BackgroundTaskFailed(format!("Steam URI launcher task failed: {error}"))

--- a/apps/desktop/src-tauri/src/providers/gamebanana/client.rs
+++ b/apps/desktop/src-tauri/src/providers/gamebanana/client.rs
@@ -26,16 +26,33 @@ const UPDATE_FIELDS: &[&str] = &["Url().sProfileUrl()", "mdate", "Files().aFiles
 #[derive(Clone)]
 pub struct GameBananaClient {
   transport: GameBananaTransport,
+  api_base: String,
 }
 
 impl GameBananaClient {
   pub fn new() -> Result<Self, Error> {
-    Self::with_config(TransportConfig::default())
+    let api_base = crate::runtime_environment::current()
+      .e2e()
+      .map(|configuration| {
+        format!(
+          "{}/apiv11/",
+          configuration
+            .endpoint(crate::runtime_environment::ServiceName::Gamebanana)
+            .trim_end_matches('/')
+        )
+      })
+      .unwrap_or_else(|| API_BASE.to_string());
+    Self::with_base_and_config(api_base, TransportConfig::default())
   }
 
   pub fn with_config(config: TransportConfig) -> Result<Self, Error> {
+    Self::with_base_and_config(API_BASE.to_string(), config)
+  }
+
+  fn with_base_and_config(api_base: String, config: TransportConfig) -> Result<Self, Error> {
     Ok(Self {
       transport: GameBananaTransport::new(config)?,
+      api_base,
     })
   }
 
@@ -53,7 +70,7 @@ impl GameBananaClient {
     }
 
     let model = model_name(submission_type);
-    let mut url = reqwest::Url::parse(&format!("{API_BASE}{model}/Index"))
+    let mut url = reqwest::Url::parse(&format!("{}{model}/Index", self.api_base))
       .map_err(|error| Error::ProviderInvalidResponse(error.to_string()))?;
     {
       let mut query = url.query_pairs_mut();
@@ -74,7 +91,7 @@ impl GameBananaClient {
     submission: &SubmissionRef,
     cancel: &CancellationToken,
   ) -> Result<Profile, Error> {
-    let url = submission_url(submission, "ProfilePage")?;
+    let url = submission_url(&self.api_base, submission, "ProfilePage")?;
     self.transport.get_json("profile", url, cancel).await
   }
 
@@ -83,12 +100,12 @@ impl GameBananaClient {
     submission: &SubmissionRef,
     cancel: &CancellationToken,
   ) -> Result<DownloadPage, Error> {
-    let url = submission_url(submission, "DownloadPage")?;
+    let url = submission_url(&self.api_base, submission, "DownloadPage")?;
     self.transport.get_json("download page", url, cancel).await
   }
 
   pub async fn fileservers(&self, cancel: &CancellationToken) -> Result<FileserverPage, Error> {
-    let url = reqwest::Url::parse(&format!("{API_BASE}Util/Fileservers?_nPage=1"))
+    let url = reqwest::Url::parse(&format!("{}Util/Fileservers?_nPage=1", self.api_base))
       .map_err(|error| Error::ProviderInvalidResponse(error.to_string()))?;
     self.transport.get_json("fileservers", url, cancel).await
   }
@@ -114,7 +131,7 @@ impl GameBananaClient {
       ));
     }
 
-    let mut url = reqwest::Url::parse(&format!("{API_BASE}Core/Item/Data"))
+    let mut url = reqwest::Url::parse(&format!("{}Core/Item/Data", self.api_base))
       .map_err(|error| Error::ProviderInvalidResponse(error.to_string()))?;
     {
       let mut query = url.query_pairs_mut();
@@ -167,7 +184,7 @@ impl GameBananaClient {
         "bulk update requires up to 50 GameBanana submissions of one type".to_string(),
       ));
     }
-    let mut url = reqwest::Url::parse(&format!("{API_BASE}Core/Item/Data"))
+    let mut url = reqwest::Url::parse(&format!("{}Core/Item/Data", self.api_base))
       .map_err(|error| Error::ProviderInvalidResponse(error.to_string()))?;
     {
       let mut query = url.query_pairs_mut();
@@ -199,7 +216,11 @@ impl GameBananaClient {
   }
 }
 
-fn submission_url(submission: &SubmissionRef, operation: &str) -> Result<reqwest::Url, Error> {
+fn submission_url(
+  api_base: &str,
+  submission: &SubmissionRef,
+  operation: &str,
+) -> Result<reqwest::Url, Error> {
   if submission.provider != SubmissionProvider::Gamebanana
     || submission
       .submission_id
@@ -214,7 +235,7 @@ fn submission_url(submission: &SubmissionRef, operation: &str) -> Result<reqwest
   }
 
   reqwest::Url::parse(&format!(
-    "{API_BASE}{}/{}/{operation}",
+    "{api_base}{}/{}/{operation}",
     model_name(submission.submission_type),
     submission.submission_id
   ))
@@ -230,7 +251,9 @@ fn model_name(submission_type: SubmissionType) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-  use super::{MAX_BULK_ITEMS, MAX_BULK_URL_BYTES, MAX_INDEX_PAGE, model_name, submission_url};
+  use super::{
+    API_BASE, MAX_BULK_ITEMS, MAX_BULK_URL_BYTES, MAX_INDEX_PAGE, model_name, submission_url,
+  };
   use crate::providers::{SubmissionRef, SubmissionType};
 
   #[test]
@@ -238,13 +261,14 @@ mod tests {
     let sound = SubmissionRef::parse_slug("snd-42").unwrap();
     assert_eq!(model_name(SubmissionType::Sound), "Sound");
     assert_eq!(
-      submission_url(&sound, "ProfilePage").unwrap().as_str(),
+      submission_url(API_BASE, &sound, "ProfilePage")
+        .unwrap()
+        .as_str(),
       "https://gamebanana.com/apiv11/Sound/42/ProfilePage"
     );
 
-    let local =
-      SubmissionRef::parse_slug("local-550e8400-e29b-41d4-a716-446655440000").unwrap();
-    assert!(submission_url(&local, "ProfilePage").is_err());
+    let local = SubmissionRef::parse_slug("local-550e8400-e29b-41d4-a716-446655440000").unwrap();
+    assert!(submission_url(API_BASE, &local, "ProfilePage").is_err());
     assert_eq!(MAX_INDEX_PAGE, 250);
     assert_eq!(MAX_BULK_ITEMS, 50);
     assert_eq!(MAX_BULK_URL_BYTES, 7_000);

--- a/apps/desktop/src-tauri/src/runtime_environment.rs
+++ b/apps/desktop/src-tauri/src/runtime_environment.rs
@@ -1,0 +1,656 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tauri::Manager;
+use thiserror::Error;
+
+use crate::app_runtime::AppHandle;
+
+pub const E2E_CONFIG_ENV: &str = "DMM_E2E_CONFIG";
+const E2E_IDENTITY_PREFIX: &str = "dev.stormix.deadlock-mod-manager.e2e.";
+
+static RUNTIME_ENVIRONMENT: OnceLock<RuntimeEnvironment> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+pub enum RuntimeEnvironment {
+  Production,
+  E2e(E2eConfiguration),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct E2eConfiguration {
+  pub schema_version: u32,
+  pub run_id: String,
+  pub case_id: String,
+  pub attempt: u32,
+  pub application_identity: String,
+  pub roots: E2eRoots,
+  pub endpoints: Vec<ServiceEndpoint>,
+  pub network_mode: FixtureOnly,
+  pub integrations: IntegrationPolicy,
+  pub ui: UiConfiguration,
+  pub control: ControlConfiguration,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct E2eRoots {
+  pub world: PathBuf,
+  pub game: PathBuf,
+  pub steam: PathBuf,
+  pub steam_http_cache: PathBuf,
+  pub app_data: PathBuf,
+  pub app_config: PathBuf,
+  pub app_cache: PathBuf,
+  pub app_logs: PathBuf,
+  pub webview_data: PathBuf,
+  pub temporary: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum ServiceName {
+  Gamebanana,
+  Downloads,
+  DmmApi,
+  Auth,
+  DeadlockApi,
+  Assets,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ServiceEndpoint {
+  pub service: ServiceName,
+  pub origin: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct IntegrationPolicy {
+  pub updater: UpdaterPolicy,
+  pub steam_discovery: FixtureOnly,
+  pub game_launch: RecordOnly,
+  pub presence: DisabledOnly,
+  pub ingestion: DisabledOnly,
+  pub match_sync: DisabledOnly,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UpdaterPolicy {
+  Disabled,
+  Fixture,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FixtureOnly {
+  Fixture,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RecordOnly {
+  Record,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DisabledOnly {
+  Disabled,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UiConfiguration {
+  pub language: String,
+  pub width: u32,
+  pub height: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ControlConfiguration {
+  pub endpoint: String,
+  pub token_file: PathBuf,
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeEnvironmentError {
+  #[error("{E2E_CONFIG_ENV} is required in an e2e-harness build")]
+  MissingConfiguration,
+  #[error("{E2E_CONFIG_ENV} cannot activate E2E mode in a production build")]
+  UnsupportedConfiguration,
+  #[error("failed to read E2E configuration '{path}': {source}")]
+  ReadConfiguration {
+    path: PathBuf,
+    source: std::io::Error,
+  },
+  #[error("failed to parse E2E configuration '{path}': {source}")]
+  ParseConfiguration {
+    path: PathBuf,
+    source: serde_json::Error,
+  },
+  #[error("invalid E2E configuration: {0}")]
+  InvalidConfiguration(String),
+  #[error("runtime environment was initialized more than once with a different value")]
+  AlreadyInitialized,
+}
+
+impl E2eConfiguration {
+  pub fn from_file(path: &Path) -> Result<Self, RuntimeEnvironmentError> {
+    let contents = std::fs::read_to_string(path).map_err(|source| {
+      RuntimeEnvironmentError::ReadConfiguration {
+        path: path.to_path_buf(),
+        source,
+      }
+    })?;
+    let configuration = serde_json::from_str::<Self>(&contents).map_err(|source| {
+      RuntimeEnvironmentError::ParseConfiguration {
+        path: path.to_path_buf(),
+        source,
+      }
+    })?;
+    configuration.validate(path)?;
+    Ok(configuration)
+  }
+
+  fn validate(&self, config_path: &Path) -> Result<(), RuntimeEnvironmentError> {
+    if self.schema_version != 1 {
+      return invalid(format!(
+        "unsupported schemaVersion {}; expected 1",
+        self.schema_version
+      ));
+    }
+    validate_id("runId", &self.run_id)?;
+    validate_id("caseId", &self.case_id)?;
+    if self.attempt == 0 {
+      return invalid("attempt must be greater than zero");
+    }
+    if !self.application_identity.starts_with(E2E_IDENTITY_PREFIX)
+      || !self
+        .application_identity
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '-'))
+    {
+      return invalid(format!(
+        "applicationIdentity must start with '{E2E_IDENTITY_PREFIX}' and contain only ASCII letters, digits, dots, or hyphens"
+      ));
+    }
+    if !(320..=8192).contains(&self.ui.width) || !(240..=8192).contains(&self.ui.height) {
+      return invalid("ui dimensions must be between 320x240 and 8192x8192");
+    }
+    validate_id("ui.language", &self.ui.language)?;
+    if self.control.endpoint.trim().is_empty() {
+      return invalid("control.endpoint must not be empty");
+    }
+    validate_loopback_url("control.endpoint", &self.control.endpoint, true)?;
+    let world = canonical_directory("roots.world", &self.roots.world)?;
+    for (name, path) in self.roots.named_paths().into_iter().skip(1) {
+      let canonical = canonical_directory(name, path)?;
+      ensure_contained(name, &canonical, &world)?;
+    }
+
+    let token_file = canonical_file("control.tokenFile", &self.control.token_file)?;
+    ensure_contained("control.tokenFile", &token_file, &world)?;
+    let config_file = canonical_file("configuration file", config_path)?;
+    ensure_contained("configuration file", &config_file, &world)?;
+
+    let expected_services = [
+      ServiceName::Gamebanana,
+      ServiceName::Downloads,
+      ServiceName::DmmApi,
+      ServiceName::Auth,
+      ServiceName::DeadlockApi,
+      ServiceName::Assets,
+    ];
+    let mut observed = HashSet::new();
+    for endpoint in &self.endpoints {
+      if !observed.insert(endpoint.service) {
+        return invalid(format!("duplicate endpoint for {:?}", endpoint.service));
+      }
+      validate_loopback_origin(&endpoint.origin)?;
+    }
+    if observed.len() != expected_services.len()
+      || expected_services
+        .iter()
+        .any(|service| !observed.contains(service))
+    {
+      return invalid("endpoints must define each supported service exactly once");
+    }
+
+    Ok(())
+  }
+
+  pub fn state_store_path(&self) -> PathBuf {
+    self.roots.app_data.join("state.json")
+  }
+
+  pub fn endpoint(&self, service: ServiceName) -> &str {
+    self
+      .endpoints
+      .iter()
+      .find(|endpoint| endpoint.service == service)
+      .map(|endpoint| endpoint.origin.as_str())
+      .expect("validated E2E configuration has every endpoint")
+  }
+}
+
+impl E2eRoots {
+  fn named_paths(&self) -> [(&'static str, &Path); 10] {
+    [
+      ("roots.world", &self.world),
+      ("roots.game", &self.game),
+      ("roots.steam", &self.steam),
+      ("roots.steamHttpCache", &self.steam_http_cache),
+      ("roots.appData", &self.app_data),
+      ("roots.appConfig", &self.app_config),
+      ("roots.appCache", &self.app_cache),
+      ("roots.appLogs", &self.app_logs),
+      ("roots.webviewData", &self.webview_data),
+      ("roots.temporary", &self.temporary),
+    ]
+  }
+}
+
+impl RuntimeEnvironment {
+  pub fn e2e(&self) -> Option<&E2eConfiguration> {
+    match self {
+      Self::Production => None,
+      Self::E2e(configuration) => Some(configuration),
+    }
+  }
+}
+
+pub fn initialize() -> Result<&'static RuntimeEnvironment, RuntimeEnvironmentError> {
+  if let Some(existing) = RUNTIME_ENVIRONMENT.get() {
+    return Ok(existing);
+  }
+  let environment = environment_from_process()?;
+  RUNTIME_ENVIRONMENT
+    .set(environment)
+    .map_err(|_| RuntimeEnvironmentError::AlreadyInitialized)?;
+  Ok(
+    RUNTIME_ENVIRONMENT
+      .get()
+      .expect("runtime environment was just initialized"),
+  )
+}
+
+pub fn current() -> &'static RuntimeEnvironment {
+  RUNTIME_ENVIRONMENT
+    .get()
+    .expect("runtime environment must be initialized before application setup")
+}
+
+pub fn is_e2e_active() -> bool {
+  matches!(RUNTIME_ENVIRONMENT.get(), Some(RuntimeEnvironment::E2e(_)))
+}
+
+pub fn records_game_launches() -> bool {
+  RUNTIME_ENVIRONMENT
+    .get()
+    .and_then(RuntimeEnvironment::e2e)
+    .is_some()
+}
+
+pub fn ensure_e2e_managed_path(path: &Path) -> Result<(), String> {
+  let Some(configuration) = RUNTIME_ENVIRONMENT.get().and_then(RuntimeEnvironment::e2e) else {
+    return Ok(());
+  };
+  let candidate = path
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve E2E path '{}': {error}", path.display()))?;
+  let world = configuration
+    .roots
+    .world
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve E2E world: {error}"))?;
+  if candidate.starts_with(&world) {
+    Ok(())
+  } else {
+    Err(format!(
+      "E2E path '{}' resolves outside the owned world",
+      path.display()
+    ))
+  }
+}
+
+pub fn record_game_launch(program: &Path, uri: &str) -> Result<(), std::io::Error> {
+  let Some(configuration) = current().e2e() else {
+    return Ok(());
+  };
+  let artifacts = configuration.roots.world.join("artifacts");
+  std::fs::create_dir_all(&artifacts)?;
+  let mut journal = std::fs::OpenOptions::new()
+    .create(true)
+    .append(true)
+    .open(artifacts.join("game-launches.ndjson"))?;
+  let record = serde_json::json!({
+    "atUnixMs": std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_millis(),
+    "program": program.to_string_lossy(),
+    "uri": uri,
+  });
+  serde_json::to_writer(&mut journal, &record).map_err(std::io::Error::other)?;
+  journal.write_all(b"\n")
+}
+
+pub fn configure_process() {
+  let Some(configuration) = current().e2e() else {
+    return;
+  };
+
+  // Startup calls this before Tauri or any application worker threads exist.
+  // These process-local overrides keep Rust temporary files and WebView2 data
+  // inside the disposable world inherited by child processes.
+  unsafe {
+    std::env::set_var("TMP", &configuration.roots.temporary);
+    std::env::set_var("TEMP", &configuration.roots.temporary);
+    #[cfg(target_os = "windows")]
+    std::env::set_var(
+      "WEBVIEW2_USER_DATA_FOLDER",
+      &configuration.roots.webview_data,
+    );
+  }
+}
+
+pub fn apply_to_context(context: &mut tauri::Context<crate::app_runtime::AppRuntime>) {
+  let Some(configuration) = current().e2e() else {
+    return;
+  };
+
+  context.config_mut().identifier = configuration.application_identity.clone();
+  context.config_mut().app.with_global_tauri = true;
+  for window in &mut context.config_mut().app.windows {
+    if window.label == "main" {
+      window.width = configuration.ui.width as f64;
+      window.height = configuration.ui.height as f64;
+    }
+  }
+}
+
+pub fn state_store_path() -> PathBuf {
+  current()
+    .e2e()
+    .map(E2eConfiguration::state_store_path)
+    .unwrap_or_else(|| PathBuf::from("state.json"))
+}
+
+pub fn app_local_data_dir(app_handle: &AppHandle) -> Result<PathBuf, tauri::Error> {
+  match current().e2e() {
+    Some(configuration) => Ok(configuration.roots.app_data.clone()),
+    None => app_handle.path().app_local_data_dir(),
+  }
+}
+
+pub fn app_log_dir(app_handle: &AppHandle) -> Result<PathBuf, tauri::Error> {
+  match current().e2e() {
+    Some(configuration) => Ok(configuration.roots.app_logs.clone()),
+    None => app_handle.path().app_log_dir(),
+  }
+}
+
+pub fn app_config_dir(identifier: &str) -> Option<PathBuf> {
+  current()
+    .e2e()
+    .map(|configuration| configuration.roots.app_config.clone())
+    .or_else(|| dirs::config_dir().map(|directory| directory.join(identifier)))
+}
+
+fn environment_from_process() -> Result<RuntimeEnvironment, RuntimeEnvironmentError> {
+  let config_path = std::env::var_os(E2E_CONFIG_ENV).map(PathBuf::from);
+  #[cfg(feature = "e2e-harness")]
+  {
+    let path = config_path.ok_or(RuntimeEnvironmentError::MissingConfiguration)?;
+    return Ok(RuntimeEnvironment::E2e(E2eConfiguration::from_file(&path)?));
+  }
+  #[cfg(not(feature = "e2e-harness"))]
+  {
+    if config_path.is_some() {
+      return Err(RuntimeEnvironmentError::UnsupportedConfiguration);
+    }
+    Ok(RuntimeEnvironment::Production)
+  }
+}
+
+fn validate_id(name: &str, value: &str) -> Result<(), RuntimeEnvironmentError> {
+  if value.is_empty()
+    || value.len() > 80
+    || !value
+      .chars()
+      .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+  {
+    return invalid(format!(
+      "{name} must contain 1-80 ASCII letters, digits, hyphens, or underscores"
+    ));
+  }
+  Ok(())
+}
+
+fn canonical_directory(name: &str, path: &Path) -> Result<PathBuf, RuntimeEnvironmentError> {
+  if !path.is_absolute() || !path.is_dir() {
+    return invalid(format!("{name} must be an existing absolute directory"));
+  }
+  path.canonicalize().map_err(|error| {
+    RuntimeEnvironmentError::InvalidConfiguration(format!("failed to resolve {name}: {error}"))
+  })
+}
+
+fn canonical_file(name: &str, path: &Path) -> Result<PathBuf, RuntimeEnvironmentError> {
+  if !path.is_absolute() || !path.is_file() {
+    return invalid(format!("{name} must be an existing absolute file"));
+  }
+  path.canonicalize().map_err(|error| {
+    RuntimeEnvironmentError::InvalidConfiguration(format!("failed to resolve {name}: {error}"))
+  })
+}
+
+fn ensure_contained(
+  name: &str,
+  candidate: &Path,
+  world: &Path,
+) -> Result<(), RuntimeEnvironmentError> {
+  if candidate == world || candidate.starts_with(world) {
+    Ok(())
+  } else {
+    invalid(format!("{name} resolves outside roots.world"))
+  }
+}
+
+fn validate_loopback_origin(origin: &str) -> Result<(), RuntimeEnvironmentError> {
+  validate_loopback_url("service origin", origin, false)
+}
+
+fn validate_loopback_url(
+  name: &str,
+  value: &str,
+  allow_path: bool,
+) -> Result<(), RuntimeEnvironmentError> {
+  let parsed = reqwest::Url::parse(value).map_err(|error| {
+    RuntimeEnvironmentError::InvalidConfiguration(format!("invalid {name} '{value}': {error}"))
+  })?;
+  if !matches!(parsed.scheme(), "http" | "https")
+    || (!allow_path && parsed.path() != "/")
+    || parsed.query().is_some()
+    || parsed.fragment().is_some()
+    || !parsed.username().is_empty()
+    || parsed.password().is_some()
+    || !matches!(parsed.host_str(), Some("127.0.0.1" | "::1" | "localhost"))
+  {
+    return invalid(format!(
+      "{name} '{value}' must be a loopback HTTP(S) URL without a query or fragment"
+    ));
+  }
+  Ok(())
+}
+
+fn invalid<T>(message: impl Into<String>) -> Result<T, RuntimeEnvironmentError> {
+  Err(RuntimeEnvironmentError::InvalidConfiguration(
+    message.into(),
+  ))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+  use tempfile::TempDir;
+
+  struct TestWorld {
+    _directory: TempDir,
+    config_path: PathBuf,
+  }
+
+  fn test_world(mut mutate: impl FnMut(&mut serde_json::Value)) -> TestWorld {
+    let directory = tempfile::tempdir().unwrap();
+    let world = directory.path().join("world");
+    let path_names = [
+      "game",
+      "steam",
+      "steam-http-cache",
+      "app-data",
+      "app-config",
+      "app-cache",
+      "app-logs",
+      "webview-data",
+      "temporary",
+    ];
+    std::fs::create_dir_all(&world).unwrap();
+    for path_name in path_names {
+      std::fs::create_dir_all(world.join(path_name)).unwrap();
+    }
+    let token_file = world.join("control.token");
+    std::fs::write(&token_file, "test-token").unwrap();
+    let config_path = world.join("e2e-config.json");
+    let endpoints = [
+      "gamebanana",
+      "downloads",
+      "dmmApi",
+      "auth",
+      "deadlockApi",
+      "assets",
+    ]
+    .into_iter()
+    .map(|service| json!({ "service": service, "origin": "http://127.0.0.1:43199" }))
+    .collect::<Vec<_>>();
+    let mut configuration = json!({
+      "schemaVersion": 1,
+      "runId": "run-01",
+      "caseId": "about-smoke",
+      "attempt": 1,
+      "applicationIdentity": "dev.stormix.deadlock-mod-manager.e2e.run-01",
+      "roots": {
+        "world": world,
+        "game": world.join("game"),
+        "steam": world.join("steam"),
+        "steamHttpCache": world.join("steam-http-cache"),
+        "appData": world.join("app-data"),
+        "appConfig": world.join("app-config"),
+        "appCache": world.join("app-cache"),
+        "appLogs": world.join("app-logs"),
+        "webviewData": world.join("webview-data"),
+        "temporary": world.join("temporary")
+      },
+      "endpoints": endpoints,
+      "networkMode": "fixture",
+      "integrations": {
+        "updater": "disabled",
+        "steamDiscovery": "fixture",
+        "gameLaunch": "record",
+        "presence": "disabled",
+        "ingestion": "disabled",
+        "matchSync": "disabled"
+      },
+      "ui": { "language": "en", "width": 1280, "height": 800 },
+      "control": { "endpoint": "http://127.0.0.1:43199/__control", "tokenFile": token_file }
+    });
+    mutate(&mut configuration);
+    std::fs::write(
+      &config_path,
+      serde_json::to_vec_pretty(&configuration).unwrap(),
+    )
+    .unwrap();
+    TestWorld {
+      _directory: directory,
+      config_path,
+    }
+  }
+
+  #[test]
+  fn valid_configuration_resolves_every_root_inside_world() {
+    let world = test_world(|_| {});
+    let configuration = E2eConfiguration::from_file(&world.config_path).unwrap();
+
+    assert_eq!(configuration.schema_version, 1);
+    assert!(configuration
+      .state_store_path()
+      .ends_with("app-data/state.json"));
+    assert_eq!(
+      configuration.endpoint(ServiceName::DmmApi),
+      "http://127.0.0.1:43199"
+    );
+  }
+
+  #[test]
+  fn root_outside_world_is_rejected() {
+    let outside = tempfile::tempdir().unwrap();
+    let world = test_world(|configuration| {
+      configuration["roots"]["appLogs"] = json!(outside.path());
+    });
+
+    let error = E2eConfiguration::from_file(&world.config_path).unwrap_err();
+    assert!(error
+      .to_string()
+      .contains("roots.appLogs resolves outside roots.world"));
+  }
+
+  #[test]
+  fn duplicate_service_is_rejected() {
+    let world = test_world(|configuration| {
+      configuration["endpoints"][1]["service"] = json!("gamebanana");
+    });
+
+    let error = E2eConfiguration::from_file(&world.config_path).unwrap_err();
+    assert!(error.to_string().contains("duplicate endpoint"));
+  }
+
+  #[test]
+  fn non_loopback_service_is_rejected() {
+    let world = test_world(|configuration| {
+      configuration["endpoints"][0]["origin"] = json!("https://gamebanana.com");
+    });
+
+    let error = E2eConfiguration::from_file(&world.config_path).unwrap_err();
+    assert!(error.to_string().contains("must be a loopback HTTP(S) URL"));
+  }
+
+  #[test]
+  fn unsafe_e2e_policies_are_rejected() {
+    let world = test_world(|configuration| {
+      configuration["integrations"]["gameLaunch"] = json!("native");
+    });
+
+    let error = E2eConfiguration::from_file(&world.config_path).unwrap_err();
+    assert!(error.to_string().contains("unknown variant `native`"));
+  }
+
+  #[test]
+  fn configuration_file_outside_world_is_rejected() {
+    let world = test_world(|_| {});
+    let outside = tempfile::tempdir().unwrap();
+    let outside_config = outside.path().join("e2e-config.json");
+    std::fs::copy(&world.config_path, &outside_config).unwrap();
+
+    let error = E2eConfiguration::from_file(&outside_config).unwrap_err();
+    assert!(error
+      .to_string()
+      .contains("configuration file resolves outside roots.world"));
+  }
+}

--- a/apps/desktop/src-tauri/src/updater_channel.rs
+++ b/apps/desktop/src-tauri/src/updater_channel.rs
@@ -43,7 +43,7 @@ struct ChannelConfig {
 }
 
 fn channel_config_path(identifier: &str) -> Option<PathBuf> {
-  dirs::config_dir().map(|config_dir| config_dir.join(identifier).join(CHANNEL_FILE))
+  crate::runtime_environment::app_config_dir(identifier).map(|path| path.join(CHANNEL_FILE))
 }
 
 pub fn resolve_channel(identifier: &str) -> UpdateChannel {
@@ -55,6 +55,22 @@ pub fn resolve_channel(identifier: &str) -> UpdateChannel {
 }
 
 pub fn apply_to_context(context: &mut tauri::Context<AppRuntime>) {
+  if let Some(configuration) = crate::runtime_environment::current().e2e() {
+    let endpoints = match configuration.integrations.updater {
+      crate::runtime_environment::UpdaterPolicy::Disabled => serde_json::json!([]),
+      crate::runtime_environment::UpdaterPolicy::Fixture => serde_json::json!([format!(
+        "{}/updater/latest.json",
+        configuration
+          .endpoint(crate::runtime_environment::ServiceName::Downloads)
+          .trim_end_matches('/')
+      )]),
+    };
+    if let Some(updater) = context.config_mut().plugins.0.get_mut("updater") {
+      updater["endpoints"] = endpoints;
+    }
+    return;
+  }
+
   let identifier = context.config().identifier.clone();
   let channel = resolve_channel(&identifier);
 

--- a/apps/desktop/src-tauri/tauri.e2e.conf.json
+++ b/apps/desktop/src-tauri/tauri.e2e.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "withGlobalTauri": true
+  }
+}

--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -2,10 +2,8 @@ import { toast } from "@deadlock-mods/ui/components/sonner";
 import { TooltipProvider } from "@deadlock-mods/ui/components/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
-import { load } from "@tauri-apps/plugin-store";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import usePromise from "react-promise-suspense";
 import { Outlet } from "react-router";
 import { FontInstallDialog } from "./components/downloads/font-install-dialog";
 import { ProgressProvider } from "./components/downloads/progress-indicator";
@@ -34,14 +32,11 @@ import { useHeroDetection } from "./hooks/use-hero-detection";
 import { useGameBananaCatalogSync } from "./hooks/use-gamebanana-catalog-sync";
 import { useModOrderMigration } from "./hooks/use-mod-order-migration";
 import { Layout } from "./layout";
-import { initializeApiUrl } from "./lib/tauri-commands";
 import { queryClient } from "./lib/client";
-import { STORE_NAME } from "./lib/constants";
 import { downloadManager } from "./lib/download/manager";
 import logger from "./lib/logger";
-import { syncProxyConfigToBackend } from "./lib/proxy";
-import { usePersistedStore } from "./lib/store";
-import { markStorageReady, storageReady } from "./lib/store/storage";
+import type { RuntimeBootstrap } from "./lib/runtime-bootstrap";
+import type { StorageReadyStatus } from "./lib/store/storage";
 import type { FontInfo } from "./types/mods";
 
 interface PendingFontInstall {
@@ -49,7 +44,13 @@ interface PendingFontInstall {
   fonts: FontInfo[];
 }
 
-const App = () => {
+type AppProps = {
+  runtime: RuntimeBootstrap;
+  storage: StorageReadyStatus;
+};
+
+const App = ({ runtime, storage }: AppProps) => {
+  const integrations = runtime.integrations;
   useDeepLink();
   useLanguageListener();
   useModOrderMigration();
@@ -57,8 +58,9 @@ const App = () => {
   useCrosshairConfigReconciliation();
   useHeroDetection();
   useGameBananaCatalogSync();
-  useIngestToolInit();
+  useIngestToolInit(integrations?.ingestion !== "disabled");
   const { t } = useTranslation();
+  const hasReportedStorageFailure = useRef(false);
 
   const [pendingFontInstalls, setPendingFontInstalls] = useState<
     PendingFontInstall[]
@@ -72,38 +74,18 @@ const App = () => {
     downloadProgress,
     handleUpdate,
     handleDismiss,
-  } = useAutoUpdate();
+  } = useAutoUpdate(integrations?.updater !== "disabled");
 
-  const hydrateStore = async () => {
-    await load(STORE_NAME, { autoSave: true, defaults: {} });
-    try {
-      await usePersistedStore.persist.rehydrate();
-    } finally {
-      markStorageReady();
-    }
-    const status = await storageReady();
-    if (!status.ok) {
+  useEffect(() => {
+    if (!storage.ok && !hasReportedStorageFailure.current) {
+      hasReportedStorageFailure.current = true;
       toast.error(t("persist.loadFailed"), {
         description: t("persist.loadFailedDescription", {
-          reason: status.reason ?? "unknown",
+          reason: storage.reason ?? "unknown",
         }),
       });
     }
-    await initializeApiUrl();
-    await syncProxyConfigToBackend();
-    void invoke("refresh_policy_manifest").catch((error) => {
-      logger
-        .withError(error)
-        .warn("Policy refresh failed; keeping the last cached policy");
-    });
-    await downloadManager.init();
-
-    logger.debug(
-      "Store rehydrated, API URL initialized, and download manager ready",
-    );
-  };
-
-  usePromise(hydrateStore, []);
+  }, [storage, t]);
 
   const dequeuePendingFontInstall = useCallback(() => {
     setPendingFontInstalls((currentQueue) => currentQueue.slice(1));
@@ -157,9 +139,15 @@ const App = () => {
                       </FoundryProvider>
                     </ThemeOverridesProvider>
                     <GlobalPluginRenderer />
-                    <GamePresenceRenderer />
-                    <MatchSyncRenderer />
-                    <LiveMatchRenderer />
+                    {integrations?.presence !== "disabled" && (
+                      <GamePresenceRenderer />
+                    )}
+                    {integrations?.matchSync !== "disabled" && (
+                      <>
+                        <MatchSyncRenderer />
+                        <LiveMatchRenderer />
+                      </>
+                    )}
                     <ForgeInstallRenderer />
                     <UpdateDialog
                       downloadProgress={downloadProgress}

--- a/apps/desktop/src/hooks/use-auto-update.ts
+++ b/apps/desktop/src/hooks/use-auto-update.ts
@@ -8,7 +8,7 @@ import useUpdateManager from "./use-update-manager";
 
 const logger = createLogger("auto-update");
 
-export const useAutoUpdate = () => {
+export const useAutoUpdate = (integrationEnabled = true) => {
   const { t } = useTranslation();
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
   const updateManager = useUpdateManager();
@@ -19,6 +19,9 @@ export const useAutoUpdate = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: auto update hook
   useEffect(() => {
     const checkForUpdatesOnLaunch = async () => {
+      if (!integrationEnabled) {
+        return;
+      }
       try {
         // Check if auto-update is disabled via CLI flag
         const disabledViaCli = await isAutoUpdateDisabled();
@@ -63,7 +66,7 @@ export const useAutoUpdate = () => {
     const timeout = setTimeout(checkForUpdatesOnLaunch, 2000);
 
     return () => clearTimeout(timeout);
-  }, [autoUpdateEnabled]);
+  }, [autoUpdateEnabled, integrationEnabled]);
 
   const handleUpdate = async () => {
     try {

--- a/apps/desktop/src/hooks/use-ingest-tool-init.ts
+++ b/apps/desktop/src/hooks/use-ingest-tool-init.ts
@@ -6,7 +6,7 @@ import { usePersistedStore } from "@/lib/store";
 /**
  * Hook to initialize the ingest tool on app startup if enabled
  */
-export const useIngestToolInit = () => {
+export const useIngestToolInit = (integrationEnabled = true) => {
   const ingestToolEnabled = usePersistedStore(
     (state) => state.ingestToolEnabled,
   );
@@ -14,7 +14,7 @@ export const useIngestToolInit = () => {
 
   useEffect(() => {
     const initializeIngestTool = async () => {
-      if (!ingestToolEnabled) {
+      if (!integrationEnabled || !ingestToolEnabled) {
         logger.debug("Ingest tool is disabled, skipping initialization");
         return;
       }
@@ -33,5 +33,5 @@ export const useIngestToolInit = () => {
     };
 
     initializeIngestTool();
-  }, [ingestToolEnabled]);
+  }, [ingestToolEnabled, integrationEnabled]);
 };

--- a/apps/desktop/src/hooks/use-oidc-session.ts
+++ b/apps/desktop/src/hooks/use-oidc-session.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/auth/token";
 import { AUTH_URL } from "@/lib/config";
 import { HttpError } from "@/lib/http-error";
+import { runtimeServiceOrigin } from "@/lib/runtime-bootstrap";
 
 export type { OIDCSession, OIDCUser };
 
@@ -56,11 +57,14 @@ export function useOIDCSession(): UseOIDCSessionResult {
 
       let response: Response;
       try {
-        response = await fetch(`${AUTH_URL}/api/auth/oauth2/userinfo`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
+        response = await fetch(
+          `${runtimeServiceOrigin("auth", AUTH_URL)}/api/auth/oauth2/userinfo`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
           },
-        });
+        );
       } catch {
         throw new HttpError("auth", 0, "/api/auth/oauth2/userinfo");
       }

--- a/apps/desktop/src/lib/api-client.ts
+++ b/apps/desktop/src/lib/api-client.ts
@@ -17,6 +17,7 @@ import { ensureValidToken } from "./auth/token";
 import { fetch } from "./fetch";
 import { HttpError } from "./http-error";
 import logger from "./logger";
+import { runtimeServiceOrigin } from "./runtime-bootstrap";
 import {
   checkDirectGameBananaUpdates,
   getGameBananaCatalogDownloads,
@@ -44,12 +45,15 @@ const apiRequest = async <T>(
 
   let response: Response;
   try {
-    response = await fetch(`${BASE_URL}${endpoint}`, {
-      method: method ?? (body ? "POST" : "GET"),
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-      credentials: "include",
-    });
+    response = await fetch(
+      `${runtimeServiceOrigin("dmmApi", BASE_URL)}${endpoint}`,
+      {
+        method: method ?? (body ? "POST" : "GET"),
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+        credentials: "include",
+      },
+    );
   } catch (cause) {
     logger.withError(cause).error("API network failure");
     throw new HttpError("backend", 0, endpoint);

--- a/apps/desktop/src/lib/application-bootstrap.ts
+++ b/apps/desktop/src/lib/application-bootstrap.ts
@@ -1,0 +1,62 @@
+import { invoke } from "@tauri-apps/api/core";
+import { load } from "@tauri-apps/plugin-store";
+import { downloadManager } from "./download/manager";
+import logger from "./logger";
+import {
+  initializeRuntimeBootstrap,
+  type RuntimeBootstrap,
+  getRuntimeServiceOrigin,
+} from "./runtime-bootstrap";
+import { syncProxyConfigToBackend } from "./proxy";
+import { usePersistedStore } from "./store";
+import {
+  setStateStorePath,
+  storageReady,
+  type StorageReadyStatus,
+} from "./store/storage";
+import { initializeApiUrl } from "./tauri-commands";
+
+export type ApplicationBootstrap = {
+  runtime: RuntimeBootstrap;
+  storage: StorageReadyStatus;
+};
+
+let applicationBootstrapPromise: Promise<ApplicationBootstrap> | null = null;
+
+const bootstrapApplication = async (): Promise<ApplicationBootstrap> => {
+  const runtime = await initializeRuntimeBootstrap();
+
+  setStateStorePath(runtime.stateStorePath);
+  await load(runtime.stateStorePath, { autoSave: true, defaults: {} });
+  await usePersistedStore.persist.rehydrate();
+  const storage = await storageReady();
+
+  logger
+    .withMetadata({
+      hasCompletedOnboarding:
+        usePersistedStore.getState().hasCompletedOnboarding,
+      runtimeMode: runtime.mode,
+      storageReady: storage.ok,
+    })
+    .info("Persisted store hydration completed");
+
+  await initializeApiUrl(getRuntimeServiceOrigin(runtime, "dmmApi"));
+  await syncProxyConfigToBackend();
+  void invoke("refresh_policy_manifest").catch((error) => {
+    logger
+      .withError(error)
+      .warn("Policy refresh failed; keeping the last cached policy");
+  });
+  await downloadManager.init();
+
+  logger.debug(
+    "Store rehydrated, API URL initialized, and download manager ready",
+  );
+
+  return { runtime, storage };
+};
+
+export const initializeApplication = (): Promise<ApplicationBootstrap> => {
+  applicationBootstrapPromise ??= bootstrapApplication();
+  return applicationBootstrapPromise;
+};

--- a/apps/desktop/src/lib/auth/health.ts
+++ b/apps/desktop/src/lib/auth/health.ts
@@ -1,13 +1,19 @@
 import { fetch } from "../fetch";
 import { AUTH_URL } from "@/lib/config";
 import { HttpError } from "@/lib/http-error";
+import { runtimeServiceOrigin } from "@/lib/runtime-bootstrap";
 
 export interface AuthHealthData {
   status: string;
 }
 
 export async function getAuthHealth(): Promise<AuthHealthData> {
-  const response = await fetch(`${AUTH_URL}/health`, { method: "GET" });
+  const response = await fetch(
+    `${runtimeServiceOrigin("auth", AUTH_URL)}/health`,
+    {
+      method: "GET",
+    },
+  );
 
   if (!response.ok) {
     throw new HttpError("auth", response.status, "/health");

--- a/apps/desktop/src/lib/auth/oidc.ts
+++ b/apps/desktop/src/lib/auth/oidc.ts
@@ -9,10 +9,12 @@ import {
 import { fetch } from "../fetch";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { AUTH_URL } from "../config";
+import { runtimeServiceOrigin } from "../runtime-bootstrap";
 import { HttpError } from "../http-error";
 
 const CLIENT_ID = "deadlockmods-desktop";
-const REDIRECT_URI = `${AUTH_URL}/auth/desktop-callback`;
+const authOrigin = (): string => runtimeServiceOrigin("auth", AUTH_URL);
+const redirectUri = (): string => `${authOrigin()}/auth/desktop-callback`;
 
 export { parseOIDCState, type OIDCState, type TokenResponse };
 
@@ -27,7 +29,7 @@ export async function initiateOIDCLogin(): Promise<void> {
 
   const params = new URLSearchParams({
     client_id: CLIENT_ID,
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: "openid profile email offline_access",
     state: encodedState,
@@ -35,7 +37,7 @@ export async function initiateOIDCLogin(): Promise<void> {
     code_challenge_method: "S256",
   });
 
-  const authUrl = `${AUTH_URL}/api/auth/oauth2/authorize?${params}`;
+  const authUrl = `${authOrigin()}/api/auth/oauth2/authorize?${params}`;
   await openUrl(authUrl);
 }
 
@@ -48,11 +50,11 @@ export async function exchangeCodeForTokens(
     throw new Error("Code verifier not found. Please initiate login again.");
   }
 
-  const tokenUrl = `${AUTH_URL}/api/auth/oauth2/token`;
+  const tokenUrl = `${authOrigin()}/api/auth/oauth2/token`;
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code,
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     client_id: CLIENT_ID,
     code_verifier: codeVerifier,
   }).toString();
@@ -88,7 +90,7 @@ export class TokenRefreshError extends HttpError {
 export async function refreshTokens(
   refreshToken: string,
 ): Promise<TokenResponse> {
-  const response = await fetch(`${AUTH_URL}/api/auth/oauth2/token`, {
+  const response = await fetch(`${authOrigin()}/api/auth/oauth2/token`, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",

--- a/apps/desktop/src/lib/deadlock-api.ts
+++ b/apps/desktop/src/lib/deadlock-api.ts
@@ -7,14 +7,13 @@ import {
   parseList,
 } from "./validation/deadlock-api";
 import { fetch } from "./fetch";
+import { runtimeServiceOrigin } from "./runtime-bootstrap";
 
 export type { DeadlockHero, DeadlockItem };
 
 export const ASSETS_BASE_URL = "https://assets.deadlock-api.com";
-
-const HEROES_API = `${ASSETS_BASE_URL}/v2/heroes`;
-const ITEMS_API = `${ASSETS_BASE_URL}/v2/items`;
-const HERO_API = `${HEROES_API}/by-name`;
+export const assetsBaseUrl = (): string =>
+  runtimeServiceOrigin("assets", ASSETS_BASE_URL);
 
 /**
  * Every deadlock-api failure, on the app's shared error hierarchy. Lives here
@@ -32,7 +31,7 @@ export class DeadlockApiError extends ProviderError {
 
 /** Every playable hero, for id -> name/portrait lookups. Changes only per patch. */
 export const getHeroes = async (): Promise<DeadlockHero[]> => {
-  const res = await fetch(`${HEROES_API}?only_active=true`);
+  const res = await fetch(`${assetsBaseUrl()}/v2/heroes?only_active=true`);
   if (!res.ok) {
     throw new DeadlockApiError(res.status, "/v2/heroes");
   }
@@ -45,7 +44,7 @@ export const getHeroes = async (): Promise<DeadlockHero[]> => {
  * ever reaches the cache.
  */
 export const getItems = async (): Promise<DeadlockItem[]> => {
-  const res = await fetch(`${ITEMS_API}?only_active=true`);
+  const res = await fetch(`${assetsBaseUrl()}/v2/items?only_active=true`);
   if (!res.ok) {
     throw new DeadlockApiError(res.status, "/v2/items");
   }
@@ -66,7 +65,9 @@ export const getItems = async (): Promise<DeadlockItem[]> => {
 export const getHeroByName = async (
   name: string,
 ): Promise<DeadlockHero | null> => {
-  const res = await fetch(`${HERO_API}/${encodeURIComponent(name)}`);
+  const res = await fetch(
+    `${assetsBaseUrl()}/v2/heroes/by-name/${encodeURIComponent(name)}`,
+  );
   if (!res.ok) {
     return null;
   }

--- a/apps/desktop/src/lib/runtime-bootstrap.ts
+++ b/apps/desktop/src/lib/runtime-bootstrap.ts
@@ -1,0 +1,67 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type RuntimeServiceName =
+  | "gamebanana"
+  | "downloads"
+  | "dmmApi"
+  | "auth"
+  | "deadlockApi"
+  | "assets";
+
+export type RuntimeServiceEndpoint = {
+  service: RuntimeServiceName;
+  origin: string;
+};
+
+export type RuntimeBootstrap = {
+  mode: "production" | "e2e";
+  stateStorePath: string;
+  appDataPath: string | null;
+  endpoints: RuntimeServiceEndpoint[];
+  integrations: {
+    updater: "disabled" | "fixture";
+    steamDiscovery: "fixture";
+    gameLaunch: "record";
+    presence: "disabled";
+    ingestion: "disabled";
+    matchSync: "disabled";
+  } | null;
+};
+
+let runtimeBootstrapPromise: Promise<RuntimeBootstrap> | null = null;
+let runtimeBootstrap: RuntimeBootstrap | null = null;
+
+export const getRuntimeBootstrap = (): Promise<RuntimeBootstrap> => {
+  runtimeBootstrapPromise ??= invoke<RuntimeBootstrap>(
+    "get_runtime_bootstrap",
+  ).then((bootstrap) => {
+    runtimeBootstrap = bootstrap;
+    return bootstrap;
+  });
+  return runtimeBootstrapPromise;
+};
+
+export const initializeRuntimeBootstrap = async (): Promise<RuntimeBootstrap> =>
+  await getRuntimeBootstrap();
+
+export const runtimeServiceOrigin = (
+  service: RuntimeServiceName,
+  fallback: string,
+): string =>
+  runtimeBootstrap?.endpoints.find((endpoint) => endpoint.service === service)
+    ?.origin ?? fallback;
+
+export const getRuntimeServiceOrigin = (
+  bootstrap: RuntimeBootstrap,
+  service: RuntimeServiceName,
+): string | undefined =>
+  bootstrap.endpoints.find((endpoint) => endpoint.service === service)?.origin;
+
+export const resolveStorePath = async (fileName: string): Promise<string> => {
+  const bootstrap = await getRuntimeBootstrap();
+  if (bootstrap.mode === "production" || bootstrap.appDataPath === null) {
+    return fileName;
+  }
+  const separator = bootstrap.appDataPath.includes("\\") ? "\\" : "/";
+  return bootstrap.appDataPath + separator + fileName;
+};

--- a/apps/desktop/src/lib/stats/api.ts
+++ b/apps/desktop/src/lib/stats/api.ts
@@ -1,4 +1,4 @@
-import { ASSETS_BASE_URL, DeadlockApiError } from "@/lib/deadlock-api";
+import { assetsBaseUrl, DeadlockApiError } from "@/lib/deadlock-api";
 import { fetch } from "@/lib/fetch";
 import {
   parseList,
@@ -21,6 +21,7 @@ import {
   steamProfileSchema,
 } from "@/lib/validation/stats-api";
 import type { z } from "zod";
+import { runtimeServiceOrigin } from "@/lib/runtime-bootstrap";
 
 export { DeadlockApiError };
 export type { RankAsset };
@@ -47,6 +48,7 @@ export type {
 } from "@/lib/validation/stats-api";
 
 const BASE_URL = "https://api.deadlock-api.com";
+const apiBaseUrl = (): string => runtimeServiceOrigin("deadlockApi", BASE_URL);
 
 // Endpoints deliberately avoided: /card and /account-stats are Patreon-only and
 // capped at 5 req/min per IP, and match-history?force_refetch=true is 1 req/h.
@@ -63,7 +65,9 @@ export const API_HEADERS: Readonly<Record<string, string>> = {
 };
 
 const request = async (path: string): Promise<unknown> => {
-  const response = await fetch(`${BASE_URL}${path}`, { headers: API_HEADERS });
+  const response = await fetch(`${apiBaseUrl()}${path}`, {
+    headers: API_HEADERS,
+  });
   if (!response.ok) {
     throw new DeadlockApiError(response.status, path);
   }
@@ -210,7 +214,7 @@ export const resolveRank = (
 };
 
 export const getRankAssets = async (): Promise<RankAsset[]> => {
-  const response = await fetch(`${ASSETS_BASE_URL}/v2/ranks`);
+  const response = await fetch(`${assetsBaseUrl()}/v2/ranks`);
   if (!response.ok) {
     throw new DeadlockApiError(response.status, "/v2/ranks");
   }

--- a/apps/desktop/src/lib/stats/cache.ts
+++ b/apps/desktop/src/lib/stats/cache.ts
@@ -1,5 +1,6 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
 import { createLogger } from "@/lib/logger";
+import { resolveStorePath } from "@/lib/runtime-bootstrap";
 
 const logger = createLogger("stats-cache");
 
@@ -60,16 +61,16 @@ const evictExpired = async (store: Store): Promise<void> => {
 };
 
 const getCacheStore = (): Promise<Store> => {
-  storePromise ??= load(STORE_FILE, { autoSave: true, defaults: {} }).then(
-    async (store) => {
+  storePromise ??= resolveStorePath(STORE_FILE)
+    .then((storePath) => load(storePath, { autoSave: true, defaults: {} }))
+    .then(async (store) => {
       try {
         await evictExpired(store);
       } catch (error) {
         logger.withError(error).warn("Cache eviction failed");
       }
       return store;
-    },
-  );
+    });
   return storePromise;
 };
 

--- a/apps/desktop/src/lib/stats/live-store.ts
+++ b/apps/desktop/src/lib/stats/live-store.ts
@@ -1,4 +1,5 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
+import { resolveStorePath } from "@/lib/runtime-bootstrap";
 import { createLogger } from "@/lib/logger";
 import {
   type LiveMatchSample,
@@ -209,7 +210,9 @@ type PersistedBoard = {
 
 let storePromise: Promise<Store> | null = null;
 const getStore = (): Promise<Store> => {
-  storePromise ??= load(PERSIST_FILE, { autoSave: false, defaults: {} });
+  storePromise ??= resolveStorePath(PERSIST_FILE).then((storePath) =>
+    load(storePath, { autoSave: false, defaults: {} }),
+  );
   return storePromise;
 };
 

--- a/apps/desktop/src/lib/stats/live.ts
+++ b/apps/desktop/src/lib/stats/live.ts
@@ -17,6 +17,7 @@ import {
   type LiveBroadcast,
   liveBroadcastSchema,
 } from "@/lib/validation/live-match";
+import { runtimeServiceOrigin } from "@/lib/runtime-bootstrap";
 
 // The scoreboard model itself lives in `live-players`; re-exported so callers
 // keep one import for the whole live feature.
@@ -26,6 +27,7 @@ export type { LiveBroadcast };
 const logger = createLogger("live-match");
 
 const BASE_URL = "https://api.deadlock-api.com";
+const apiBaseUrl = (): string => runtimeServiceOrigin("deadlockApi", BASE_URL);
 
 /**
  * Resolving this makes the API spectate the lobby, which is why it is capped at
@@ -34,9 +36,12 @@ const BASE_URL = "https://api.deadlock-api.com";
 export const getLiveBroadcast = async (
   matchId: string,
 ): Promise<LiveBroadcast> => {
-  const response = await fetch(`${BASE_URL}/v1/matches/${matchId}/live/url`, {
-    headers: API_HEADERS,
-  });
+  const response = await fetch(
+    `${apiBaseUrl()}/v1/matches/${matchId}/live/url`,
+    {
+      headers: API_HEADERS,
+    },
+  );
   if (!response.ok) {
     throw new DeadlockApiError(response.status, "/live/url");
   }
@@ -84,7 +89,7 @@ export const subscribeToLiveMatch = (
   onStatus: (status: LiveStatus) => void,
   onSamples?: (samples: LiveMatchSample[]) => void,
 ): (() => void) => {
-  const url = new URL(`${BASE_URL}/v1/matches/demo/live/query`);
+  const url = new URL(`${apiBaseUrl()}/v1/matches/demo/live/query`);
   url.searchParams.set("query", LIVE_QUERY);
   url.searchParams.set("broadcast_url", broadcastUrl);
 

--- a/apps/desktop/src/lib/store/storage.ts
+++ b/apps/desktop/src/lib/store/storage.ts
@@ -4,6 +4,11 @@ import logger from "@/lib/logger";
 import { STORE_NAME } from "../constants";
 
 const RETRY_DELAYS_MS: readonly number[] = [50, 150, 400];
+let stateStorePath = STORE_NAME;
+
+export const setStateStorePath = (path: string): void => {
+  stateStorePath = path;
+};
 
 export type StorageReadyStatus = {
   ok: boolean;
@@ -42,7 +47,7 @@ const tryRead = async (key: string): Promise<string | null> => {
   let lastError: unknown;
   for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
     try {
-      const store = await getStore(STORE_NAME);
+      const store = await getStore(stateStorePath);
       const value = await store?.get<string>(key);
       return value ?? null;
     } catch (error) {
@@ -94,7 +99,7 @@ const storage: StateStorage = {
       return;
     }
     try {
-      const store = await getStore(STORE_NAME);
+      const store = await getStore(stateStorePath);
       await store?.set(key, value);
       await store?.save();
     } catch (error) {
@@ -115,7 +120,7 @@ const storage: StateStorage = {
       return;
     }
     try {
-      const store = await getStore(STORE_NAME);
+      const store = await getStore(stateStorePath);
       await store?.delete(key);
       await store?.save();
     } catch (error) {
@@ -132,6 +137,7 @@ export default storage;
 // Test-only escape hatch. Resets module state between test cases so each test
 // can exercise the write gate from a clean slate. Not exported from index.
 export const __resetForTests = (): void => {
+  stateStorePath = STORE_NAME;
   firstReadDone = false;
   storageReadyPromise = new Promise<StorageReadyStatus>((resolve) => {
     storageReadyResolve = resolve;

--- a/apps/desktop/src/lib/tauri-commands.ts
+++ b/apps/desktop/src/lib/tauri-commands.ts
@@ -14,9 +14,9 @@ export interface ServerPingResult {
   latencyMs: number | null;
 }
 
-export const initializeApiUrl = async (): Promise<void> => {
+export const initializeApiUrl = async (apiUrl = BASE_URL): Promise<void> => {
   try {
-    await invoke("set_api_url", { apiUrl: BASE_URL });
+    await invoke("set_api_url", { apiUrl });
   } catch (error) {
     logger.withError(error).error("Failed to set API URL in Rust backend");
   }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -29,6 +29,13 @@ import Stats from "./pages/stats";
 import "flag-icons/css/flag-icons.min.css";
 import "./index.css";
 import "./lib/i18n";
+import { initializeApplication } from "./lib/application-bootstrap";
+
+if (import.meta.env.VITE_DMM_E2E_HARNESS === "1") {
+  await import("@wdio/tauri-plugin");
+}
+
+const application = await initializeApplication();
 
 const MapsRouteGate = () => {
   const { isEnabled } = useFeatureFlag("custom-maps", false);
@@ -70,7 +77,13 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
       <Suspense fallback={<Splash />}>
         <BrowserRouter>
           <Routes>
-            <Route element={<App />}>
+            <Route
+              element={
+                <App
+                  runtime={application.runtime}
+                  storage={application.storage}
+                />
+              }>
               <Route element={<Dashboard />} path='/' />
               <Route element={<MyMods />} path='/my-mods' />
               <Route element={<GetMods />} path='/mods' />

--- a/apps/desktop/tsconfig.e2e.json
+++ b/apps/desktop/tsconfig.e2e.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2021", "DOM"],
+    "noEmit": true,
+    "types": ["node", "@wdio/globals/types", "bun", "mocha"]
+  },
+  "include": ["e2e/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src-tauri"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,13 +153,13 @@ importers:
         version: 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/openapi':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/server':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/zod':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(@orpc/contract@1.13.13(@opentelemetry/api@1.9.1))(@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1))(crossws@0.3.5)(ws@8.20.1)(zod@4.3.6)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(@orpc/contract@1.13.13(@opentelemetry/api@1.9.1))(@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3))(crossws@0.3.5)(ws@8.21.3)(zod@4.3.6)
       '@sentry/node':
         specifier: 'catalog:'
         version: 10.46.0(supports-color@10.2.2)
@@ -359,19 +359,19 @@ importers:
         version: 2.6.1
       '@langchain/community':
         specifier: ^1.1.25
-        version: 1.1.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(d3-dsv@3.0.1)(discord.js@14.25.1)(fast-xml-parser@5.5.9)(ignore@7.0.5)(ioredis@5.10.1(supports-color@10.2.2))(jsdom@29.0.0(@noble/hashes@2.0.1))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@6.27.0(ws@8.20.1)(zod@4.3.6))(pg@8.20.0)(puppeteer@24.43.1(supports-color@10.2.2)(typescript@6.0.3))(ws@8.20.1)
+        version: 1.1.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(d3-dsv@3.0.1)(discord.js@14.25.1)(fast-xml-parser@5.5.9)(ignore@7.0.5)(ioredis@5.10.1(supports-color@10.2.2))(jsdom@29.0.0(@noble/hashes@2.0.1))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@6.27.0(ws@8.21.3)(zod@4.3.6))(pg@8.20.0)(puppeteer@24.43.1(supports-color@10.2.2)(typescript@6.0.3))(ws@8.21.3)
       '@langchain/core':
         specifier: ^1.1.36
-        version: 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+        version: 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       '@langchain/langgraph':
         specifier: ^1.2.6
-        version: 1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.3.6)
+        version: 1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.3.6)
       '@langchain/openai':
         specifier: ^1.3.1
-        version: 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(ws@8.20.1)
+        version: 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(ws@8.21.3)
       '@langchain/textsplitters':
         specifier: ^1.0.1
-        version: 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))
+        version: 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))
       '@langfuse/client':
         specifier: ^4.6.1
         version: 4.6.1(@opentelemetry/api@1.9.1)
@@ -380,7 +380,7 @@ importers:
         version: 4.6.1(@opentelemetry/api@1.9.1)
       '@langfuse/langchain':
         specifier: ^4.6.1
-        version: 4.6.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)
+        version: 4.6.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)
       '@langfuse/otel':
         specifier: ^4.6.1
         version: 4.6.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
@@ -431,7 +431,7 @@ importers:
         version: 5.10.1(supports-color@10.2.2)
       langchain:
         specifier: ^1.2.37
-        version: 1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -668,6 +668,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.11.1
         version: 2.11.2
+      '@types/mocha':
+        specifier: 10.0.10
+        version: 10.0.10
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -683,6 +686,27 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(supports-color@10.2.2)(vite@7.1.11(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@wdio/cli':
+        specifier: 9.31.5
+        version: 9.31.5(@types/node@22.19.15)(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+      '@wdio/globals':
+        specifier: 9.31.3
+        version: 9.31.3(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/local-runner':
+        specifier: 9.31.5
+        version: 9.31.5(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(supports-color@10.2.2)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/mocha-framework':
+        specifier: 9.31.5
+        version: 9.31.5(supports-color@10.2.2)
+      '@wdio/spec-reporter':
+        specifier: 9.31.2
+        version: 9.31.2
+      '@wdio/tauri-plugin':
+        specifier: 1.3.0
+        version: 1.3.0(supports-color@10.2.2)(tsx@4.21.0)
+      '@wdio/tauri-service':
+        specifier: 1.3.0
+        version: 1.3.0(supports-color@10.2.2)(tsx@4.21.0)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.14)
@@ -695,6 +719,9 @@ importers:
       tailwind-scrollbar:
         specifier: ^3.1.0
         version: 3.1.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
@@ -704,6 +731,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 7.1.11(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0)
+      webdriverio:
+        specifier: 9.31.5
+        version: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
 
   apps/dmodpkg:
     dependencies:
@@ -913,19 +943,19 @@ importers:
         version: 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/json-schema':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/openapi':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/server':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/tanstack-query':
         specifier: ^1.13.13
         version: 1.13.13(@opentelemetry/api@1.9.1)(@orpc/client@1.13.13(@opentelemetry/api@1.9.1))(@tanstack/query-core@5.95.2)
       '@orpc/zod':
         specifier: ^1.13.13
-        version: 1.13.13(@opentelemetry/api@1.9.1)(@orpc/contract@1.13.13(@opentelemetry/api@1.9.1))(@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1))(crossws@0.3.5)(ws@8.20.1)(zod@4.3.6)
+        version: 1.13.13(@opentelemetry/api@1.9.1)(@orpc/contract@1.13.13(@opentelemetry/api@1.9.1))(@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3))(crossws@0.3.5)(ws@8.21.3)(zod@4.3.6)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2130,6 +2160,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -2144,6 +2180,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2166,6 +2208,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -2180,6 +2228,12 @@ packages:
 
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2202,6 +2256,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
@@ -2216,6 +2276,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2238,6 +2304,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
@@ -2252,6 +2324,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2274,6 +2352,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
@@ -2288,6 +2372,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2310,6 +2400,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
@@ -2324,6 +2420,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2346,6 +2448,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
@@ -2360,6 +2468,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2382,6 +2496,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -2396,6 +2516,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2418,6 +2544,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -2432,6 +2564,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2454,6 +2592,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -2468,6 +2612,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2490,6 +2640,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -2504,6 +2660,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2526,6 +2688,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
@@ -2540,6 +2708,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2562,6 +2736,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
@@ -2576,6 +2756,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2851,8 +3037,133 @@ packages:
   '@import-maps/resolve@2.0.0':
     resolution: {integrity: sha512-RwzRTpmrrS6Q1ZhQExwuxJGK1Wqhv4stt+OF2JzS+uawewpwNyU7EJL1WpBex7aDiiGLs4FsXGkfUBdYuX7xiQ==}
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': 22.19.15
@@ -2874,6 +3185,30 @@ packages:
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
+
+  '@jest/diff-sequences@30.5.0':
+    resolution: {integrity: sha512-OsqBjHXCn8cadasoAZBP6nWYvMsRhpMzGXTpxJ5aO04NlbdhIz+FVe3q49l0AwVhsz/cEmIpBes6gAFl1/dWQg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@30.5.0':
+    resolution: {integrity: sha512-5j0ztPxSy3McUJihjkDdCyCfjvT2hxykFTWsgEBZKB8qsw9ALdCiGTpTRH5gnf/d+qI4SflYUJ0dWNbzjQCWbA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.5.0':
+    resolution: {integrity: sha512-9/2VUPitAjmBzbvDvqrxmvB7BzWsBW0WmkkojX1ODuxX1NLGxx9gfaZpHB0z8DtJ9uhGNmZG/VXBhf8uO0OV8Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.5.0':
+    resolution: {integrity: sha512-HdNQYSdRTEBNrginaqzQtTjG0HRMfrra/z6Ok7uL3S87vSlarIVohEsJsSj5edu3MiHoHjAkvPROz5ZjoKai+w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/schemas@30.5.0':
+    resolution: {integrity: sha512-/hunigyNpc4RCjC0VaW3f5RCUZVM2+WQ65qP7z083Gmvac7or2LI50XVNOtE4YPgBpV0yxYiAgorAPGniCoJmg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.5.0':
+    resolution: {integrity: sha512-s1N+79S4Yp9ZgklCauZXi+YPJdCdtStNYQT32stuD6EeQaIBGHoUfyj2P0YWy8RmuQfaJboO+ulxEvEheR/POQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -4888,6 +5223,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
+  '@promptbook/utils@0.69.5':
+    resolution: {integrity: sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -5985,6 +6323,9 @@ packages:
     resolution: {integrity: sha512-bIFfdiDyHVcUQHY2iTsmtDwhUHX09F/xCM5cGp1cVSbbahMiMmdKaxf/PnNsGSR5wGHfYknV1X1KS1brtXxrnw==}
     engines: {node: '>=22'}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sentry-internal/browser-utils@10.46.0':
     resolution: {integrity: sha512-WB1gBT9G13V02ekZ6NpUhoI1aGHV2eNfjEPthkU2bGBvFpQKnstwzjg7waIRGR7cu+YSW2Q6UI6aQLgBeOPD1g==}
     engines: {node: '>=18'}
@@ -6198,6 +6539,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sinclair/typebox@0.34.52':
+    resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
   '@sindresorhus/is@7.1.1':
     resolution: {integrity: sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ==}
@@ -6611,6 +6955,9 @@ packages:
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/cli-darwin-arm64@2.11.2':
     resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
     engines: {node: '>= 10'}
@@ -6704,6 +7051,9 @@ packages:
 
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
+
+  '@tauri-apps/plugin-log@2.9.0':
+    resolution: {integrity: sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -7071,6 +7421,15 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -7097,6 +7456,9 @@ packages:
 
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -7148,6 +7510,12 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/sinonjs__fake-timers@8.1.5':
+    resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
+
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
@@ -7178,8 +7546,17 @@ packages:
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
+  '@types/which@2.0.2':
+    resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -7313,6 +7690,9 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
@@ -7325,6 +7705,9 @@ packages:
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
@@ -7336,6 +7719,9 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@vladfrangu/async_event_emitter@2.4.7':
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
@@ -7356,6 +7742,139 @@ packages:
   '@vue/shared@3.5.26':
     resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
 
+  '@wdio/cli@9.31.5':
+    resolution: {integrity: sha512-Z040xR3VJ67fGbIj2tAzQmQSWDME6gcTefVVPqOCj3zOrjdIfMKvc+7FPwKwGblR67+6E4q94Yt4P5x0r9P88A==}
+    engines: {node: '>=18.20.0'}
+    hasBin: true
+
+  '@wdio/config@9.31.5':
+    resolution: {integrity: sha512-Xdjo6+Qxg31kMflG2uBp7oCOlr0/BGxjsNJXdz9gT6J3pkNwiQf2O5wSUuJYqOYnuYLAimAklC47/0L//+3H4w==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/dot-reporter@9.31.2':
+    resolution: {integrity: sha512-SY7lYPJzCGdedPxHcGMEJlC2tjdxqqq+e8ROGaob3kmjbKH2Zn7bQIqgCk9fOsA814Zz+V628pEKJNKHL8xpyQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/globals@9.29.1':
+    resolution: {integrity: sha512-F96BKppx4HGD64v+s57TM4K4zaxqUCg2RXHk6sjB2xrSa7P+d2VYV28ID2ddF7iSodVfPlpa1i2/jy8jMGrU8w==}
+    engines: {node: '>=18.20.0'}
+    peerDependencies:
+      expect-webdriverio: ^5.6.5
+      webdriverio: ^9.0.0
+
+  '@wdio/globals@9.31.3':
+    resolution: {integrity: sha512-ZzmRKUlwUBahNoNxHbAzst+9dNInEjLQc7Z3c86OhDRxAf3Ivw8k2rc56UCbyYiZnkd1dOpuA91zFiTrUNNORw==}
+    engines: {node: '>=18.20.0'}
+    peerDependencies:
+      expect-webdriverio: ^6.0.9
+      webdriverio: ^9.28.0
+
+  '@wdio/local-runner@9.31.5':
+    resolution: {integrity: sha512-5jZcUpZGxWXr4Mido8DgiCzZ+B7EMXtPo8wGe96KwTWkHnCjFj53ZIjpT9GVYIxnJsX0zslqsuA28/2An0pq2g==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/logger@9.18.0':
+    resolution: {integrity: sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/logger@9.29.1':
+    resolution: {integrity: sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/mocha-framework@9.31.5':
+    resolution: {integrity: sha512-UYGNF8M77T7PKvRGidN+Iu++LSPLKbKpQ+K3eJEaDnP7hWcHk+x7VYKrXWPWorPuJfS2ocT+QWAgZlkEhTo6fQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/native-core@1.1.0':
+    resolution: {integrity: sha512-whRLCp8ZpZDvjNHOkXZdPzSJmRyqtyA7XldUZaawV+g+ib8N4EcgjhSiT58djmJw4jxMec+94niEj5a1c6ZkCA==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+
+  '@wdio/native-spy@1.2.0':
+    resolution: {integrity: sha512-roTRIi/0pxSpC7C4DIAqzh3i2dqKaV+T+mx9Yu1vOGAG9vbQwHGn/qwxHTggE+3kV1FYWOoSI0eKnKw9aqFiDg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+
+  '@wdio/native-types@2.4.0':
+    resolution: {integrity: sha512-GjgPskOoTvl17Jwj8aAU3A31gpklL5M1KfbrwYffbQT16CTpJTD8A4PdoS2ZjGoCWcyLBR1CWdJI3W8T0JBLjw==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+
+  '@wdio/native-types@2.5.0':
+    resolution: {integrity: sha512-NjaIfcsEKpU9gm0goywEG0A7J4pyEsgORKNrQ1xboSy10BeTk5QpgHWP1bNvqUnZrKoKJRonpSn81ZyYKghO1g==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+
+  '@wdio/native-utils@2.5.0':
+    resolution: {integrity: sha512-Qv0mJ2elRBZCgYbHCnKPNgE9VaqnmNJyjythTDYyOQpj8pAs6FZXXmWXGkUIdMds5cK0ux/qtxyKU0Y0tDsUUQ==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+    peerDependencies:
+      tsx: ^4.22.4
+    peerDependenciesMeta:
+      tsx:
+        optional: true
+
+  '@wdio/native-utils@2.6.0':
+    resolution: {integrity: sha512-54qpJ1XwNl4gBTYb84xsRTHDi3zTdmbms4FBUVFY50+X3t0FDuMmWlBLYADdyS1d17uv698GUFRjrorRKLAPXw==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+    peerDependencies:
+      tsx: ^4.22.4
+    peerDependenciesMeta:
+      tsx:
+        optional: true
+
+  '@wdio/protocols@9.31.5':
+    resolution: {integrity: sha512-e4H5exl5xCcITF0y/3zd6pf9kX4TmV8/0nnWDGt4X0KbgDi/+tGqlquZ+YS4YBEPbv95yTqVhnazEsaBiH85Tw==}
+
+  '@wdio/repl@9.16.2':
+    resolution: {integrity: sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/reporter@9.29.1':
+    resolution: {integrity: sha512-CKAcVy9BGwvufokMcl3H+yNcvD11Klku/1BPz8bKSRv7/KzueXR06s1cPbJH3tv9r9zxPErxgdVMpulN8I0qAg==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/reporter@9.31.2':
+    resolution: {integrity: sha512-3cKE6vCOsro/Ep9dGTIbo3FBn3WNvJ++BIn32lFd9m19pFdjuwlVgLtPXHb9jWNCJs740h5AIUcVkcscqUYhAA==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/runner@9.31.5':
+    resolution: {integrity: sha512-ffr8v2X104yrETxaVxq0oi0oFBfL3Q7xTrGLGneOsCSpwS+fuq6TkQr51zNZzB06ikjaFZnTmNMMh3GblC6jBQ==}
+    engines: {node: '>=18.20.0'}
+    peerDependencies:
+      expect-webdriverio: ^6.0.9
+      webdriverio: ^9.28.0
+
+  '@wdio/spec-reporter@9.29.1':
+    resolution: {integrity: sha512-iqlHW/qGDRGmxQKN7XyCHxfKphTbPNnniV3yxNXZRSGHCCQok5KFKOnj4fpUCKEyD5jtPAmP6Y0qc1UyR3Dc3Q==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/spec-reporter@9.31.2':
+    resolution: {integrity: sha512-lNLLPUk4y1Yp5pWwBFF+tjZIy7bOv0TPTk4HDWV4LnnHnkc24abI0nN+kb2y5/JV8ZgwLCCVKUFRdRUxfKsAaQ==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/tauri-plugin@1.3.0':
+    resolution: {integrity: sha512-dq0utb6Lj5bi3zzHkIIb4WTegpqVMc3D+mVsJCx7OzRPiFQfhYutmRIkNS/i3Cai41KqTf2eP5ZvlPO0LCKv0A==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+
+  '@wdio/tauri-service@1.3.0':
+    resolution: {integrity: sha512-CzO7ddZo0gIdwVWDftUbHmDPC74M2ZDwWiucUe1M37/QCNy9y4QEdYbobD8yuL1c9n4dAO+NQzmvC3BUICjl0Q==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.11.0}
+    peerDependencies:
+      webdriverio: ^9.0.0
+
+  '@wdio/types@9.29.1':
+    resolution: {integrity: sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/types@9.31.2':
+    resolution: {integrity: sha512-lQKaiQDCJJ6VC1K/cKzaAxCpwB9pL1U0VbmX2uGksMxO4EDbNuLvIxWryuUDJ7OaSYTjxILTKYFErdbT/xEikg==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/utils@9.31.5':
+    resolution: {integrity: sha512-wufYrRdz0Dr8Oa9OiaFsitQJsD8HWG5J4FQi/r3nZv/W3S+1h1lpBCAmDisH1Q6wN7Ed9v20E56ZU0UOaP5v3g==}
+    engines: {node: '>=18.20.0'}
+
+  '@wdio/xvfb@9.31.2':
+    resolution: {integrity: sha512-48MqdcrvdC/Jn2YPhW6hjGLzcQqOEt1Q6KELR/TWz3vIJoZwzTngGAdT06voUnZS+PUEcd/vKSo4a6zxQ/mm7g==}
+    engines: {node: '>=18.20.0'}
+
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
     engines: {node: '>=18.0.0'}
@@ -7375,6 +7894,10 @@ packages:
   '@whatwg-node/server@0.10.17':
     resolution: {integrity: sha512-QxI+HQfJeI/UscFNCTcSri6nrHP25mtyAMbhEri7W2ctdb3EsorPuJz7IovSgNjvKVs73dg9Fmayewx1O2xOxA==}
     engines: {node: '>=18.0.0'}
+
+  '@zip.js/zip.js@2.8.61':
+    resolution: {integrity: sha512-F9RnQJXgvCSdAJfMtSrH5Uh/LcLg8fZlg5ARC4u5N4w9v/DG27cN3C/ngUrY1JdJGX2LRv5DDViXeZJgbcppWA==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -7506,6 +8029,10 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  async-exit-hook@2.0.1:
+    resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
+    engines: {node: '>=0.12.0'}
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
@@ -7705,6 +8232,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -7837,6 +8367,10 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
@@ -7860,12 +8394,19 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -7874,6 +8415,10 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -7930,6 +8475,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -7944,6 +8493,10 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
@@ -8026,6 +8579,11 @@ packages:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
 
+  create-wdio@9.31.2:
+    resolution: {integrity: sha512-5dEHfcBbaOwL+XPAlVSdC9YzOTe+bjZRQk2mQnR0/QeeAffdY6ZaJ0QS0NiMTyZsphwoJZW4Mokialsgz1Hn6A==}
+    engines: {node: '>=18.20.0'}
+    hasBin: true
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
@@ -8057,6 +8615,9 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-shorthand-properties@1.1.2:
+    resolution: {integrity: sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==}
+
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
@@ -8068,6 +8629,9 @@ packages:
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-value@0.0.1:
+    resolution: {integrity: sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==}
 
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
@@ -8309,6 +8873,14 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
+  decamelize@6.0.1:
+    resolution: {integrity: sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -8330,6 +8902,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deepmerge-ts@7.1.6:
+    resolution: {integrity: sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==}
+    engines: {node: '>=16.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -8341,6 +8917,9 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -8441,6 +9020,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
@@ -8617,8 +9200,20 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  easy-table@1.2.0:
+    resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  edge-paths@3.0.5:
+    resolution: {integrity: sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==}
+    engines: {node: '>=14.0.0'}
+
+  edgedriver@6.3.0:
+    resolution: {integrity: sha512-ggEQL+oEyIcM4nP2QC3AtCQ04o4kDNefRM3hja0odvlPSnsaxiruMxEZ93v3gDCKWYW6BXUr51PPradb+3nffw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -8731,12 +9326,21 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -8823,9 +9427,29 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  exit-hook@4.0.0:
+    resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
+    engines: {node: '>=18'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  expect-webdriverio@6.0.9:
+    resolution: {integrity: sha512-f5FDdMpHnHHMaXjV0jwtDl3nu4R3/VLaWtEGZwcM2GVyMpLGdTY4fMbpDHx3VwXPudxkB73Nde7RW0QfsLmxtw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@wdio/globals': ^9.0.0
+      '@wdio/logger': ^9.0.0
+      webdriverio: ^9.28.0
+
+  expect@30.5.0:
+    resolution: {integrity: sha512-8fiMWcEjPU7B9nErC4FtFcCzf2tC6I75Qf7m8wzBAWC2taZmcno3yAFEjIQL34SwoGZNgPf63UDiJLyh4SMPaw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -8933,6 +9557,10 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-up@6.3.0:
+    resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   find-up@7.0.0:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
@@ -8989,6 +9617,9 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -9144,6 +9775,11 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  geckodriver@6.1.1:
+    resolution: {integrity: sha512-/AcCyc9o9o6hUbudaSJM2iOtXbxSLqQPOb4GrPvEN40cjraUeaX/j5kH3mSgwiroyMn7qzx2wM61AQ2XY8j3sA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -9184,6 +9820,10 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
@@ -9219,6 +9859,11 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -9246,6 +9891,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grapheme-splitter@1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
   gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
@@ -9314,6 +9962,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
@@ -9331,6 +9983,10 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  hosted-git-info@8.1.0:
+    resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -9343,6 +9999,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlfy@0.8.1:
+    resolution: {integrity: sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==}
 
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
@@ -9377,6 +10036,10 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   i18next-browser-languagedetector@8.2.1:
     resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
@@ -9453,6 +10116,10 @@ packages:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -9464,6 +10131,15 @@ packages:
     peerDependencies:
       react: 19.2.0
       react-dom: 19.2.0
+
+  inquirer@12.11.1:
+    resolution: {integrity: sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': 22.19.15
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -9590,6 +10266,10 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
   is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
@@ -9627,6 +10307,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -9634,6 +10318,30 @@ packages:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  jest-diff@30.5.0:
+    resolution: {integrity: sha512-QjCfDMwdPFvLxTQmS4/Dswx3PUCiqmSXVLGljMC3SU7YG1qHVoR6b86IH/O2G9k9OMyKXz2vS2Q60VnAozNDwA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@30.5.0:
+    resolution: {integrity: sha512-EfaYMC9f9ds7fahB/LYFTgd1Z2RS9Vpm2e46gazij0onkpoQG7Daq+MLm8/gQVqWwRVjL/RNDggbFx9MsrJEmQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-message-util@30.5.0:
+    resolution: {integrity: sha512-dBYMhplGfspKaCnVk9TUy1cZnknWubpuPNEputjz0YJk1G/92R45rn45BvbPMPMtC5LVcIdxJGPOaOSQTiuzJw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.5.0:
+    resolution: {integrity: sha512-bP5MHZpkYrV7xpV+yvhl36DPcXoEmTR57Un5EACcdVpMY7mpkDefCBq+V4mhcjE/3rwUajT6OTrcJTN7EwN1BA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-regex-util@30.5.0:
+    resolution: {integrity: sha512-Mg0WK7A6xRHLSA1udJ8y9f3lM0uUhFTBnLKzwPmqB9AylvpleJ6BLemR8K9dK27DY+cesDryoA7yLZCAHsPG1A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-util@30.5.0:
+    resolution: {integrity: sha512-lzU4aGUWaS+2X/B0CmgheDasfnsVlRfZh/rNQxB9b9s8cSYUq5BcqdQA95ld+KqJXBUVVt1sqnMQ2T3OxIalmg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -9697,6 +10405,10 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-parse-even-better-errors@3.0.2:
+    resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   json-pointer@0.6.2:
     resolution: {integrity: sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==}
@@ -9952,6 +10664,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lines-and-columns@2.0.4:
+    resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -9965,6 +10681,9 @@ packages:
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
+
+  locate-app@2.5.0:
+    resolution: {integrity: sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -9984,8 +10703,14 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.flattendeep@4.4.0:
+    resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -10011,17 +10736,30 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash.pickby@4.6.0:
+    resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
+
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+
+  lodash.zip@4.2.0:
+    resolution: {integrity: sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -10038,6 +10776,13 @@ packages:
   loglayer@6.10.0:
     resolution: {integrity: sha512-EOxAzIiyzmfdXjCiwLWzPl9Syxt2ds+8w4tkdeC3TzSXnKzPcD4dc6vh8JRBO37BE6kiQhXWXrxJMqZ0BWi1fQ==}
     engines: {node: '>=18'}
+
+  loglevel-plugin-prefix@0.8.4:
+    resolution: {integrity: sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -10370,6 +11115,15 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  mocha@10.8.2:
+    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
+    engines: {node: '>= 14.0.0'}
+    hasBin: true
+
+  modern-tar@0.7.7:
+    resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
+    engines: {node: '>=18.0.0'}
+
   module-definition@6.0.1:
     resolution: {integrity: sha512-FeVc50FTfVVQnolk/WQT8MX+2WVcDnTGiq6Wo+/+lJ2ET1bRVi3HG3YlJUfqagNMc/kUlFSoR96AJkxGpKz13g==}
     engines: {node: '>=18'}
@@ -10419,6 +11173,10 @@ packages:
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -10553,6 +11311,10 @@ packages:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  normalize-package-data@7.0.1:
+    resolution: {integrity: sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
     engines: {node: '>=0.10.0'}
@@ -10564,6 +11326,10 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   npm-to-yarn@3.0.1:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
@@ -10584,6 +11350,10 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
@@ -10792,8 +11562,16 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-json@7.1.1:
+    resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
+    engines: {node: '>=16'}
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
@@ -10898,9 +11676,6 @@ packages:
     resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
     peerDependencies:
       pg: '>=8.0'
-
-  pg-protocol@1.10.3:
-    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
 
   pg-protocol@1.13.0:
     resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
@@ -11063,6 +11838,14 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-format@30.5.0:
+    resolution: {integrity: sha512-mzNzBErpHwM0zpmWS7ExOv62yhQhvd546nUuFqVR0dmnJB59tfrw9sjDF0DJknwsr59OXP0buwJ7PaKguczHSg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  pretty-ms@9.3.1:
+    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
+    engines: {node: '>=18'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -11188,6 +11971,9 @@ packages:
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -11262,6 +12048,9 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.8:
+    resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
 
   react-medium-image-zoom@5.4.1:
     resolution: {integrity: sha512-DD2iZYaCfAwiQGR8AN62r/cDJYoXhezlYJc5HY4TzBUGuGge43CptG0f7m0PEIM72aN6GfpjohvY1yYdtCJB7g==}
@@ -11345,6 +12134,14 @@ packages:
     resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
     engines: {node: '>=18'}
 
+  read-pkg-up@10.1.0:
+    resolution: {integrity: sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==}
+    engines: {node: '>=16'}
+
+  read-pkg@8.1.0:
+    resolution: {integrity: sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==}
+    engines: {node: '>=16'}
+
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
     engines: {node: '>=18'}
@@ -11407,6 +12204,10 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  recursive-readdir@2.2.3:
+    resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
+    engines: {node: '>=6.0.0'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -11494,9 +12295,16 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  resq@1.11.0:
+    resolution: {integrity: sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -11505,6 +12313,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgb2hex@0.2.5:
+    resolution: {integrity: sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==}
 
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
@@ -11569,6 +12380,10 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -11578,11 +12393,19 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safaridriver@1.0.1:
+    resolution: {integrity: sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==}
+    engines: {node: '>=18.0.0'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -11731,6 +12554,10 @@ packages:
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
 
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
+
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -11766,6 +12593,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spacetrim@0.11.59:
+    resolution: {integrity: sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -11799,6 +12629,10 @@ packages:
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -11818,6 +12652,10 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
+
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -11858,6 +12696,14 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -12041,6 +12887,10 @@ packages:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
@@ -12184,6 +13034,14 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
+
+  type-fest@4.26.0:
+    resolution: {integrity: sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==}
+    engines: {node: '>=16'}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -12240,6 +13098,10 @@ packages:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   undici@7.23.0:
     resolution: {integrity: sha512-HVMxHKZKi+eL2mrUZDzDkKW3XvCjynhbtpSq20xQp4ePDFeSFuAfnvM0GIwZIv8fiKHjXFQ5WjxhCt15KRNj+g==}
     engines: {node: '>=20.18.1'}
@@ -12253,6 +13115,10 @@ packages:
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
   unicorn-magic@0.4.0:
@@ -12498,6 +13364,10 @@ packages:
     peerDependencies:
       react: 19.2.0
 
+  userhome@1.0.1:
+    resolution: {integrity: sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==}
+    engines: {node: '>= 0.8.0'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -12711,6 +13581,14 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wait-port@1.1.0:
+    resolution: {integrity: sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -12723,6 +13601,19 @@ packages:
 
   webdriver-bidi-protocol@0.4.1:
     resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
+  webdriver@9.31.5:
+    resolution: {integrity: sha512-ppQ3sKydQ59CVDsODri/pIdVfVp5nSP78qfwbK9LrrICbLkXktCd0pK/Nbc3EclbJ2hOfhfHpU8vuodJ73e4uA==}
+    engines: {node: '>=18.20.0'}
+
+  webdriverio@9.31.5:
+    resolution: {integrity: sha512-XfbzuhqNcpdZeX70bEEmYCvpQ9fgfXVVOkQWF+rCZBkmqW4W61Ol4bqUnKLIhXI4vysSATi2S19vxPK+WTAeWA==}
+    engines: {node: '>=18.20.0'}
+    peerDependencies:
+      puppeteer-core: '>=22.x <=24.x'
+    peerDependenciesMeta:
+      puppeteer-core:
+        optional: true
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -12767,6 +13658,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -12785,6 +13681,13 @@ packages:
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -12817,8 +13720,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -12881,6 +13784,10 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -12888,6 +13795,14 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -12925,6 +13840,14 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -13617,7 +14540,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.27.4
+      esbuild: 0.28.2
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -13634,6 +14557,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
@@ -13641,6 +14567,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -13652,6 +14581,9 @@ snapshots:
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
     optional: true
 
@@ -13659,6 +14591,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -13670,6 +14605,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
@@ -13677,6 +14615,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -13688,6 +14629,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
@@ -13695,6 +14639,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -13706,6 +14653,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
@@ -13713,6 +14663,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -13724,6 +14677,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
@@ -13731,6 +14687,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -13742,6 +14701,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
@@ -13749,6 +14711,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -13760,6 +14725,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -13767,6 +14735,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -13778,6 +14749,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
@@ -13785,6 +14759,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -13796,6 +14773,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
@@ -13803,6 +14783,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -13814,6 +14797,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
@@ -13821,6 +14807,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
@@ -13832,6 +14821,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
@@ -13839,6 +14831,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
@@ -13850,6 +14845,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
@@ -13857,6 +14855,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
@@ -14062,10 +15063,128 @@ snapshots:
 
   '@import-maps/resolve@2.0.0': {}
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/confirm@5.1.21(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/core@10.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/editor@4.2.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/expand@4.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
   '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/number@3.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/password@4.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.15)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.15)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.15)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.15)
+      '@inquirer/input': 4.3.1(@types/node@22.19.15)
+      '@inquirer/number': 3.0.23(@types/node@22.19.15)
+      '@inquirer/password': 4.0.23(@types/node@22.19.15)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.15)
+      '@inquirer/search': 3.2.2(@types/node@22.19.15)
+      '@inquirer/select': 4.4.2(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/search@3.2.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/select@4.4.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/type@3.0.10(@types/node@22.19.15)':
     optionalDependencies:
       '@types/node': 22.19.15
 
@@ -14082,9 +15201,36 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@isaacs/ttlcache@1.4.1': {}
+
+  '@jest/diff-sequences@30.5.0': {}
+
+  '@jest/expect-utils@30.5.0':
+    dependencies:
+      '@jest/get-type': 30.5.0
+
+  '@jest/get-type@30.5.0': {}
+
+  '@jest/pattern@30.5.0':
+    dependencies:
+      '@types/node': 22.19.15
+      jest-regex-util: 30.5.0
+
+  '@jest/schemas@30.5.0':
+    dependencies:
+      '@sinclair/typebox': 0.34.52
+
+  '@jest/types@30.5.0':
+    dependencies:
+      '@jest/pattern': 30.5.0
+      '@jest/schemas': 30.5.0
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 22.19.15
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -14127,11 +15273,11 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@langchain/classic@1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)':
+  '@langchain/classic@1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))(ws@8.21.3)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
-      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(ws@8.20.1)
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
+      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(ws@8.21.3)
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))
       handlebars: 4.7.8
       js-yaml: 4.1.1
       jsonpointer: 5.0.1
@@ -14140,7 +15286,7 @@ snapshots:
       yaml: 2.8.2
       zod: 4.3.6
     optionalDependencies:
-      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -14148,17 +15294,17 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(d3-dsv@3.0.1)(discord.js@14.25.1)(fast-xml-parser@5.5.9)(ignore@7.0.5)(ioredis@5.10.1(supports-color@10.2.2))(jsdom@29.0.0(@noble/hashes@2.0.1))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@6.27.0(ws@8.20.1)(zod@4.3.6))(pg@8.20.0)(puppeteer@24.43.1(supports-color@10.2.2)(typescript@6.0.3))(ws@8.20.1)':
+  '@langchain/community@1.1.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(d3-dsv@3.0.1)(discord.js@14.25.1)(fast-xml-parser@5.5.9)(ignore@7.0.5)(ioredis@5.10.1(supports-color@10.2.2))(jsdom@29.0.0(@noble/hashes@2.0.1))(jsonwebtoken@9.0.3)(lodash@4.18.1)(openai@6.27.0(ws@8.21.3)(zod@4.3.6))(pg@8.20.0)(puppeteer@24.43.1(supports-color@10.2.2)(typescript@6.0.3))(ws@8.21.3)':
     dependencies:
-      '@langchain/classic': 1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
-      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(ws@8.20.1)
+      '@langchain/classic': 1.0.25(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))(ws@8.21.3)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
+      '@langchain/openai': 1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(ws@8.21.3)
       binary-extensions: 2.3.0
       flat: 5.0.2
       js-yaml: 4.1.1
-      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       math-expression-evaluator: 2.0.7
-      openai: 6.27.0(ws@8.20.1)(zod@4.3.6)
+      openai: 6.27.0(ws@8.21.3)(zod@4.3.6)
       uuid: 10.0.0
       zod: 4.3.6
     optionalDependencies:
@@ -14172,14 +15318,14 @@ snapshots:
       lodash: 4.18.1
       pg: 8.20.0
       puppeteer: 24.43.1(supports-color@10.2.2)(typescript@6.0.3)
-      ws: 8.20.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - peggy
 
-  '@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))':
+  '@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -14187,7 +15333,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 11.1.0
@@ -14198,32 +15344,32 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       uuid: 10.0.0
 
-  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))':
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.8.2(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@langchain/langgraph-sdk@1.8.2(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.2
     optionalDependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@langchain/langgraph@1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.3.6)':
+  '@langchain/langgraph@1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
-      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))
-      '@langchain/langgraph-sdk': 1.8.2(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))
+      '@langchain/langgraph-sdk': 1.8.2(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6
@@ -14233,18 +15379,18 @@ snapshots:
       - svelte
       - vue
 
-  '@langchain/openai@1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(ws@8.20.1)':
+  '@langchain/openai@1.3.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(ws@8.21.3)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       js-tiktoken: 1.0.21
-      openai: 6.27.0(ws@8.20.1)(zod@4.3.6)
+      openai: 6.27.0(ws@8.21.3)(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       js-tiktoken: 1.0.21
 
   '@langfuse/client@4.6.1(@opentelemetry/api@1.9.1)':
@@ -14258,9 +15404,9 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@langfuse/langchain@4.6.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)':
+  '@langfuse/langchain@4.6.1(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       '@langfuse/core': 4.6.1(@opentelemetry/api@1.9.1)
       '@langfuse/tracing': 4.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
@@ -15899,12 +17045,12 @@ snapshots:
 
   '@orpc/interop@1.13.13': {}
 
-  '@orpc/json-schema@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)':
+  '@orpc/json-schema@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)':
     dependencies:
       '@orpc/contract': 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/interop': 1.13.13
-      '@orpc/openapi': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
-      '@orpc/server': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+      '@orpc/openapi': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
+      '@orpc/server': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/shared': 1.13.13(@opentelemetry/api@1.9.1)
       json-schema-typed: 8.0.2
     transitivePeerDependencies:
@@ -15922,13 +17068,13 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/openapi@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)':
+  '@orpc/openapi@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)':
     dependencies:
       '@orpc/client': 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/contract': 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/interop': 1.13.13
       '@orpc/openapi-client': 1.13.13(@opentelemetry/api@1.9.1)
-      '@orpc/server': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+      '@orpc/server': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/shared': 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/standard-server': 1.13.13(@opentelemetry/api@1.9.1)
       json-schema-typed: 8.0.2
@@ -15939,7 +17085,7 @@ snapshots:
       - fastify
       - ws
 
-  '@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)':
+  '@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)':
     dependencies:
       '@orpc/client': 1.13.13(@opentelemetry/api@1.9.1)
       '@orpc/contract': 1.13.13(@opentelemetry/api@1.9.1)
@@ -15954,7 +17100,7 @@ snapshots:
       cookie: 1.1.1
     optionalDependencies:
       crossws: 0.3.5
-      ws: 8.20.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - fastify
@@ -16019,12 +17165,12 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/zod@1.13.13(@opentelemetry/api@1.9.1)(@orpc/contract@1.13.13(@opentelemetry/api@1.9.1))(@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1))(crossws@0.3.5)(ws@8.20.1)(zod@4.3.6)':
+  '@orpc/zod@1.13.13(@opentelemetry/api@1.9.1)(@orpc/contract@1.13.13(@opentelemetry/api@1.9.1))(@orpc/server@1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3))(crossws@0.3.5)(ws@8.21.3)(zod@4.3.6)':
     dependencies:
       '@orpc/contract': 1.13.13(@opentelemetry/api@1.9.1)
-      '@orpc/json-schema': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
-      '@orpc/openapi': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
-      '@orpc/server': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.20.1)
+      '@orpc/json-schema': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
+      '@orpc/openapi': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
+      '@orpc/server': 1.13.13(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@orpc/shared': 1.13.13(@opentelemetry/api@1.9.1)
       escape-string-regexp: 5.0.0
       wildcard-match: 5.1.4
@@ -16243,6 +17389,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@promptbook/utils@0.69.5':
+    dependencies:
+      spacetrim: 0.11.59
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -16280,7 +17430,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
-    optional: true
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -17259,6 +18408,8 @@ snapshots:
     dependencies:
       '@scalar/openapi-types': 0.6.1
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@sentry-internal/browser-utils@10.46.0':
     dependencies:
       '@sentry/core': 10.46.0
@@ -17561,6 +18712,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sinclair/typebox@0.34.52': {}
 
   '@sindresorhus/is@7.1.1': {}
 
@@ -18057,6 +19210,8 @@ snapshots:
 
   '@tauri-apps/api@2.11.0': {}
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/cli-darwin-arm64@2.11.2':
     optional: true
 
@@ -18127,6 +19282,10 @@ snapshots:
   '@tauri-apps/plugin-log@2.8.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-log@2.9.0':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
@@ -18346,8 +19505,7 @@ snapshots:
       '@tiptap/extensions': 3.21.0(@tiptap/core@3.21.0(@tiptap/pm@3.21.0))(@tiptap/pm@3.21.0)
       '@tiptap/pm': 3.21.0
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    optional: true
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@turbo/darwin-64@2.9.6':
     optional: true
@@ -18555,6 +19713,16 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@5.0.0': {}
@@ -18581,6 +19749,8 @@ snapshots:
   '@types/memcached@2.2.10':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/mocha@10.0.10': {}
 
   '@types/ms@2.1.0': {}
 
@@ -18615,7 +19785,7 @@ snapshots:
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 22.19.15
-      pg-protocol: 1.10.3
+      pg-protocol: 1.13.0
       pg-types: 2.2.0
 
   '@types/pg@8.6.1':
@@ -18642,6 +19812,10 @@ snapshots:
   '@types/retry@0.12.2': {}
 
   '@types/shimmer@1.2.0': {}
+
+  '@types/sinonjs__fake-timers@8.1.5': {}
+
+  '@types/stack-utils@2.0.3': {}
 
   '@types/stats.js@0.17.4': {}
 
@@ -18673,9 +19847,17 @@ snapshots:
 
   '@types/webxr@0.5.24': {}
 
+  '@types/which@2.0.2': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -18848,6 +20030,10 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
   '@vitest/runner@2.1.9':
     dependencies:
       '@vitest/utils': 2.1.9
@@ -18871,6 +20057,13 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
@@ -18890,6 +20083,12 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
 
@@ -18925,6 +20124,289 @@ snapshots:
 
   '@vue/shared@3.5.26': {}
 
+  '@wdio/cli@9.31.5(@types/node@22.19.15)(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@vitest/snapshot': 2.1.9
+      '@wdio/config': 9.31.5(supports-color@10.2.2)
+      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/logger': 9.29.1
+      '@wdio/protocols': 9.31.5
+      '@wdio/types': 9.31.2
+      '@wdio/utils': 9.31.5(supports-color@10.2.2)
+      async-exit-hook: 2.0.1
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      create-wdio: 9.31.2(@types/node@22.19.15)
+      dotenv: 17.2.3
+      import-meta-resolve: 4.2.0
+      lodash.flattendeep: 4.4.0
+      lodash.pickby: 4.6.0
+      lodash.union: 4.6.0
+      read-pkg-up: 10.1.0
+      tsx: 4.21.0
+      webdriverio: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - expect-webdriverio
+      - puppeteer-core
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  '@wdio/config@9.31.5(supports-color@10.2.2)':
+    dependencies:
+      '@wdio/logger': 9.29.1
+      '@wdio/types': 9.31.2
+      '@wdio/utils': 9.31.5(supports-color@10.2.2)
+      deepmerge-ts: 7.1.6
+      glob: 10.5.0
+      import-meta-resolve: 4.2.0
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@wdio/dot-reporter@9.31.2':
+    dependencies:
+      '@wdio/reporter': 9.31.2
+      '@wdio/types': 9.31.2
+      chalk: 5.6.2
+
+  '@wdio/globals@9.29.1(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))':
+    dependencies:
+      webdriverio: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+
+  '@wdio/globals@9.31.3(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))':
+    dependencies:
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      webdriverio: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+
+  '@wdio/local-runner@9.31.5(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(supports-color@10.2.2)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))':
+    dependencies:
+      '@types/node': 22.19.15
+      '@wdio/logger': 9.29.1
+      '@wdio/repl': 9.16.2
+      '@wdio/runner': 9.31.5(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(supports-color@10.2.2)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/types': 9.31.2
+      '@wdio/xvfb': 9.31.2
+      exit-hook: 4.0.0
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      split2: 4.2.0
+      stream-buffers: 3.0.3
+    transitivePeerDependencies:
+      - '@wdio/globals'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+      - webdriverio
+
+  '@wdio/logger@9.18.0':
+    dependencies:
+      chalk: 5.6.2
+      loglevel: 1.9.2
+      loglevel-plugin-prefix: 0.8.4
+      safe-regex2: 5.1.1
+      strip-ansi: 7.1.2
+
+  '@wdio/logger@9.29.1':
+    dependencies:
+      chalk: 5.6.2
+      loglevel: 1.9.2
+      loglevel-plugin-prefix: 0.8.4
+      safe-regex2: 5.1.1
+      strip-ansi: 7.1.2
+
+  '@wdio/mocha-framework@9.31.5(supports-color@10.2.2)':
+    dependencies:
+      '@types/mocha': 10.0.10
+      '@types/node': 22.19.15
+      '@wdio/logger': 9.29.1
+      '@wdio/types': 9.31.2
+      '@wdio/utils': 9.31.5(supports-color@10.2.2)
+      mocha: 10.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@wdio/native-core@1.1.0(supports-color@10.2.2)(tsx@4.21.0)':
+    dependencies:
+      '@wdio/logger': 9.29.1
+      '@wdio/native-types': 2.4.0
+      '@wdio/native-utils': 2.5.0(supports-color@10.2.2)(tsx@4.21.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      get-port: 7.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - tsx
+
+  '@wdio/native-spy@1.2.0': {}
+
+  '@wdio/native-types@2.4.0': {}
+
+  '@wdio/native-types@2.5.0': {}
+
+  '@wdio/native-utils@2.5.0(supports-color@10.2.2)(tsx@4.21.0)':
+    dependencies:
+      '@wdio/logger': 9.18.0
+      debug: 4.4.3(supports-color@10.2.2)
+      esbuild: 0.28.2
+      find-up-simple: 1.0.1
+      json5: 2.2.3
+      smol-toml: 1.8.0
+      yaml: 2.9.0
+    optionalDependencies:
+      tsx: 4.21.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@wdio/native-utils@2.6.0(supports-color@10.2.2)(tsx@4.21.0)':
+    dependencies:
+      '@wdio/logger': 9.29.1
+      debug: 4.4.3(supports-color@10.2.2)
+      esbuild: 0.28.2
+      find-up-simple: 1.0.1
+      json5: 2.2.3
+      smol-toml: 1.8.0
+      yaml: 2.9.0
+    optionalDependencies:
+      tsx: 4.21.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@wdio/protocols@9.31.5': {}
+
+  '@wdio/repl@9.16.2':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@wdio/reporter@9.29.1':
+    dependencies:
+      '@types/node': 22.19.15
+      '@wdio/logger': 9.29.1
+      '@wdio/types': 9.29.1
+      diff: 8.0.3
+      object-inspect: 1.13.4
+
+  '@wdio/reporter@9.31.2':
+    dependencies:
+      '@types/node': 22.19.15
+      '@wdio/logger': 9.29.1
+      '@wdio/types': 9.31.2
+      diff: 8.0.3
+      object-inspect: 1.13.4
+
+  '@wdio/runner@9.31.5(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(supports-color@10.2.2)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))':
+    dependencies:
+      '@types/node': 22.19.15
+      '@wdio/config': 9.31.5(supports-color@10.2.2)
+      '@wdio/dot-reporter': 9.31.2
+      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/logger': 9.29.1
+      '@wdio/types': 9.31.2
+      '@wdio/utils': 9.31.5(supports-color@10.2.2)
+      deepmerge-ts: 7.1.6
+      expect-webdriverio: 6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      webdriver: 9.31.5(supports-color@10.2.2)
+      webdriverio: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  '@wdio/spec-reporter@9.29.1':
+    dependencies:
+      '@wdio/reporter': 9.29.1
+      '@wdio/types': 9.29.1
+      chalk: 5.6.2
+      easy-table: 1.2.0
+      pretty-ms: 9.3.1
+
+  '@wdio/spec-reporter@9.31.2':
+    dependencies:
+      '@wdio/reporter': 9.31.2
+      '@wdio/types': 9.31.2
+      chalk: 5.6.2
+      easy-table: 1.2.0
+      pretty-ms: 9.3.1
+
+  '@wdio/tauri-plugin@1.3.0(supports-color@10.2.2)(tsx@4.21.0)':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+      '@tauri-apps/plugin-log': 2.9.0
+      '@wdio/native-spy': 1.2.0
+      '@wdio/native-utils': 2.6.0(supports-color@10.2.2)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+      - tsx
+
+  '@wdio/tauri-service@1.3.0(supports-color@10.2.2)(tsx@4.21.0)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))':
+    dependencies:
+      '@wdio/globals': 9.29.1(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/logger': 9.29.1
+      '@wdio/native-core': 1.1.0(supports-color@10.2.2)(tsx@4.21.0)
+      '@wdio/native-spy': 1.2.0
+      '@wdio/native-types': 2.5.0
+      '@wdio/native-utils': 2.6.0(supports-color@10.2.2)(tsx@4.21.0)
+      '@wdio/spec-reporter': 9.29.1
+      '@wdio/types': 9.29.1
+      debug: 4.4.3(supports-color@10.2.2)
+      get-port: 7.1.0
+      tslib: 2.8.1
+      webdriverio: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - expect-webdriverio
+      - supports-color
+      - tsx
+
+  '@wdio/types@9.29.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@wdio/types@9.31.2':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@wdio/utils@9.31.5(supports-color@10.2.2)':
+    dependencies:
+      '@puppeteer/browsers': 2.13.2(supports-color@10.2.2)
+      '@wdio/logger': 9.29.1
+      '@wdio/types': 9.31.2
+      decamelize: 6.0.1
+      deepmerge-ts: 7.1.6
+      edgedriver: 6.3.0(supports-color@10.2.2)
+      geckodriver: 6.1.1(supports-color@10.2.2)
+      get-port: 7.1.0
+      import-meta-resolve: 4.2.0
+      locate-app: 2.5.0
+      mitt: 3.0.1
+      safaridriver: 1.0.1
+      split2: 4.2.0
+      wait-port: 1.1.0(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@wdio/xvfb@9.31.2':
+    dependencies:
+      '@wdio/logger': 9.29.1
+
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
@@ -18953,6 +20435,8 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
+
+  '@zip.js/zip.js@2.8.61': {}
 
   abbrev@3.0.1: {}
 
@@ -19071,13 +20555,14 @@ snapshots:
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
 
   astring@1.9.0: {}
+
+  async-exit-hook@2.0.1: {}
 
   async-sema@3.1.1: {}
 
@@ -19150,8 +20635,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
-  basic-ftp@5.3.1:
-    optional: true
+  basic-ftp@5.3.1: {}
 
   better-ajv-errors@1.2.0(ajv@8.18.0):
     dependencies:
@@ -19266,6 +20750,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  browser-stdout@1.3.1: {}
 
   browserslist@4.28.1:
     dependencies:
@@ -19434,6 +20920,8 @@ snapshots:
       zod: 3.25.76
     optional: true
 
+  ci-info@4.4.0: {}
+
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
@@ -19454,6 +20942,8 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
 
   clipboardy@4.0.0:
@@ -19461,6 +20951,12 @@ snapshots:
       execa: 8.0.1
       is-wsl: 3.1.0
       is64bit: 2.0.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -19473,6 +20969,9 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.0
+
+  clone@1.0.4:
+    optional: true
 
   clsx@2.1.1: {}
 
@@ -19521,6 +21020,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -19528,6 +21029,8 @@ snapshots:
   commander@7.2.0: {}
 
   commander@8.3.0: {}
+
+  commander@9.5.0: {}
 
   common-path-prefix@3.0.0: {}
 
@@ -19606,6 +21109,24 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
+  create-wdio@9.31.2(@types/node@22.19.15):
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      cross-spawn: 7.0.6
+      ejs: 3.1.10
+      execa: 9.6.1
+      import-meta-resolve: 4.2.0
+      inquirer: 12.11.1(@types/node@22.19.15)
+      normalize-package-data: 7.0.1
+      read-pkg-up: 10.1.0
+      recursive-readdir: 2.2.3
+      semver: 7.8.0
+      type-fest: 4.41.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   crelt@1.0.6: {}
 
   cron-parser@4.9.0:
@@ -19639,6 +21160,8 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-shorthand-properties@1.1.2: {}
+
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
@@ -19653,6 +21176,8 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css-value@0.0.1: {}
 
   css-what@6.2.2: {}
 
@@ -19858,8 +21383,7 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-uri-to-buffer@6.0.2:
-    optional: true
+  data-uri-to-buffer@6.0.2: {}
 
   data-urls@6.0.0:
     dependencies:
@@ -19888,11 +21412,21 @@ snapshots:
     optionalDependencies:
       supports-color: 10.2.2
 
+  debug@4.4.3(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
   decache@4.6.2:
     dependencies:
       callsite: 1.0.0
 
   decamelize@1.2.0: {}
+
+  decamelize@4.0.0: {}
+
+  decamelize@6.0.1: {}
 
   decimal.js-light@2.5.1: {}
 
@@ -19906,6 +21440,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deepmerge-ts@7.1.6: {}
+
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -19914,6 +21450,11 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+    optional: true
 
   define-lazy-prop@3.0.0: {}
 
@@ -19924,7 +21465,6 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
-    optional: true
 
   delaunator@5.1.0:
     dependencies:
@@ -20012,6 +21552,8 @@ snapshots:
     optional: true
 
   didyoumean@1.2.2: {}
+
+  diff@5.2.2: {}
 
   diff@8.0.3: {}
 
@@ -20114,9 +21656,33 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  easy-table@1.2.0:
+    dependencies:
+      ansi-regex: 5.0.1
+    optionalDependencies:
+      wcwidth: 1.0.1
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  edge-paths@3.0.5:
+    dependencies:
+      '@types/which': 2.0.2
+      which: 2.0.2
+
+  edgedriver@6.3.0(supports-color@10.2.2):
+    dependencies:
+      '@wdio/logger': 9.29.1
+      '@zip.js/zip.js': 2.8.61
+      decamelize: 6.0.1
+      edge-paths: 3.0.5
+      fast-xml-parser: 5.5.9
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      which: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   ee-first@1.1.1: {}
 
@@ -20183,7 +21749,6 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
-    optional: true
 
   error-stack-parser-es@1.0.5: {}
 
@@ -20292,9 +21857,40 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
 
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -20388,7 +21984,43 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.1
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.2.0
+
+  exit-hook@4.0.0: {}
+
   expect-type@1.3.0: {}
+
+  expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)):
+    dependencies:
+      '@vitest/snapshot': 4.1.11
+      '@wdio/globals': 9.31.3(expect-webdriverio@6.0.9(@wdio/globals@9.31.3(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(@wdio/logger@9.29.1)(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)))(webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2))
+      '@wdio/logger': 9.29.1
+      deep-eql: 5.0.2
+      expect: 30.5.0
+      jest-matcher-utils: 30.5.0
+      webdriverio: 9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2)
+
+  expect@30.5.0:
+    dependencies:
+      '@jest/expect-utils': 30.5.0
+      '@jest/get-type': 30.5.0
+      jest-matcher-utils: 30.5.0
+      jest-message-util: 30.5.0
+      jest-mock: 30.5.0
+      jest-util: 30.5.0
 
   exsolve@1.0.8: {}
 
@@ -20493,6 +22125,11 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-up@6.3.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+
   find-up@7.0.0:
     dependencies:
       locate-path: 7.2.0
@@ -20542,6 +22179,8 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -20710,6 +22349,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  geckodriver@6.1.1(supports-color@10.2.2):
+    dependencies:
+      '@wdio/logger': 9.29.1
+      '@zip.js/zip.js': 2.8.61
+      decamelize: 6.0.1
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      modern-tar: 0.7.7
+    transitivePeerDependencies:
+      - supports-color
+
   gensync@1.0.0-beta.2: {}
 
   genversion@3.2.0:
@@ -20739,6 +22389,11 @@ snapshots:
 
   get-stream@8.0.1: {}
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -20750,7 +22405,6 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   giget@2.0.0:
     dependencies:
@@ -20776,7 +22430,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 10.2.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -20791,6 +22445,14 @@ snapshots:
       minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 10.2.4
+      once: 1.4.0
 
   globby@11.1.0:
     dependencies:
@@ -20823,6 +22485,8 @@ snapshots:
   google-logging-utils@1.1.3: {}
 
   graceful-fs@4.2.11: {}
+
+  grapheme-splitter@1.0.4: {}
 
   gzip-size@7.0.0:
     dependencies:
@@ -20978,6 +22642,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   hono@4.12.18: {}
 
   hookable@5.5.3: {}
@@ -20987,6 +22653,10 @@ snapshots:
   hookified@2.1.0: {}
 
   hosted-git-info@7.0.2:
+    dependencies:
+      lru-cache: 10.4.3
+
+  hosted-git-info@8.1.0:
     dependencies:
       lru-cache: 10.4.3
 
@@ -21003,6 +22673,8 @@ snapshots:
   html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
+
+  htmlfy@0.8.1: {}
 
   htmlparser2@10.0.0:
     dependencies:
@@ -21047,6 +22719,8 @@ snapshots:
   human-id@4.1.3: {}
 
   human-signals@5.0.0: {}
+
+  human-signals@8.0.1: {}
 
   i18next-browser-languagedetector@8.2.1:
     dependencies:
@@ -21130,6 +22804,11 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
@@ -21138,6 +22817,18 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+
+  inquirer@12.11.1(@types/node@22.19.15):
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      mute-stream: 2.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.19.15
 
   internmap@1.0.1: {}
 
@@ -21162,8 +22853,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.2.0:
-    optional: true
+  ip-address@10.2.0: {}
 
   ipx@3.1.1(@netlify/blobs@10.7.4(supports-color@10.2.2))(db0@0.3.4(@electric-sql/pglite@0.3.16)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(kysely@0.28.14)(pg@8.20.0)))(ioredis@5.10.1(supports-color@10.2.2)):
     dependencies:
@@ -21213,8 +22903,7 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  is-arrayish@0.2.1:
-    optional: true
+  is-arrayish@0.2.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -21274,6 +22963,8 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-unicode-supported@0.1.0: {}
+
   is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
@@ -21298,6 +22989,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -21309,6 +23002,51 @@ snapshots:
       async: 3.2.6
       filelist: 1.0.4
       picocolors: 1.1.1
+
+  jest-diff@30.5.0:
+    dependencies:
+      '@jest/diff-sequences': 30.5.0
+      '@jest/get-type': 30.5.0
+      chalk: 4.1.2
+      pretty-format: 30.5.0
+
+  jest-matcher-utils@30.5.0:
+    dependencies:
+      '@jest/get-type': 30.5.0
+      chalk: 4.1.2
+      jest-diff: 30.5.0
+      pretty-format: 30.5.0
+
+  jest-message-util@30.5.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@jest/types': 30.5.0
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-util: 30.5.0
+      picomatch: 4.0.4
+      pretty-format: 30.5.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@30.5.0:
+    dependencies:
+      '@jest/expect-utils': 30.5.0
+      '@jest/types': 30.5.0
+      '@types/node': 22.19.15
+      jest-util: 30.5.0
+
+  jest-regex-util@30.5.0: {}
+
+  jest-util@30.5.0:
+    dependencies:
+      '@jest/types': 30.5.0
+      '@types/node': 22.19.15
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.4
 
   jiti@1.21.7: {}
 
@@ -21402,6 +23140,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1:
     optional: true
 
+  json-parse-even-better-errors@3.0.2: {}
+
   json-pointer@0.6.2:
     dependencies:
       foreach: 2.0.6
@@ -21481,12 +23221,12 @@ snapshots:
       dotenv: 16.6.1
       winston: 3.19.0
 
-  langchain@1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  langchain@1.2.37(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
-      '@langchain/langgraph': 1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.3.6)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)))
-      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6))
+      '@langchain/core': 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
+      '@langchain/langgraph': 1.2.6(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)))
+      langsmith: 0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6))
       uuid: 11.1.0
       zod: 4.3.6
     transitivePeerDependencies:
@@ -21500,7 +23240,7 @@ snapshots:
       - vue
       - zod-to-json-schema
 
-  langsmith@0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.20.1)(zod@4.3.6)):
+  langsmith@0.5.7(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.27.0(ws@8.21.3)(zod@4.3.6)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 5.6.2
@@ -21512,7 +23252,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      openai: 6.27.0(ws@8.20.1)(zod@4.3.6)
+      openai: 6.27.0(ws@8.21.3)(zod@4.3.6)
 
   layout-base@1.0.2: {}
 
@@ -21624,6 +23364,8 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lines-and-columns@2.0.4: {}
+
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
@@ -21657,6 +23399,12 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
+  locate-app@2.5.0:
+    dependencies:
+      '@promptbook/utils': 0.69.5
+      type-fest: 4.26.0
+      userhome: 1.0.1
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -21673,7 +23421,11 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.clonedeep@4.5.0: {}
+
   lodash.defaults@4.2.0: {}
+
+  lodash.flattendeep@4.4.0: {}
 
   lodash.includes@4.3.0: {}
 
@@ -21691,13 +23443,24 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash.pickby@4.6.0: {}
+
   lodash.snakecase@4.1.1: {}
 
   lodash.startcase@4.4.0: {}
 
+  lodash.union@4.6.0: {}
+
+  lodash.zip@4.2.0: {}
+
   lodash@4.17.23: {}
 
   lodash@4.18.1: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
 
   log-symbols@6.0.0:
     dependencies:
@@ -21725,6 +23488,10 @@ snapshots:
       '@loglayer/shared': 2.5.3
       '@loglayer/transport': 2.3.4
 
+  loglevel-plugin-prefix@0.8.4: {}
+
+  loglevel@1.9.2: {}
+
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
@@ -21745,8 +23512,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lru-cache@7.18.3:
-    optional: true
+  lru-cache@7.18.3: {}
 
   lucide-react@0.468.0(react@19.2.0):
     dependencies:
@@ -22299,10 +24065,9 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
-  mitt@3.0.1:
-    optional: true
+  mitt@3.0.1: {}
 
   mkdirp@0.5.6:
     dependencies:
@@ -22321,6 +24086,31 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  mocha@10.8.2:
+    dependencies:
+      ansi-colors: 4.1.3
+      browser-stdout: 1.3.1
+      chokidar: 3.6.0
+      debug: 4.4.3(supports-color@8.1.1)
+      diff: 5.2.2
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 8.1.0
+      he: 1.2.0
+      js-yaml: 4.1.1
+      log-symbols: 4.1.0
+      minimatch: 10.2.4
+      ms: 2.1.3
+      serialize-javascript: 7.0.4
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 6.5.1
+      yargs: 16.2.2
+      yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
+
+  modern-tar@0.7.7: {}
 
   module-definition@6.0.1:
     dependencies:
@@ -22367,6 +24157,8 @@ snapshots:
 
   mustache@4.2.0: {}
 
+  mute-stream@2.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -22383,8 +24175,7 @@ snapshots:
 
   netlify-redirector@0.5.0: {}
 
-  netmask@2.1.1:
-    optional: true
+  netmask@2.1.1: {}
 
   neverthrow@8.2.0:
     optionalDependencies:
@@ -22571,6 +24362,12 @@ snapshots:
       semver: 7.8.0
       validate-npm-package-license: 3.0.4
 
+  normalize-package-data@7.0.1:
+    dependencies:
+      hosted-git-info: 8.1.0
+      semver: 7.8.0
+      validate-npm-package-license: 3.0.4
+
   normalize-path@2.1.1:
     dependencies:
       remove-trailing-separator: 1.1.0
@@ -22580,6 +24377,11 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   npm-to-yarn@3.0.1: {}
 
@@ -22598,6 +24400,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  object-inspect@1.13.4: {}
 
   ofetch@1.5.1:
     dependencies:
@@ -22646,9 +24450,9 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.27.0(ws@8.20.1)(zod@4.3.6):
+  openai@6.27.0(ws@8.21.3)(zod@4.3.6):
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.3
       zod: 4.3.6
 
   openapi-sampler@1.7.2:
@@ -22805,13 +24609,11 @@ snapshots:
       socks-proxy-agent: 8.0.5(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   pac-resolver@7.0.1:
     dependencies:
       degenerator: 5.0.1
       netmask: 2.1.1
-    optional: true
 
   package-json-from-dist@1.0.1: {}
 
@@ -22857,11 +24659,21 @@ snapshots:
       lines-and-columns: 1.2.4
     optional: true
 
+  parse-json@7.1.1:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 3.0.2
+      lines-and-columns: 2.0.4
+      type-fest: 3.13.1
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.0
       index-to-position: 1.2.0
       type-fest: 4.41.0
+
+  parse-ms@4.0.0: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -22901,12 +24713,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.1:
     dependencies:
       lru-cache: 11.2.7
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -22941,8 +24753,6 @@ snapshots:
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
-
-  pg-protocol@1.10.3: {}
 
   pg-protocol@1.13.0: {}
 
@@ -23102,6 +24912,17 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@30.5.0:
+    dependencies:
+      '@jest/react-is-18': react-is@18.3.1
+      '@jest/react-is-19': react-is@19.2.8
+      '@jest/schemas': 30.5.0
+      ansi-styles: 5.2.0
+
+  pretty-ms@9.3.1:
+    dependencies:
+      parse-ms: 4.0.0
+
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
@@ -23256,7 +25077,6 @@ snapshots:
       socks-proxy-agent: 8.0.5(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   proxy-from-env@1.1.0: {}
 
@@ -23277,7 +25097,7 @@ snapshots:
       devtools-protocol: 0.0.1608973
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.20.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -23312,6 +25132,8 @@ snapshots:
   quansync@0.2.11: {}
 
   quansync@1.0.0: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -23370,6 +25192,8 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-is@19.2.8: {}
 
   react-medium-image-zoom@5.4.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -23449,6 +25273,19 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.1
       read-pkg: 9.0.1
+      type-fest: 4.41.0
+
+  read-pkg-up@10.1.0:
+    dependencies:
+      find-up: 6.3.0
+      read-pkg: 8.1.0
+      type-fest: 4.41.0
+
+  read-pkg@8.1.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 6.0.2
+      parse-json: 7.1.1
       type-fest: 4.41.0
 
   read-pkg@9.0.1:
@@ -23555,6 +25392,10 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  recursive-readdir@2.2.3:
+    dependencies:
+      minimatch: 10.2.4
 
   redis-errors@1.2.0: {}
 
@@ -23680,14 +25521,22 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  resq@1.11.0:
+    dependencies:
+      fast-deep-equal: 2.0.1
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  ret@0.5.0: {}
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rgb2hex@0.2.5: {}
 
   rimraf@6.1.3:
     dependencies:
@@ -23791,6 +25640,8 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-async@4.0.6: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -23801,9 +25652,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safaridriver@1.0.1: {}
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
 
@@ -23961,10 +25818,11 @@ snapshots:
 
   slashes@3.0.12: {}
 
-  smart-buffer@4.2.0:
-    optional: true
+  smart-buffer@4.2.0: {}
 
   smob@1.5.0: {}
+
+  smol-toml@1.8.0: {}
 
   socks-proxy-agent@8.0.5(supports-color@10.2.2):
     dependencies:
@@ -23973,13 +25831,11 @@ snapshots:
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   socks@2.8.9:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
-    optional: true
 
   solid-js@1.9.10:
     dependencies:
@@ -24004,6 +25860,8 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spacetrim@0.11.59: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -24036,6 +25894,10 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
@@ -24047,6 +25909,8 @@ snapshots:
   std-env@4.0.0: {}
 
   stdin-discarder@0.2.2: {}
+
+  stream-buffers@3.0.3: {}
 
   streamx@2.25.0:
     dependencies:
@@ -24099,6 +25963,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-final-newline@3.0.0: {}
+
+  strip-final-newline@4.0.0: {}
+
+  strip-json-comments@3.1.1: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -24216,7 +26084,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-    optional: true
 
   tar-stream@3.1.7:
     dependencies:
@@ -24231,7 +26098,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -24305,6 +26172,8 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -24426,6 +26295,10 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  type-fest@3.13.1: {}
+
+  type-fest@4.26.0: {}
+
   type-fest@4.41.0: {}
 
   type-fest@5.5.0:
@@ -24478,6 +26351,8 @@ snapshots:
 
   undici@6.24.1: {}
 
+  undici@6.28.0: {}
+
   undici@7.23.0: {}
 
   undici@7.25.0: {}
@@ -24487,6 +26362,8 @@ snapshots:
       pathe: 2.0.3
 
   unicorn-magic@0.1.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unicorn-magic@0.4.0: {}
 
@@ -24672,6 +26549,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  userhome@1.0.1: {}
 
   util-deprecate@1.0.2: {}
 
@@ -24947,6 +26826,19 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  wait-port@1.1.0(supports-color@10.2.2):
+    dependencies:
+      chalk: 4.1.2
+      commander: 9.5.0
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+    optional: true
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
@@ -24955,6 +26847,64 @@ snapshots:
 
   webdriver-bidi-protocol@0.4.1:
     optional: true
+
+  webdriver@9.31.5(supports-color@10.2.2):
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/ws': 8.18.1
+      '@wdio/config': 9.31.5(supports-color@10.2.2)
+      '@wdio/logger': 9.29.1
+      '@wdio/protocols': 9.31.5
+      '@wdio/types': 9.31.2
+      '@wdio/utils': 9.31.5(supports-color@10.2.2)
+      deepmerge-ts: 7.1.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      undici: 6.28.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  webdriverio@9.31.5(puppeteer-core@24.43.1(supports-color@10.2.2))(supports-color@10.2.2):
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/sinonjs__fake-timers': 8.1.5
+      '@wdio/config': 9.31.5(supports-color@10.2.2)
+      '@wdio/logger': 9.29.1
+      '@wdio/protocols': 9.31.5
+      '@wdio/repl': 9.16.2
+      '@wdio/types': 9.31.2
+      '@wdio/utils': 9.31.5(supports-color@10.2.2)
+      archiver: 7.0.1
+      aria-query: 5.3.0
+      cheerio: 1.1.2
+      css-shorthand-properties: 1.1.2
+      css-value: 0.0.1
+      grapheme-splitter: 1.0.4
+      htmlfy: 0.8.1
+      is-plain-obj: 4.1.0
+      jszip: 3.10.1
+      lodash.clonedeep: 4.5.0
+      lodash.zip: 4.2.0
+      query-selector-shadow-dom: 1.0.1
+      resq: 1.11.0
+      rgb2hex: 0.2.5
+      serialize-error: 12.0.0
+      urlpattern-polyfill: 10.1.0
+      webdriver: 9.31.5(supports-color@10.2.2)
+    optionalDependencies:
+      puppeteer-core: 24.43.1(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   webidl-conversions@3.0.1: {}
 
@@ -24994,6 +26944,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -25023,6 +26977,14 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  workerpool@6.5.1: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -25050,8 +27012,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  ws@8.20.1:
-    optional: true
+  ws@8.21.3: {}
 
   wsl-utils@0.3.1:
     dependencies:
@@ -25092,9 +27053,28 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:
@@ -25136,6 +27116,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yoctocolors-cjs@2.1.3: {}
+
+  yoctocolors@2.2.0: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,8 @@ allowBuilds:
   puppeteer: true
   sharp: true
   better-sqlite3: false
+  edgedriver: true
+  geckodriver: false
 
 autoInstallPeers: false
 dedupePeerDependents: true


### PR DESCRIPTION
Builds on #694.

## Summary

DMM needs native end-to-end coverage that exercises the shipped React UI, Tauri IPC, and Rust file-management code without reading or modifying the developer's real Steam, Deadlock, application-data, cache, log, or WebView directories. This PR adds the first Windows/Wry harness milestone: every run creates an owned disposable world, injects validated loopback services and integration policies, launches the compiled application through WDIO's embedded Tauri provider, records observable side effects, and removes the world only after a passing run.

The required provider is `@wdio/tauri-service`'s embedded server. The external `tauri-driver` path remains optional because elevated apps on current WebView2 runtimes are affected by webdriverio/desktop-mobile#542.

## 1. Compile-gated runtime isolation

The `e2e-harness` Cargo feature requires `DMM_E2E_CONFIG`; production builds reject the same variable. The configuration must use a unique E2E application identity, define every service exactly once at a loopback origin, and place every managed root and control file beneath the owned world.

E2E startup redirects state, GameBanana catalog, policy manifest, logs, WebView data, temporary files, Steam discovery, and the game installation. Host-facing integrations are disabled or replaced with explicit policies: launches write intent records, presence/ingestion/match sync are disabled, updater access is disabled or fixture-backed, and host `.env`, machine ID, deep-link, MCP, and single-instance behavior are not loaded.

```text
production build + DMM_E2E_CONFIG  -> reject startup
E2E build without DMM_E2E_CONFIG   -> reject startup
E2E build with an escaped root      -> reject startup
validated owned E2E world           -> start real UI + real Rust IPC
```

## 2. Deterministic worlds and inspection

Each run creates a manifest-owned directory under `.e2e/worlds` with synthetic Steam/Deadlock layouts and deterministic VPK v2 fixture generation. The harness streams SHA-256 inventories for every configured root, journals live filesystem changes, records game-launch intent, and retains failed worlds with an expiry marker. Cleanup verifies ownership before recursive deletion and terminates the complete Windows process tree on failure, signal, or timeout.

The loopback fixture server supplies every application service origin. Registered requests receive deterministic responses; unmatched requests, absolute-form proxy requests, and HTTPS `CONNECT` attempts are journaled and fail the run. Credential-like query parameters and headers are redacted before artifacts are written.

## 3. Real application automation

The WDIO smoke starts the compiled Tauri executable in a fresh world, clicks through Settings to About, invokes the compile-gated `e2e_status` Rust command, verifies isolated persisted state, prepares a real Steam launch request, and confirms that launch/liveness/stop operations cannot touch a host game.

`e2e:doctor` checks the interactive Windows session, WebView2 runtime, embedded service, pnpm/Cargo, process-tree cleanup support, E2E binary feature marker, `.e2e` write/delete access, and an ephemeral `127.0.0.1` bind before a run begins.

## Callstack

The frontend now waits for the Rust runtime bootstrap before loading persisted state or initializing service clients. Calldiff for the new entrypoint:

```diff
+ initializeApplication()
+ └─ bootstrapApplication()
+    ├─ initializeRuntimeBootstrap()
+    │  └─ getRuntimeBootstrap()
+    │     ├─ then()
+    │     └─ invoke()
+    ├─ setStateStorePath(path)
+    ├─ load()
+    ├─ rehydrate()
+    ├─ storageReady()
+    ├─ initializeApiUrl(apiUrl)
+    ├─ getRuntimeServiceOrigin(bootstrap, service)
+    ├─ syncProxyConfigToBackend()
+    ├─ downloadManager.init()
+    └─ logger.debug()
```

## Test plan

- `pnpm --filter @deadlock-mods/desktop e2e:test:world`: 8 tests and 31 assertions passed for owned worlds, inventories, network blocking/redaction, and deterministic VPKs (§2).
- `pnpm --filter @deadlock-mods/desktop e2e:check-types` and `check-types`: passed (§1–§3).
- `cargo check` and `cargo check --features e2e-harness`: passed (§1).
- `cargo test runtime_environment --lib --features e2e-harness`: 6 isolation/validation tests passed (§1).
- `pnpm --filter @deadlock-mods/desktop e2e:build` and `e2e:doctor`: passed all prerequisite checks (§1, §3).
- Embedded `e2e:test`: passed a fresh real-process UI/Rust run in 12.2 seconds (§3).
- Embedded qualification: 10/10 retry-free fresh runs passed in 10.6–14.7 seconds (11.6-second average), followed by a passing intentional-timeout teardown (§2, §3).
- Pre-commit `oxfmt`, `oxlint --fix`, and Cargo Clippy completed with no errors. Existing repository warnings remain.
- The full Rust suite reached 348/350; `drop_rolls_back_uncommitted_staging` and `rollback_restores_files_that_swapped_slots` also fail on the #694 base and are not changed by this harness.

AI Assistance: Used Codex for harness research, implementation, review, and test execution.
