### PR TITLE
test(desktop): cover profile switching and native mod ordering

### DIFF
--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -24,6 +24,19 @@ The first process imports a synthetic VPK, verifies the real Rust parser, then e
 
 Retained worlds contain `wdio-<phase>.log`, `native-picker.log`, per-step `lifecycle-*.json` evidence, and screenshots plus DOM HTML on failure. Without `--keep`, successful worlds and their artifacts are deleted.
 
+Profile ordering has separate pointer and keyboard scenarios, each with two preinstalled profile recipes and a fresh-process restart:
+
+```powershell
+pnpm --filter @deadlock-mods/desktop e2e:build:picker
+pnpm --filter @deadlock-mods/desktop e2e:doctor -- --case profiles-pointer
+pnpm --filter @deadlock-mods/desktop e2e:test -- --case profiles-pointer --keep
+pnpm --filter @deadlock-mods/desktop e2e:test -- --case profiles-keyboard --keep
+```
+
+Each scenario moves Alpha's first mod to last through the ordering dialog, saves through the real Rust command, switches to Beta, restarts with Beta active, and switches back to Alpha. The oracle checks persisted profile and library state, manifest slots, exact file inventories, distinct VPK payload hashes, protected files, and active game search paths. Beta remains byte-identical to its initial fixture; Alpha remains byte-identical after its reorder while switching and restarting. Artifacts include `profiles-*.json` checkpoints and `native-input.log`.
+
+The pinned embedded driver's Windows pointer implementation dispatches mouse events, which do not activate Radix's pointer menu or dnd-kit's pointer sensor. These scenarios use the existing FlaUI helper for native clicks and dragging, and scan-code keyboard input for Space/Down/Down/Space. WebDriver focuses the keyboard handle and verifies DOM state. No core IPC response or application state is substituted. The helper validates the owned world, executable and PID, converts viewport coordinates with per-monitor DPI awareness, and requires the owned window to have focus before sending input. Run native scenarios serially on an interactive Windows desktop; they bring the test window to the foreground.
+
 Successful worlds are deleted after their artifacts and filesystem inventories are written. Failed worlds are retained and printed by the CLI. `--keep` retains a successful single run for inspection. Cleanup only operates on directories beneath `.e2e/worlds` whose manifest identifies the harness as owner. Each run records live changes in `artifacts/filesystem.ndjson` and writes complete before/after SHA-256 inventories for every managed root. Restoring a test means deleting its disposable world; a test never edits the developer's real installation.
 
 The fixture server records all requests to `artifacts/network.ndjson`, returns a hard failure for any unregistered fixture, and is also installed as the child process HTTP(S) proxy. Absolute-form HTTP proxy requests and HTTPS `CONNECT` tunnels are blocked, recorded, and fail the run. Every application service origin is injected as a loopback fixture URL, and the E2E-only Tauri HTTP capability allows only those validated origins. A passing run therefore has a deterministic response for every observed request and no production-service traffic.
@@ -33,6 +46,8 @@ The fixture server records all requests to `artifacts/network.ndjson`, returns a
 The first smoke flow uses WebDriver clicks to open Settings and the About dialog, then invokes the compile-gated `e2e_status` command to prove the UI process is connected to the real Rust backend and isolated world. It also prepares a real Steam launch request through Rust, verifies that the `record` policy writes the redacted intent to `artifacts/game-launches.ndjson`, and proves that game liveness/stop operations cannot inspect or terminate a host game in the default E2E world.
 
 ## Qualification status
+
+The profile pointer and keyboard scenarios each passed three consecutive retry-free Windows/Wry worlds, with two application processes per world. These six runs took 32.6–36.6 seconds and had no unmatched fixture requests.
 
 The local-mod lifecycle passed 10 consecutive retry-free Windows/Wry runs in 24.5–27.2 seconds per world, with two application processes per run. A final verification after adding bounded inventory retries for transient Windows file locks passed both the lifecycle and the intentional-timeout cleanup probe. The inventory still fails if a file remains locked; it never skips a locked file.
 
@@ -50,7 +65,7 @@ Native Windows dialogs are outside the webview DOM and cannot be driven by WebDr
 | --- | --- | --- | --- |
 | M1: safe harness foundation | Complete in PR #707 (replaces #706) | Compile-gated runtime configuration, owned worlds, root routing, fixture network, filesystem oracle, synthetic VPK builder, supervisor, doctor, and embedded-driver qualification | Ten retry-free fresh UI/IPC runs pass; intentional timeout cleanup succeeds; production cannot activate E2E mode |
 | M2: complete local-mod lifecycle | Implemented and validated on Windows/Wry | Drive a synthetic VPK through a narrowly scoped FlaUI native-picker helper, the real Rust parser, import/install, enable/disable, delete, and application restart | UI state, VPK manifest, persisted store, and independent file hashes agree after every step; the final world matches its expected restored state |
-| M3: profiles and ordering | Planned | Two-profile switching plus pointer and keyboard reorder flows | Inactive profiles and protected files remain unchanged; order and profile state survive restart without mocked core IPC |
+| M3: profiles and ordering | Implemented and validated on Windows/Wry | Two-profile switching plus native pointer and keyboard reorder flows | Inactive profiles and protected files remain unchanged; order and profile state survive restart without mocked core IPC |
 | M4: downloads and network failures | Planned; transport foundation exists | Exercise actual Rust downloads against fixture endpoints, including variants, Range resume, pause, cancel, malformed responses, and authentication failures | Every request matches the strict journal; unexpected traffic fails; partial files and state recover correctly |
 | M5: recovery and hostile filesystem cases | Planned | Backup replace/merge, interrupted mutations, shard boundaries, collisions, Windows locks, and crash barriers | Restart recovers retained worlds and the independent oracle proves restoration without normalizing unexpected writes |
 | M6: CI and release coverage | Planned | Serial Windows PR lane, broader nightly matrix, packaged-app/native smoke, and ordinary-release exclusion checks | Clean runners reproduce required flows and ordinary builds contain no harness server, capability, control channel, or fixture policy |

--- a/apps/desktop/e2e/cli.ts
+++ b/apps/desktop/e2e/cli.ts
@@ -136,7 +136,7 @@ const doctor = async (): Promise<void> => {
   const binaryPath = valueAfter("--binary") ?? defaultBinaryPath;
   const selectedProvider = provider();
   const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
-  if (parseScenarioId(valueAfter("--case")) === "local-mod-lifecycle") {
+  if (parseScenarioId(valueAfter("--case")) !== "about-smoke") {
     let pickerExists = true;
     try {
       await access(nativePickerBinary);
@@ -144,7 +144,7 @@ const doctor = async (): Promise<void> => {
       pickerExists = false;
     }
     checks.push({
-      name: "native picker",
+      name: "native input helper",
       ok: pickerExists,
       detail: pickerExists
         ? nativePickerBinary

--- a/apps/desktop/e2e/native/Picker/NativeInput.cs
+++ b/apps/desktop/e2e/native/Picker/NativeInput.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using FlaUI.Core.Input;
+using FlaUI.UIA3;
+
+internal static class NativeInput
+{
+    private sealed record Request(string Action, double X, double Y, double EndX, double EndY, double Width, double Height);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Rect { public int Left, Top, Right, Bottom; }
+    [DllImport("user32.dll")] private static extern bool GetClientRect(nint window, out Rect rectangle);
+    [DllImport("user32.dll")] private static extern bool ClientToScreen(nint window, ref Point point);
+    [DllImport("user32.dll")] private static extern bool SetForegroundWindow(nint window);
+    [DllImport("user32.dll")] private static extern nint GetForegroundWindow();
+    [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(nint window, out uint processId);
+    [DllImport("kernel32.dll")] private static extern uint GetCurrentThreadId();
+    [DllImport("user32.dll")] private static extern bool AttachThreadInput(uint source, uint target, bool attach);
+    [DllImport("user32.dll")] private static extern nint SetThreadDpiAwarenessContext(nint context);
+
+    public static void Run(Process process, string json)
+    {
+        // PER_MONITOR_AWARE_V2 keeps Win32 coordinates in the physical pixels FlaUI uses.
+        SetThreadDpiAwarenessContext(new nint(-4));
+        var request = JsonSerializer.Deserialize<Request>(json) ?? throw new ArgumentException("Missing input request");
+        if (request.Action is not ("click" or "drag" or "keyboard-reorder")) throw new ArgumentException("Unsupported input action");
+        var window = process.MainWindowHandle;
+        if (window == 0 || !GetClientRect(window, out var rect)) throw new InvalidOperationException("Owned window unavailable");
+        if (!(request.Width > 0 && request.Height > 0)) throw new ArgumentException("Invalid viewport dimensions");
+        var origin = new Point(0, 0);
+        if (!ClientToScreen(window, ref origin)) throw new InvalidOperationException("Cannot locate owned viewport");
+        Point Position(double x, double y)
+        {
+            if (!(x >= 0 && x < request.Width && y >= 0 && y < request.Height)) throw new ArgumentException("Input must stay inside owned viewport");
+            return new Point(origin.X + (int)Math.Round(x * rect.Right / request.Width), origin.Y + (int)Math.Round(y * rect.Bottom / request.Height));
+        }
+        var start = Position(request.X, request.Y);
+        var end = Position(request.EndX, request.EndY);
+        using var automation = new UIA3Automation();
+        var element = automation.FromHandle(window);
+        var foregroundThread = GetWindowThreadProcessId(GetForegroundWindow(), out _);
+        var currentThread = GetCurrentThreadId();
+        var attached = AttachThreadInput(currentThread, foregroundThread, true);
+        try
+        {
+            if (GetForegroundWindow() != window)
+            {
+                element.SetForeground();
+                element.FocusNative();
+                SetForegroundWindow(window);
+            }
+        }
+        finally { if (attached) AttachThreadInput(currentThread, foregroundThread, false); }
+        Thread.Sleep(100);
+        if (GetForegroundWindow() != window) throw new InvalidOperationException($"Owned E2E window must have focus: expected {window}, actual {GetForegroundWindow()}, title {process.MainWindowTitle}");
+        Mouse.MoveTo(start);
+        if (request.Action == "drag")
+        {
+            Mouse.Down(MouseButton.Left);
+            try
+            {
+                Thread.Sleep(100);
+                Mouse.MoveTo(end);
+                Thread.Sleep(200);
+            }
+            finally { Mouse.Up(MouseButton.Left); }
+        }
+        else if (request.Action == "click") Mouse.Click(MouseButton.Left);
+        else
+        {
+            // Scan codes preserve KeyboardEvent.code, which dnd-kit's keyboard sensor requires.
+            foreach (var scanCode in new ushort[] { 0x39, 0x50, 0x50, 0x39 })
+            {
+                if (GetForegroundWindow() != window) throw new InvalidOperationException("Owned window lost focus during keyboard input");
+                Keyboard.TypeScanCode(scanCode, scanCode == 0x50);
+                Thread.Sleep(150);
+            }
+        }
+        Console.WriteLine(JsonSerializer.Serialize(new { processId = process.Id, request.Action, start, end }));
+    }
+}

--- a/apps/desktop/e2e/native/Picker/Program.cs
+++ b/apps/desktop/e2e/native/Picker/Program.cs
@@ -4,7 +4,7 @@ using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Definitions;
 using FlaUI.UIA3;
 
-if (args.Length != 2 || !int.TryParse(args[0], out var processId))
+if (args.Length is not (2 or 3) || !int.TryParse(args[0], out var processId))
     throw new ArgumentException("Expected application PID and owned world directory");
 
 var world = Path.GetFullPath(args[1]);
@@ -16,6 +16,12 @@ if (manifest.RootElement.GetProperty("owner").GetString() != "dmm-e2e-harness" |
 using var process = Process.GetProcessById(processId);
 if (!string.Equals(process.MainModule?.FileName, Environment.GetEnvironmentVariable("DMM_E2E_BINARY"), StringComparison.OrdinalIgnoreCase))
     throw new InvalidOperationException("Picker PID does not match the harness binary");
+
+if (args.Length == 3)
+{
+    NativeInput.Run(process, args[2]);
+    return;
+}
 
 var fixture = Path.Combine(world, "fixtures", "e2e-local-mod.vpk");
 if (!File.Exists(fixture)) throw new FileNotFoundException("Lifecycle fixture is missing", fixture);

--- a/apps/desktop/e2e/specs/profiles-ordering.e2e.ts
+++ b/apps/desktop/e2e/specs/profiles-ordering.e2e.ts
@@ -1,0 +1,134 @@
+import { $, $$, browser, expect } from "@wdio/globals";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { nativeInput } from "../support/native-input";
+import {
+  ALPHA,
+  ALPHA_MODS,
+  BETA,
+  BETA_MODS,
+} from "../support/profile-fixtures";
+import {
+  assertProfilesDisk,
+  readProfileState,
+} from "../support/profile-oracle";
+
+const reordered = [ALPHA_MODS[1], ALPHA_MODS[2], ALPHA_MODS[0]];
+const openOrdering = async (): Promise<void> => {
+  const menu = await $("button=Add Local Mod").$(
+    './following-sibling::button[@aria-haspopup="menu"]',
+  );
+  await menu.waitForClickable();
+  await nativeInput("click", menu);
+  await expect(menu).toHaveAttribute("aria-expanded", "true");
+  await $(
+    '//*[@role="menuitem" and normalize-space()="Change Mods Order"]',
+  ).click();
+  await $('[aria-roledescription="sortable"]').waitForDisplayed();
+};
+const assertOrder = async (order: string[]): Promise<void> => {
+  const names = await $('[role="dialog"]')
+    .$$("p.font-medium")
+    .map((element) => element.getText());
+  expect(names).toEqual(order);
+};
+const switchProfile = async (
+  world: string,
+  profile: typeof ALPHA,
+): Promise<void> => {
+  await $('button[aria-label="Active Profile"]').click();
+  const control = await $(
+    `[role="switch"][aria-label="Activate ${profile.name} profile"]`,
+  );
+  await control.waitForClickable();
+  await control.click();
+  await browser.waitUntil(
+    async () => (await readProfileState(world)).activeProfileId === profile.id,
+  );
+  await expect(control).toHaveAttribute("aria-checked", "true");
+  await browser.keys("Escape");
+  await expect($('button[aria-label="Active Profile"]')).toHaveText(
+    expect.stringContaining(profile.name),
+  );
+  for (const modId of profile.id === ALPHA.id ? ALPHA_MODS : BETA_MODS)
+    await expect($(`[title="${modId}"]`)).toBeDisplayed();
+  for (const modId of profile.id === ALPHA.id ? BETA_MODS : ALPHA_MODS)
+    await expect($(`[title="${modId}"]`)).not.toExist();
+};
+
+describe("profile ordering", () => {
+  it("persists native ordering and isolates profiles across process restart", async () => {
+    const dismiss = await $("button=Got it!");
+    if (await dismiss.isDisplayed()) await dismiss.click();
+    const runtime = await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<{
+        processId: number;
+        roots: { world: string };
+      }>("e2e_status"),
+    );
+    const world = runtime.roots.world;
+    await $('a[href="/my-mods"]').click();
+    const checkpointPath = path.join(
+      world,
+      "artifacts",
+      "profiles-checkpoint.json",
+    );
+    if (process.env.DMM_E2E_PHASE === "reorder-switch") {
+      await assertProfilesDisk(world, "initial-state", ALPHA.id, ALPHA_MODS);
+      await openOrdering();
+      await assertOrder(ALPHA_MODS);
+      const handles = await $$('[aria-roledescription="sortable"]');
+      if (process.env.DMM_E2E_CASE_ID === "profiles-pointer") {
+        await nativeInput("drag", handles[0], handles[2]);
+      } else {
+        await handles[0].click();
+        await expect(handles[0]).toBeFocused();
+        await nativeInput("keyboard-reorder", handles[0]);
+      }
+      await assertOrder(reordered);
+      await $('[role="dialog"]').$("button=Save").click();
+      await browser.waitUntil(
+        async () =>
+          (await readProfileState(world)).localMods.find(
+            (mod) => mod.remoteId === ALPHA_MODS[0],
+          )?.installOrder === 2,
+      );
+      const alpha = await assertProfilesDisk(
+        world,
+        "reordered",
+        ALPHA.id,
+        reordered,
+      );
+      await switchProfile(world, BETA);
+      expect(
+        await assertProfilesDisk(world, "switched-beta", BETA.id, reordered),
+      ).toEqual(alpha);
+      await writeFile(
+        checkpointPath,
+        JSON.stringify({ processId: runtime.processId, alpha }),
+      );
+    } else if (process.env.DMM_E2E_PHASE === "restart-profiles") {
+      const checkpoint = z
+        .object({
+          processId: z.number(),
+          alpha: z.record(z.string(), z.string()),
+        })
+        .parse(JSON.parse(await readFile(checkpointPath, "utf8")));
+      expect(runtime.processId).not.toBe(checkpoint.processId);
+      expect(
+        await assertProfilesDisk(world, "restarted-beta", BETA.id, reordered),
+      ).toEqual(checkpoint.alpha);
+      await openOrdering();
+      await assertOrder(BETA_MODS);
+      await browser.keys("Escape");
+      await switchProfile(world, ALPHA);
+      expect(
+        await assertProfilesDisk(world, "restored-alpha", ALPHA.id, reordered),
+      ).toEqual(checkpoint.alpha);
+      await openOrdering();
+      await assertOrder(reordered);
+      await browser.keys("Escape");
+    } else throw new Error("Unknown profile phase");
+  });
+});

--- a/apps/desktop/e2e/support/native-input.ts
+++ b/apps/desktop/e2e/support/native-input.ts
@@ -1,0 +1,62 @@
+import { browser } from "@wdio/globals";
+import { execFile } from "node:child_process";
+import { appendFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { ChainablePromiseElement } from "webdriverio";
+import { nativePickerBinary } from "./native-picker";
+
+const execute = promisify(execFile);
+export const nativeInput = async (
+  action: "click" | "drag" | "keyboard-reorder",
+  start: ChainablePromiseElement,
+  end?: ChainablePromiseElement,
+): Promise<void> => {
+  const runtime = await browser.execute(() =>
+    window.__TAURI_INTERNALS__.invoke<{
+      processId: number;
+      roots: { world: string };
+    }>("e2e_status"),
+  );
+  const viewport = await browser.execute(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
+  const center = async (element?: ChainablePromiseElement) => {
+    if (!element) return { x: 0, y: 0 };
+    const location = await element.getLocation();
+    const size = await element.getSize();
+    return { x: location.x + size.width / 2, y: location.y + size.height / 2 };
+  };
+  const from = await center(start);
+  const to = await center(end);
+  const request = JSON.stringify({
+    Action: action,
+    X: from.x,
+    Y: from.y,
+    EndX: to.x,
+    EndY: to.y,
+    Width: viewport.width,
+    Height: viewport.height,
+  });
+  const logPath = path.join(
+    runtime.roots.world,
+    "artifacts",
+    "native-input.log",
+  );
+  await appendFile(logPath, `${request}\n`);
+  try {
+    const result = await execute(
+      nativePickerBinary,
+      [String(runtime.processId), runtime.roots.world, request],
+      { windowsHide: true, timeout: 20_000 },
+    );
+    await appendFile(logPath, result.stdout + result.stderr);
+  } catch (error) {
+    await appendFile(
+      logPath,
+      `${error instanceof Error ? error.stack : String(error)}\n`,
+    );
+    throw error;
+  }
+};

--- a/apps/desktop/e2e/support/profile-fixtures.ts
+++ b/apps/desktop/e2e/support/profile-fixtures.ts
@@ -1,0 +1,218 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { ModStatus, type LocalMod } from "../../src/types/mods";
+import { buildSyntheticVpk } from "./vpk";
+import { collectFileInventory, type CreatedWorld } from "./world";
+
+export const ALPHA = {
+  id: "profile_100_alpha",
+  folder: "profile_100_alpha_alpha",
+  name: "E2E Alpha",
+};
+export const BETA = {
+  id: "profile_200_beta",
+  folder: "profile_200_beta_beta",
+  name: "E2E Beta",
+};
+export const ALPHA_MODS = [
+  "local-alpha-one",
+  "local-alpha-two",
+  "local-alpha-three",
+];
+export const BETA_MODS = ["local-beta-one", "local-beta-two"];
+
+export const profilePayload = (modId: string): Buffer =>
+  buildSyntheticVpk([
+    {
+      path: "scripts/profile-fixture.txt",
+      contents: `Distinct payload for ${modId}\n`,
+    },
+  ]);
+
+const fixtureMod = (modId: string, index: number): LocalMod => ({
+  id: modId,
+  remoteId: modId,
+  name: modId,
+  description: "E2E profile fixture",
+  remoteUrl: "local://manual",
+  category: "Skins",
+  likes: 0,
+  author: "E2E",
+  downloadable: false,
+  tags: [],
+  images: [],
+  hero: null,
+  isAudio: false,
+  isMap: false,
+  audioUrl: null,
+  downloadCount: 0,
+  isNSFW: false,
+  isObsolete: false,
+  isBlacklisted: false,
+  blacklistReason: null,
+  blacklistedAt: null,
+  blacklistedBy: null,
+  filesUpdatedAt: null,
+  overrides: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  remoteAddedAt: new Date(0),
+  remoteUpdatedAt: new Date(0),
+  status: ModStatus.Installed,
+  installedVpks: [`pak${String(index + 1).padStart(2, "0")}_dir.vpk`],
+  installOrder: index,
+});
+
+export const prepareProfileWorld = async (
+  world: CreatedWorld,
+): Promise<void> => {
+  const profiles: Record<
+    string,
+    {
+      id: string;
+      name: string;
+      folderName: string | null;
+      isDefault: boolean;
+      createdAt: Date;
+      mods: LocalMod[];
+      enabledMods: Record<
+        string,
+        { remoteId: string; enabled: boolean; lastModified: Date }
+      >;
+    }
+  > = {
+    default: {
+      id: "default",
+      name: "Default Profile",
+      folderName: null,
+      isDefault: true,
+      createdAt: new Date(0),
+      mods: [],
+      enabledMods: {},
+    },
+  };
+  for (const { profile, modIds } of [
+    { profile: ALPHA, modIds: ALPHA_MODS },
+    { profile: BETA, modIds: BETA_MODS },
+  ]) {
+    const directory = path.join(
+      world.configuration.roots.game,
+      "game",
+      "citadel",
+      "addons",
+      profile.folder,
+    );
+    await mkdir(directory, { recursive: true });
+    const mods = modIds.map(fixtureMod);
+    const entries: Record<
+      string,
+      {
+        enabled: boolean;
+        order: number;
+        shard: number;
+        currentVpks: string[];
+        disabledVpks: string[];
+        originalVpkNames: string[];
+      }
+    > = {};
+    for (const [index, mod] of mods.entries()) {
+      const filename = `pak${String(index + 1).padStart(2, "0")}_dir.vpk`;
+      await writeFile(
+        path.join(directory, filename),
+        profilePayload(mod.remoteId),
+      );
+      entries[mod.remoteId] = {
+        enabled: true,
+        order: index,
+        shard: 1,
+        currentVpks: [filename],
+        disabledVpks: [],
+        originalVpkNames: [`${mod.remoteId}.vpk`],
+      };
+    }
+    await writeFile(
+      path.join(directory, ".dmm.json"),
+      JSON.stringify({ version: 3, mods: entries }, null, 2),
+    );
+    await writeFile(
+      path.join(directory, "protected.txt"),
+      `Protected ${profile.name}\n`,
+    );
+    profiles[profile.id] = {
+      id: profile.id,
+      name: profile.name,
+      folderName: profile.folder,
+      isDefault: false,
+      createdAt: new Date(0),
+      mods,
+      enabledMods: Object.fromEntries(
+        mods.map((mod) => [
+          mod.remoteId,
+          { remoteId: mod.remoteId, enabled: true, lastModified: new Date(0) },
+        ]),
+      ),
+    };
+  }
+  const storePath = path.join(world.configuration.roots.appData, "state.json");
+  const store = z
+    .object({ "local-config": z.string() })
+    .parse(JSON.parse(await readFile(storePath, "utf8")));
+  const persisted = z
+    .object({ state: z.record(z.string(), z.json()), version: z.number() })
+    .parse(JSON.parse(store["local-config"]));
+  await writeFile(
+    storePath,
+    JSON.stringify({
+      "local-config": JSON.stringify({
+        ...persisted,
+        state: {
+          ...persisted.state,
+          profiles,
+          activeProfileId: ALPHA.id,
+          localMods: profiles[ALPHA.id].mods,
+        },
+      }),
+    }),
+  );
+  const gameinfo = path.join(
+    world.configuration.roots.game,
+    "game",
+    "citadel",
+    "gameinfo.gi",
+  );
+  await writeFile(
+    gameinfo,
+    (await readFile(gameinfo, "utf8")).replace(
+      "Game citadel",
+      `Game citadel/addons/${ALPHA.folder}\n      Game citadel`,
+    ),
+  );
+  await writeFile(
+    path.join(world.artifactsDirectory, "profiles-initial.json"),
+    JSON.stringify(
+      {
+        alpha: await collectFileInventory(
+          path.join(
+            world.configuration.roots.game,
+            "game",
+            "citadel",
+            "addons",
+            ALPHA.folder,
+          ),
+        ),
+        beta: await collectFileInventory(
+          path.join(
+            world.configuration.roots.game,
+            "game",
+            "citadel",
+            "addons",
+            BETA.folder,
+          ),
+        ),
+      },
+      null,
+      2,
+    ),
+  );
+};

--- a/apps/desktop/e2e/support/profile-oracle.test.ts
+++ b/apps/desktop/e2e/support/profile-oracle.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, expect, it } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  ALPHA,
+  ALPHA_MODS,
+  BETA,
+  prepareProfileWorld,
+} from "./profile-fixtures";
+import { assertProfilesDisk } from "./profile-oracle";
+import { createWorld, removeOwnedWorld } from "./world";
+
+const worlds: string[] = [];
+afterEach(async () => {
+  for (const world of worlds.splice(0)) await removeOwnedWorld(world);
+});
+
+it("detects swapped payloads even when VPK names and manifest remain valid", async () => {
+  const world = await createWorld({
+    runId: "unit-run",
+    caseId: "profile-bytes",
+    attempt: 1,
+    fixtureOrigin: "http://127.0.0.1:43123",
+  });
+  worlds.push(world.directory);
+  await prepareProfileWorld(world);
+  await assertProfilesDisk(world.directory, "baseline", ALPHA.id, ALPHA_MODS);
+  const directory = path.join(
+    world.configuration.roots.game,
+    "game",
+    "citadel",
+    "addons",
+    ALPHA.folder,
+  );
+  const first = await readFile(path.join(directory, "pak01_dir.vpk"));
+  const second = await readFile(path.join(directory, "pak02_dir.vpk"));
+  await writeFile(path.join(directory, "pak01_dir.vpk"), second);
+  await writeFile(path.join(directory, "pak02_dir.vpk"), first);
+  await expect(
+    assertProfilesDisk(world.directory, "corrupt", ALPHA.id, ALPHA_MODS),
+  ).rejects.toThrow("Wrong bytes");
+});
+
+it("rejects writes to protected files in an inactive profile", async () => {
+  const world = await createWorld({
+    runId: "unit-run",
+    caseId: "profile-isolation",
+    attempt: 1,
+    fixtureOrigin: "http://127.0.0.1:43123",
+  });
+  worlds.push(world.directory);
+  await prepareProfileWorld(world);
+  await writeFile(
+    path.join(
+      world.configuration.roots.game,
+      "game",
+      "citadel",
+      "addons",
+      BETA.folder,
+      "unexpected.txt",
+    ),
+    "unexpected write",
+  );
+  await expect(
+    assertProfilesDisk(world.directory, "corrupt", ALPHA.id, ALPHA_MODS),
+  ).rejects.toThrow();
+});

--- a/apps/desktop/e2e/support/profile-oracle.ts
+++ b/apps/desktop/e2e/support/profile-oracle.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { ALPHA, BETA, BETA_MODS, profilePayload } from "./profile-fixtures";
+import { assertOwnedWorld, collectFileInventory } from "./world";
+
+const modSchema = z.object({
+  remoteId: z.string(),
+  status: z.literal("installed"),
+  installOrder: z.number(),
+  installedVpks: z.array(z.string()),
+});
+const inventorySchema = z.record(z.string(), z.string());
+export const readProfileState = async (world: string) => {
+  const {
+    configuration: { roots },
+  } = await assertOwnedWorld(world);
+  const store = z
+    .object({ "local-config": z.string() })
+    .parse(
+      JSON.parse(
+        await readFile(path.join(roots.appData, "state.json"), "utf8"),
+      ),
+    );
+  return z
+    .object({
+      state: z.object({
+        activeProfileId: z.string(),
+        localMods: z.array(modSchema),
+        profiles: z.record(
+          z.string(),
+          z.object({
+            mods: z.array(modSchema),
+            enabledMods: z.record(
+              z.string(),
+              z.object({ enabled: z.boolean() }),
+            ),
+          }),
+        ),
+      }),
+    })
+    .parse(JSON.parse(store["local-config"])).state;
+};
+
+export const assertProfilesDisk = async (
+  world: string,
+  step: string,
+  activeId: string,
+  alphaOrder: string[],
+) => {
+  const {
+    configuration: { roots },
+  } = await assertOwnedWorld(world);
+  const state = await readProfileState(world);
+  assert.equal(state.activeProfileId, activeId);
+  const initial = z
+    .object({ alpha: inventorySchema, beta: inventorySchema })
+    .parse(
+      JSON.parse(
+        await readFile(
+          path.join(world, "artifacts", "profiles-initial.json"),
+          "utf8",
+        ),
+      ),
+    );
+  const inventories: Record<string, Record<string, string>> = {};
+  for (const { profile, order } of [
+    { profile: ALPHA, order: alphaOrder },
+    { profile: BETA, order: BETA_MODS },
+  ]) {
+    const directory = path.join(
+      roots.game,
+      "game",
+      "citadel",
+      "addons",
+      profile.folder,
+    );
+    const inventory = await collectFileInventory(directory);
+    inventories[profile.id] = inventory;
+    const manifest = z
+      .object({
+        version: z.literal(3),
+        mods: z.record(
+          z.string(),
+          z.object({
+            enabled: z.boolean(),
+            order: z.number(),
+            shard: z.number(),
+            currentVpks: z.array(z.string()),
+            disabledVpks: z.array(z.string()),
+            originalVpkNames: z.array(z.string()),
+          }),
+        ),
+      })
+      .parse(
+        JSON.parse(await readFile(path.join(directory, ".dmm.json"), "utf8")),
+      );
+    assert.deepEqual(Object.keys(manifest.mods).sort(), [...order].sort());
+    const expectedMods = order.map((remoteId, index) => ({
+      remoteId,
+      status: "installed",
+      installOrder: index,
+      installedVpks: [`pak${String(index + 1).padStart(2, "0")}_dir.vpk`],
+    }));
+    assert.deepEqual(
+      state.profiles[profile.id].mods.toSorted(
+        (a, b) => a.installOrder - b.installOrder,
+      ),
+      expectedMods,
+    );
+    if (activeId === profile.id)
+      assert.deepEqual(
+        state.localMods.toSorted((a, b) => a.installOrder - b.installOrder),
+        expectedMods,
+      );
+    assert.deepEqual(
+      Object.keys(state.profiles[profile.id].enabledMods).sort(),
+      order.toSorted(),
+    );
+    assert.deepEqual(
+      Object.keys(inventory).sort(),
+      [
+        ".dmm.json",
+        "protected.txt",
+        ...expectedMods.flatMap((mod) => mod.installedVpks),
+      ].sort(),
+    );
+    for (const mod of expectedMods) {
+      const payload = profilePayload(mod.remoteId);
+      assert.equal(
+        inventory[mod.installedVpks[0]],
+        `${payload.length}:${createHash("sha256").update(payload).digest("hex")}`,
+        `Wrong bytes for ${mod.remoteId}`,
+      );
+      assert.deepEqual(manifest.mods[mod.remoteId], {
+        enabled: true,
+        order: mod.installOrder,
+        shard: 1,
+        currentVpks: mod.installedVpks,
+        disabledVpks: [],
+        originalVpkNames: [`${mod.remoteId}.vpk`],
+      });
+      assert.equal(
+        state.profiles[profile.id].enabledMods[mod.remoteId].enabled,
+        true,
+      );
+    }
+    assert.equal(
+      await readFile(path.join(directory, "protected.txt"), "utf8"),
+      `Protected ${profile.name}\n`,
+    );
+  }
+  assert.deepEqual(
+    inventories[BETA.id],
+    initial.beta,
+    "Untouched profile must remain byte-identical",
+  );
+  const gameinfo = await readFile(
+    path.join(roots.game, "game", "citadel", "gameinfo.gi"),
+    "utf8",
+  );
+  const active = activeId === ALPHA.id ? ALPHA : BETA;
+  const addonSearchPaths = [
+    ...gameinfo.matchAll(/^\s*Game\s+(citadel\/addons\S*)\s*$/gm),
+  ].map((match) => match[1]);
+  assert.deepEqual(addonSearchPaths, [`citadel/addons/${active.folder}`]);
+  await writeFile(
+    path.join(world, "artifacts", `profiles-${step}.json`),
+    JSON.stringify({ state, inventories, gameinfo }, null, 2),
+  );
+  return inventories[ALPHA.id];
+};

--- a/apps/desktop/e2e/support/scenarios.ts
+++ b/apps/desktop/e2e/support/scenarios.ts
@@ -1,16 +1,30 @@
-export type ScenarioId = "about-smoke" | "local-mod-lifecycle";
+export type ScenarioId =
+  | "about-smoke"
+  | "local-mod-lifecycle"
+  | "profiles-pointer"
+  | "profiles-keyboard";
 
 export const parseScenarioId = (value = "about-smoke"): ScenarioId => {
-  if (value === "about-smoke" || value === "local-mod-lifecycle") return value;
+  if (
+    value === "about-smoke" ||
+    value === "local-mod-lifecycle" ||
+    value === "profiles-pointer" ||
+    value === "profiles-keyboard"
+  )
+    return value;
   throw new Error(`Unsupported E2E case '${value}'`);
 };
 
 export const scenarioPhases = (scenario: ScenarioId): readonly string[] =>
   scenario === "local-mod-lifecycle"
     ? ["import-toggle", "restart-delete"]
-    : ["smoke"];
+    : scenario === "about-smoke"
+      ? ["smoke"]
+      : ["reorder-switch", "restart-profiles"];
 
 export const scenarioSpec = (scenario: ScenarioId): string =>
   scenario === "local-mod-lifecycle"
     ? "./specs/local-mod-lifecycle.e2e.ts"
-    : "./specs/about.e2e.ts";
+    : scenario === "about-smoke"
+      ? "./specs/about.e2e.ts"
+      : "./specs/profiles-ordering.e2e.ts";

--- a/apps/desktop/e2e/support/supervisor.ts
+++ b/apps/desktop/e2e/support/supervisor.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { DriverProvider } from "./contracts";
 import { scenarioPhases, type ScenarioId } from "./scenarios";
 import { writeSyntheticVpk } from "./vpk";
+import { prepareProfileWorld } from "./profile-fixtures";
 import { startFilesystemJournal } from "./filesystem-journal";
 import { startFixtureServer, type FixtureRoute } from "./fixture-server";
 import {
@@ -194,6 +195,16 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
   try {
     fixtureServer = await startFixtureServer([
       ...(options.fixtureRoutes ?? []),
+      ...(options.caseId.startsWith("profiles-")
+        ? [
+            {
+              method: "GET",
+              path: "/api/v2/feature-flags",
+              status: 200,
+              body: '[{"name":"profile-management","enabled":true}]',
+            },
+          ]
+        : []),
       ...startupFixtureRoutes,
     ]);
     world = await createWorld({
@@ -203,6 +214,8 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
       fixtureOrigin: fixtureServer.origin,
     });
     const roots = world.configuration.roots;
+    if (options.caseId.startsWith("profiles-"))
+      await prepareProfileWorld(world);
     if (options.caseId === "local-mod-lifecycle") {
       await writeSyntheticVpk(
         path.join(world.directory, "fixtures", "e2e-local-mod.vpk"),


### PR DESCRIPTION
Adds M3 coverage for profile switching and mod ordering, stacked on #708. Separate pointer and keyboard scenarios reorder Alpha through the UI, save through Rust, switch to Beta, restart the application, and return to Alpha. Independent checks compare persisted state, manifest slots, exact inventories, VPK hashes, protected files, and active game search paths; the untouched profile must remain byte-identical.

The pinned embedded Windows driver emits mouse events without the pointer events required by Radix and dnd-kit. The existing FlaUI helper now supplies scoped native clicks/dragging and scan-code keyboard input, with owned-world/PID validation, DPI conversion, focus guards, and an input journal. These scenarios require a serial, interactive Windows desktop and bring the owned test window forward. Fixture profiles are preinstalled; native import remains covered by M2. No new dependencies or production application changes.

Validation:
- Pointer and keyboard scenarios each passed three consecutive fresh-world runs with retries disabled: 32.6–36.6 seconds, two app processes per world, zero unmatched requests.
- M2 native local-mod lifecycle regression passed after rebuilding the helper (24.7 seconds).
- All 14 harness unit tests pass, including swapped valid VPK payloads and unexpected inactive-profile files.
- Native helper build, profile doctor, E2E type check, root `pnpm check-types`, `pnpm lint:fix`, and `pnpm format:fix` pass. Lint reports 144 warnings and no errors.

AI Assistance: Used Codex to implement the harness scenarios, diagnose native input behavior, and run validation.

## Stack tracking

Tracked in #673 (PR 14 of 19). Based on #708. Followed by #710.

