### PR TITLE
test(desktop): cover download failures and recovery

### DIFF
--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -45,7 +45,28 @@ The fixture server records all requests to `artifacts/network.ndjson`, returns a
 
 The first smoke flow uses WebDriver clicks to open Settings and the About dialog, then invokes the compile-gated `e2e_status` command to prove the UI process is connected to the real Rust backend and isolated world. It also prepares a real Steam launch request through Rust, verifies that the `record` policy writes the redacted intent to `artifacts/game-launches.ndjson`, and proves that game liveness/stop operations cannot inspect or terminate a host game in the default E2E world.
 
+## Download scenarios
+
+M4 uses real Rust HTTP transfers against binary fixture responses. Run any case with `pnpm --filter @deadlock-mods/desktop e2e:test -- --case <case> --keep` after rebuilding the E2E application. These cases do not require the native input helper.
+
+| Case | Behavior checked |
+| --- | --- |
+| `downloads-pause` | UI pause freezes a valid partial prefix; UI resume completes the payload |
+| `downloads-range` | A connection cut after 65,536 bytes triggers an exact Range request and byte-correct completion |
+| `downloads-cancel` | Cancel a paused transfer through the existing Rust command, verify partial cleanup, restart, and retry through the UI |
+| `downloads-restart` | Restart while paused, verify stale status becomes failed while partial evidence remains, then retry from scratch |
+| `downloads-auth` | A 401 response fails visibly; UI retry completes after the fixture permits it |
+| `downloads-corrupt` | A same-length corrupt payload fails MD5 validation without publishing a file; UI retry succeeds |
+| `downloads-redirect` | Reject a redirect to a production host without making an external request; UI retry succeeds |
+| `downloads-variants` | Retry preserves a previously selected variant, including after a 401 and restart; the unselected URL has no registered fixture |
+
+Each world starts with a failed download record and persisted file selection, so Retry exercises the real frontend purge/queue flow without depending on the remote catalog. Variant coverage here is persisted selection and retry, not the initial catalog file chooser. Cancellation uses real IPC because the current UI does not expose a cancel control. Successful transfers are checked again in a new application process. The oracle compares SHA-256 hashes, partial prefixes and metadata, exact cache contents, the empty addon manifest, and protected game/Steam files. `download-*.json` captures disk/state evidence; `network.ndjson` includes Range headers, response status and bytes sent. UI retries deliberately purge stale data; only interrupted transfers within a running process resume with Range.
+
+The E2E-only download policy accepts exact configured fixture origins (including port and scheme) for initial requests and redirects. Ordinary builds retain the HTTPS trusted-host allowlist. The same downloader, checksum checks, staging files, pause gate, and cancellation logic run in both builds.
+
 ## Qualification status
+
+All eight M4 cases passed two consecutive retry-free Windows/Wry worlds each, including a new application process in every world. The final pass took approximately 20–30 seconds per world with no unmatched requests. Harness unit tests cover binary Range responses, truncated streams, wrong-variant bytes, and leftover partial files; Rust tests cover fixture-origin restrictions and the ordinary-build allowlist.
 
 The profile pointer and keyboard scenarios each passed three consecutive retry-free Windows/Wry worlds, with two application processes per world. These six runs took 32.6–36.6 seconds and had no unmatched fixture requests.
 
@@ -66,7 +87,7 @@ Native Windows dialogs are outside the webview DOM and cannot be driven by WebDr
 | M1: safe harness foundation | Complete in PR #707 (replaces #706) | Compile-gated runtime configuration, owned worlds, root routing, fixture network, filesystem oracle, synthetic VPK builder, supervisor, doctor, and embedded-driver qualification | Ten retry-free fresh UI/IPC runs pass; intentional timeout cleanup succeeds; production cannot activate E2E mode |
 | M2: complete local-mod lifecycle | Implemented and validated on Windows/Wry | Drive a synthetic VPK through a narrowly scoped FlaUI native-picker helper, the real Rust parser, import/install, enable/disable, delete, and application restart | UI state, VPK manifest, persisted store, and independent file hashes agree after every step; the final world matches its expected restored state |
 | M3: profiles and ordering | Implemented and validated on Windows/Wry | Two-profile switching plus native pointer and keyboard reorder flows | Inactive profiles and protected files remain unchanged; order and profile state survive restart without mocked core IPC |
-| M4: downloads and network failures | Planned; transport foundation exists | Exercise actual Rust downloads against fixture endpoints, including variants, Range resume, pause, cancel, malformed responses, and authentication failures | Every request matches the strict journal; unexpected traffic fails; partial files and state recover correctly |
+| M4: downloads and network failures | Implemented and validated on Windows/Wry | Real Rust downloads against binary fixtures: selected-variant retries, Range resume, pause, cancel, corrupt payloads, authentication failures, redirects, and interrupted-process recovery | Every request matches the strict journal; unexpected traffic fails; partial files and state recover correctly |
 | M5: recovery and hostile filesystem cases | Planned | Backup replace/merge, interrupted mutations, shard boundaries, collisions, Windows locks, and crash barriers | Restart recovers retained worlds and the independent oracle proves restoration without normalizing unexpected writes |
 | M6: CI and release coverage | Planned | Serial Windows PR lane, broader nightly matrix, packaged-app/native smoke, and ordinary-release exclusion checks | Clean runners reproduce required flows and ordinary builds contain no harness server, capability, control channel, or fixture policy |
 

--- a/apps/desktop/e2e/cli.ts
+++ b/apps/desktop/e2e/cli.ts
@@ -136,7 +136,8 @@ const doctor = async (): Promise<void> => {
   const binaryPath = valueAfter("--binary") ?? defaultBinaryPath;
   const selectedProvider = provider();
   const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
-  if (parseScenarioId(valueAfter("--case")) !== "about-smoke") {
+  const scenario = parseScenarioId(valueAfter("--case"));
+  if (scenario === "local-mod-lifecycle" || scenario.startsWith("profiles-")) {
     let pickerExists = true;
     try {
       await access(nativePickerBinary);

--- a/apps/desktop/e2e/specs/downloads.e2e.ts
+++ b/apps/desktop/e2e/specs/downloads.e2e.ts
@@ -1,0 +1,141 @@
+import { $, browser, expect } from "@wdio/globals";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import {
+  DOWNLOAD_FILE,
+  DOWNLOAD_MOD,
+  DOWNLOAD_NAME,
+} from "../support/download-fixtures";
+import {
+  assertDownloadDisk,
+  downloadDirectory,
+  readDownloadState,
+} from "../support/download-oracle";
+
+const card = () => $(`[role="button"][aria-label="Open ${DOWNLOAD_NAME}"]`);
+const waitStatus = async (world: string, status: string): Promise<void> => {
+  await browser.waitUntil(
+    async () => (await readDownloadState(world))[0]?.status === status,
+    { timeout: 20_000, timeoutMsg: `Download did not reach ${status}` },
+  );
+};
+const retry = async (): Promise<void> => {
+  const button = await card().$("button=Retry");
+  await button.waitForClickable();
+  await button.click();
+};
+const pause = async (world: string): Promise<void> => {
+  await waitStatus(world, "downloading");
+  const partial = path.join(
+    await downloadDirectory(world),
+    `${DOWNLOAD_FILE}.partial`,
+  );
+  await browser.waitUntil(
+    async () => (await stat(partial).catch(() => ({ size: 0 }))).size > 0,
+  );
+  const button = await card().$("button=Pause");
+  await button.waitForClickable();
+  await button.click();
+  await waitStatus(world, "paused");
+  let previousSize = -1;
+  let stableSince = Date.now();
+  await browser.waitUntil(
+    async () => {
+      const size = (await stat(partial)).size;
+      if (size !== previousSize) {
+        previousSize = size;
+        stableSince = Date.now();
+      }
+      return Date.now() - stableSince >= 800;
+    },
+    {
+      timeout: 5000,
+      interval: 100,
+      timeoutMsg: "Paused download kept writing bytes",
+    },
+  );
+  await expect(card().$("button=Resume")).toBeDisplayed();
+  await assertDownloadDisk(world, "paused", "paused");
+};
+
+describe("real Rust downloads", () => {
+  it("keeps UI, partial files and selected payload consistent across failure and restart", async () => {
+    const dismiss = await $("button=Got it!");
+    if (await dismiss.isDisplayed()) await dismiss.click();
+    const runtime = await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<{
+        processId: number;
+        roots: { world: string };
+      }>("e2e_status"),
+    );
+    const world = runtime.roots.world;
+    const scenario = process.env.DMM_E2E_CASE_ID;
+    const checkpointPath = path.join(
+      world,
+      "artifacts",
+      "download-checkpoint.json",
+    );
+    await $('a[href="/downloads"]').click();
+    await card().waitForDisplayed();
+    if (process.env.DMM_E2E_PHASE === "transfer") {
+      await retry();
+      if (
+        scenario === "downloads-pause" ||
+        scenario === "downloads-cancel" ||
+        scenario === "downloads-restart"
+      ) {
+        await pause(world);
+        if (scenario === "downloads-cancel") {
+          await browser.execute(
+            (modId: string) =>
+              window.__TAURI_INTERNALS__.invoke("cancel_download", { modId }),
+            DOWNLOAD_MOD,
+          );
+          await waitStatus(world, "failedToDownload");
+          await assertDownloadDisk(world, "cancelled", "failedToDownload");
+        } else if (scenario !== "downloads-restart") {
+          await card().$("button=Resume").click();
+          await waitStatus(world, "downloaded");
+        }
+      } else if (
+        [
+          "downloads-auth",
+          "downloads-corrupt",
+          "downloads-variants",
+          "downloads-redirect",
+        ].includes(scenario ?? "")
+      ) {
+        await waitStatus(world, "failedToDownload");
+        await assertDownloadDisk(world, "failed", "failedToDownload");
+        await expect(card().$("button=Retry")).toBeDisplayed();
+        await retry();
+        await waitStatus(world, "downloaded");
+      } else await waitStatus(world, "downloaded");
+      if (scenario !== "downloads-cancel" && scenario !== "downloads-restart")
+        await assertDownloadDisk(world, "completed", "downloaded");
+      await writeFile(
+        checkpointPath,
+        JSON.stringify({ processId: runtime.processId }),
+      );
+    } else if (process.env.DMM_E2E_PHASE === "restart-download") {
+      const checkpoint = z
+        .object({ processId: z.number() })
+        .parse(JSON.parse(await readFile(checkpointPath, "utf8")));
+      expect(runtime.processId).not.toBe(checkpoint.processId);
+      if (scenario === "downloads-cancel" || scenario === "downloads-restart") {
+        await waitStatus(world, "failedToDownload");
+        await assertDownloadDisk(
+          world,
+          "restart-incomplete",
+          "failedToDownload",
+          scenario === "downloads-restart",
+        );
+        await retry();
+        await waitStatus(world, "downloaded");
+      }
+      await assertDownloadDisk(world, "restarted", "downloaded");
+      await expect(card()).toHaveText(expect.stringContaining("Completed"));
+    } else throw new Error("Unknown download phase");
+  });
+});

--- a/apps/desktop/e2e/support/download-fixtures.ts
+++ b/apps/desktop/e2e/support/download-fixtures.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { ModStatus, type ModDownloadItem } from "../../src/types/mods";
+import { fixtureMod } from "./profile-fixtures";
+import type {
+  FixtureRequest,
+  FixtureResponse,
+  FixtureRoute,
+} from "./fixture-server";
+import { collectFileInventory, type CreatedWorld } from "./world";
+import { buildSyntheticVpk } from "./vpk";
+
+export const DOWNLOAD_MOD = "local-00000000-0000-4000-8000-000000000004";
+export const DOWNLOAD_NAME = "E2E Download";
+export const DOWNLOAD_FILE = "selected.vpk";
+export const downloadPayload = (variant = "selected") =>
+  buildSyntheticVpk([
+    {
+      path: "scripts/e2e-download.txt",
+      contents: `${variant}\n${"fixture-payload\n".repeat(32768)}`,
+    },
+  ]);
+export const downloadRoutes = (scenario: string): FixtureRoute[] => {
+  const body = downloadPayload();
+  const good = {
+    status: 200,
+    body,
+    range: true,
+    headers: { etag: '"e2e-download-v1"' },
+  };
+  const slow = { ...good, chunkBytes: 32768, chunkDelayMs: 500 };
+  const corrupt = Buffer.from(body);
+  corrupt[corrupt.length - 1] ^= 0xff;
+  let sequence: FixtureResponse[];
+  switch (scenario) {
+    case "downloads-auth":
+    case "downloads-variants":
+      sequence = [{ status: 401, body: "Authentication required" }, good];
+      break;
+    case "downloads-redirect":
+      sequence = [
+        {
+          status: 302,
+          body: "",
+          headers: { location: "https://gamebanana.com/e2e-must-not-connect" },
+        },
+        good,
+      ];
+      break;
+    case "downloads-corrupt":
+      sequence = [{ ...good, body: corrupt }, good];
+      break;
+    case "downloads-range":
+      sequence = [
+        {
+          ...good,
+          disconnectAfterBytes: 65536,
+          chunkBytes: 32768,
+          chunkDelayMs: 150,
+        },
+        good,
+      ];
+      break;
+    default:
+      sequence = [slow];
+  }
+  return [
+    { method: "GET", path: `/downloads/${DOWNLOAD_FILE}`, ...good, sequence },
+  ];
+};
+
+export const prepareDownloadWorld = async (
+  world: CreatedWorld,
+  origin: string,
+  scenario: string,
+): Promise<void> => {
+  const payload = downloadPayload();
+  const selected: ModDownloadItem = {
+    name: DOWNLOAD_FILE,
+    url: `${origin}/downloads/${DOWNLOAD_FILE}`,
+    size: payload.length,
+    md5Checksum: createHash("md5").update(payload).digest("hex"),
+    createdAt: new Date(0),
+    updatedAt: null,
+    description: "Selected E2E variant",
+  };
+  const downloads =
+    scenario === "downloads-variants"
+      ? [
+          {
+            ...selected,
+            name: "unselected.vpk",
+            url: `${origin}/downloads/unselected.vpk`,
+          },
+          selected,
+        ]
+      : [selected];
+  const mod = {
+    ...fixtureMod(DOWNLOAD_MOD, 0),
+    name: DOWNLOAD_NAME,
+    status: ModStatus.FailedToDownload,
+    installedVpks: [],
+    downloads,
+    selectedDownloads: [selected],
+  };
+  const storePath = path.join(world.configuration.roots.appData, "state.json");
+  const store = z
+    .object({ "local-config": z.string() })
+    .parse(JSON.parse(await readFile(storePath, "utf8")));
+  const persisted = z
+    .object({ state: z.record(z.string(), z.json()), version: z.number() })
+    .parse(JSON.parse(store["local-config"]));
+  const profile = {
+    id: "default",
+    name: "Default Profile",
+    folderName: null,
+    isDefault: true,
+    createdAt: new Date(0),
+    mods: [mod],
+    enabledMods: {},
+  };
+  await writeFile(
+    storePath,
+    JSON.stringify({
+      "local-config": JSON.stringify({
+        ...persisted,
+        state: {
+          ...persisted.state,
+          activeProfileId: "default",
+          localMods: [mod],
+          profiles: { default: profile },
+        },
+      }),
+    }),
+  );
+  await writeFile(
+    path.join(world.configuration.roots.game, "protected.txt"),
+    "Protected download world\n",
+  );
+  await writeFile(
+    path.join(world.artifactsDirectory, "downloads-initial.json"),
+    JSON.stringify({
+      steam: await collectFileInventory(world.configuration.roots.steam),
+    }),
+  );
+};
+
+export const assertDownloadNetwork = (
+  scenario: string,
+  journal: readonly FixtureRequest[],
+): void => {
+  const requests = journal.filter((request) =>
+    request.url.startsWith("/downloads/"),
+  );
+  assert.ok(requests.length > 0, "Download must reach the real HTTP fixture");
+  assert.ok(
+    requests.every((request) => request.url === `/downloads/${DOWNLOAD_FILE}`),
+  );
+  if (scenario === "downloads-range") {
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].headers.range, undefined);
+    assert.equal(requests[1].headers.range, "bytes=65536-");
+    assert.equal(requests[1].responseStatus, 206);
+  } else {
+    const retry = [
+      "downloads-auth",
+      "downloads-corrupt",
+      "downloads-variants",
+      "downloads-cancel",
+      "downloads-restart",
+      "downloads-redirect",
+    ].includes(scenario);
+    assert.equal(requests.length, retry ? 2 : 1);
+    assert.ok(
+      requests.every((request) => request.headers.range === undefined),
+      "UI retry must purge stale partial state",
+    );
+    if (scenario === "downloads-auth" || scenario === "downloads-variants")
+      assert.equal(requests[0].responseStatus, 401);
+    if (scenario === "downloads-redirect")
+      assert.equal(requests[0].responseStatus, 302);
+    assert.equal(requests.at(-1)?.responseStatus, 200);
+  }
+};

--- a/apps/desktop/e2e/support/download-oracle.test.ts
+++ b/apps/desktop/e2e/support/download-oracle.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, expect, it } from "bun:test";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import {
+  DOWNLOAD_FILE,
+  downloadPayload,
+  prepareDownloadWorld,
+} from "./download-fixtures";
+import { assertDownloadDisk, downloadDirectory } from "./download-oracle";
+import { createWorld, removeOwnedWorld } from "./world";
+
+const worlds: string[] = [];
+afterEach(async () => {
+  for (const world of worlds.splice(0)) await removeOwnedWorld(world);
+});
+
+it("rejects the wrong variant and leftover partial files despite a completed store status", async () => {
+  const world = await createWorld({
+    runId: "unit-run",
+    caseId: "download-oracle",
+    attempt: 1,
+    fixtureOrigin: "http://127.0.0.1:43123",
+  });
+  worlds.push(world.directory);
+  await prepareDownloadWorld(
+    world,
+    "http://127.0.0.1:43123",
+    "downloads-variants",
+  );
+  const storePath = path.join(world.configuration.roots.appData, "state.json");
+  const store = z
+    .object({ "local-config": z.string() })
+    .parse(JSON.parse(await readFile(storePath, "utf8")));
+  const persisted = z
+    .object({ state: z.record(z.string(), z.json()), version: z.number() })
+    .parse(JSON.parse(store["local-config"]));
+  const mods = z
+    .array(z.record(z.string(), z.json()))
+    .parse(persisted.state.localMods);
+  persisted.state.localMods = mods.map((mod) => ({
+    ...mod,
+    status: "downloaded",
+  }));
+  await writeFile(
+    storePath,
+    JSON.stringify({ "local-config": JSON.stringify(persisted) }),
+  );
+  const directory = await downloadDirectory(world.directory);
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, DOWNLOAD_FILE), downloadPayload());
+  await assertDownloadDisk(world.directory, "baseline", "downloaded");
+  await writeFile(
+    path.join(directory, DOWNLOAD_FILE),
+    downloadPayload("unselected"),
+  );
+  await expect(
+    assertDownloadDisk(world.directory, "wrong-variant", "downloaded"),
+  ).rejects.toThrow();
+  await writeFile(path.join(directory, DOWNLOAD_FILE), downloadPayload());
+  await writeFile(path.join(directory, `${DOWNLOAD_FILE}.partial`), "stale");
+  await expect(
+    assertDownloadDisk(world.directory, "stale-partial", "downloaded"),
+  ).rejects.toThrow();
+});

--- a/apps/desktop/e2e/support/download-oracle.ts
+++ b/apps/desktop/e2e/support/download-oracle.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import {
+  DOWNLOAD_FILE,
+  DOWNLOAD_MOD,
+  downloadPayload,
+} from "./download-fixtures";
+import { assertOwnedWorld, collectFileInventory } from "./world";
+
+export const readDownloadState = async (world: string) => {
+  const {
+    configuration: { roots },
+  } = await assertOwnedWorld(world);
+  const store = z
+    .object({ "local-config": z.string() })
+    .parse(
+      JSON.parse(
+        await readFile(path.join(roots.appData, "state.json"), "utf8"),
+      ),
+    );
+  return z
+    .object({
+      state: z.object({
+        localMods: z.array(
+          z.object({
+            remoteId: z.string(),
+            status: z.string(),
+            selectedDownloads: z.array(z.object({ name: z.string() })),
+            installedVpks: z.array(z.string()).optional(),
+          }),
+        ),
+      }),
+    })
+    .parse(JSON.parse(store["local-config"])).state.localMods;
+};
+export const downloadDirectory = async (world: string): Promise<string> => {
+  const {
+    configuration: { roots },
+  } = await assertOwnedWorld(world);
+  return path.join(roots.appData, "mods", DOWNLOAD_MOD);
+};
+export const assertDownloadDisk = async (
+  world: string,
+  step: string,
+  status: "downloaded" | "failedToDownload" | "paused",
+  retainedPartial = false,
+): Promise<void> => {
+  const {
+    configuration: { roots },
+  } = await assertOwnedWorld(world);
+  const mods = await readDownloadState(world);
+  assert.equal(mods.length, 1);
+  assert.equal(mods[0].remoteId, DOWNLOAD_MOD);
+  assert.equal(mods[0].status, status);
+  assert.deepEqual(mods[0].selectedDownloads, [{ name: DOWNLOAD_FILE }]);
+  assert.deepEqual(mods[0].installedVpks ?? [], []);
+  const directory = await downloadDirectory(world);
+  const inventory = await collectFileInventory(directory);
+  const payload = downloadPayload();
+  if (status === "downloaded") {
+    assert.deepEqual(inventory, {
+      [DOWNLOAD_FILE]: `${payload.length}:${createHash("sha256").update(payload).digest("hex")}`,
+    });
+  } else if (status === "paused" || retainedPartial) {
+    const partial = await readFile(
+      path.join(directory, `${DOWNLOAD_FILE}.partial`),
+    );
+    assert.ok(partial.length > 0 && partial.length < payload.length);
+    assert.deepEqual(partial, payload.subarray(0, partial.length));
+    assert.deepEqual(Object.keys(inventory).sort(), [
+      `${DOWNLOAD_FILE}.partial`,
+      `${DOWNLOAD_FILE}.partial.meta`,
+    ]);
+    assert.equal(
+      z
+        .object({ etag: z.string() })
+        .parse(
+          JSON.parse(
+            await readFile(
+              path.join(directory, `${DOWNLOAD_FILE}.partial.meta`),
+              "utf8",
+            ),
+          ),
+        ).etag,
+      '"e2e-download-v1"',
+    );
+  } else
+    assert.deepEqual(
+      inventory,
+      {},
+      "Failed or cancelled transfers must not publish a file or leave partial data",
+    );
+  const addons = path.join(roots.game, "game", "citadel", "addons");
+  const addonInventory = await collectFileInventory(addons);
+  assert.ok(
+    Object.keys(addonInventory).every((name) => name === ".dmm.json"),
+    "Download alone must not install VPKs",
+  );
+  if (addonInventory[".dmm.json"])
+    assert.deepEqual(
+      z
+        .object({ version: z.literal(3), mods: z.record(z.string(), z.json()) })
+        .parse(
+          JSON.parse(await readFile(path.join(addons, ".dmm.json"), "utf8")),
+        ).mods,
+      {},
+    );
+  assert.equal(
+    await readFile(path.join(roots.game, "protected.txt"), "utf8"),
+    "Protected download world\n",
+  );
+  const initial = z
+    .object({ steam: z.record(z.string(), z.string()) })
+    .parse(
+      JSON.parse(
+        await readFile(
+          path.join(world, "artifacts", "downloads-initial.json"),
+          "utf8",
+        ),
+      ),
+    );
+  assert.deepEqual(await collectFileInventory(roots.steam), initial.steam);
+  await writeFile(
+    path.join(world, "artifacts", `download-${step}.json`),
+    JSON.stringify({ mods, inventory, addonInventory }, null, 2),
+  );
+};

--- a/apps/desktop/e2e/support/fixture-server.test.ts
+++ b/apps/desktop/e2e/support/fixture-server.test.ts
@@ -45,6 +45,82 @@ const proxyRequest = async (
 };
 
 describe("fixture network", () => {
+  it("serves exact binary ranges and deterministic failure sequences", async () => {
+    const body = Buffer.from([0, 255, 128, 1, 2, 3, 4, 5]);
+    const good = {
+      status: 200,
+      body,
+      range: true,
+      headers: { etag: '"fixture"' },
+    };
+    const server = await startFixtureServer([
+      {
+        method: "GET",
+        path: "/file",
+        ...good,
+        sequence: [{ status: 401, body: "denied" }, good],
+      },
+    ]);
+    try {
+      const denied = await fetch(`${server.origin}/file`);
+      expect(denied.status).toBe(401);
+      await denied.text();
+      const resumed = await fetch(`${server.origin}/file`, {
+        headers: { range: "bytes=3-" },
+      });
+      expect(resumed.status).toBe(206);
+      expect(resumed.headers.get("content-range")).toBe("bytes 3-7/8");
+      expect(Buffer.from(await resumed.arrayBuffer())).toEqual(
+        body.subarray(3),
+      );
+      const invalid = await fetch(`${server.origin}/file`, {
+        headers: { range: "bytes=99-" },
+      });
+      expect(invalid.status).toBe(416);
+      await invalid.text();
+      expect(server.requests().map((entry) => entry.responseStatus)).toEqual([
+        401, 206, 416,
+      ]);
+      expect(server.unmatchedRequests()).toHaveLength(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("cuts a streamed response short and permits its remaining range", async () => {
+    const body = Buffer.alloc(65536, 7);
+    const good = { status: 200, body, range: true };
+    const server = await startFixtureServer([
+      {
+        method: "GET",
+        path: "/file",
+        ...good,
+        sequence: [
+          {
+            ...good,
+            disconnectAfterBytes: 16384,
+            chunkBytes: 8192,
+            chunkDelayMs: 20,
+          },
+          good,
+        ],
+      },
+    ]);
+    try {
+      const broken = await fetch(`${server.origin}/file`);
+      await expect(broken.arrayBuffer()).rejects.toThrow();
+      const resumed = await fetch(`${server.origin}/file`, {
+        headers: { range: "bytes=16384-" },
+      });
+      expect(Buffer.from(await resumed.arrayBuffer())).toEqual(
+        body.subarray(16384),
+      );
+      expect(server.requests()[0].responseBytes).toBe(16384);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("serves registered responses and journals matched and unmatched requests", async () => {
     const artifacts = await mkdtemp(
       path.join(os.tmpdir(), "dmm-network-test-"),

--- a/apps/desktop/e2e/support/fixture-server.ts
+++ b/apps/desktop/e2e/support/fixture-server.ts
@@ -12,20 +12,95 @@ export type FixtureRequest = {
   url: string;
   headers: Record<string, string | string[]>;
   bodyBytes: number;
+  responseStatus?: number;
+  responseBytes?: number;
 };
 
-export type FixtureRoute = {
-  method: string;
-  path: string;
+export type FixtureResponse = {
   status: number;
   headers?: Record<string, string>;
-  body: string;
+  body: string | Buffer;
+  range?: boolean;
+  chunkBytes?: number;
+  chunkDelayMs?: number;
+  disconnectAfterBytes?: number;
+};
+
+export type FixtureRoute = FixtureResponse & {
+  method: string;
+  path: string;
+  sequence?: readonly FixtureResponse[];
 };
 
 export type FixtureServer = {
   origin: string;
   unmatchedRequests: () => readonly FixtureRequest[];
+  requests: () => readonly FixtureRequest[];
   close: (artifactsDirectory?: string) => Promise<void>;
+};
+
+const sendFixture = async (
+  request: IncomingMessage,
+  response: ServerResponse,
+  fixture: FixtureResponse,
+  record: FixtureRequest,
+): Promise<void> => {
+  const body = Buffer.isBuffer(fixture.body)
+    ? fixture.body
+    : Buffer.from(fixture.body);
+  let offset = 0;
+  let status = fixture.status;
+  const headers = {
+    "content-type": Buffer.isBuffer(fixture.body)
+      ? "application/octet-stream"
+      : "application/json",
+    ...fixture.headers,
+  };
+  if (fixture.range && request.headers.range) {
+    const match = /^bytes=(\d+)-$/.exec(request.headers.range);
+    offset = match ? Number(match[1]) : body.length;
+    if (!Number.isSafeInteger(offset) || offset >= body.length) {
+      record.responseStatus = 416;
+      record.responseBytes = 0;
+      response.writeHead(416, { "content-range": `bytes */${body.length}` });
+      response.end();
+      return;
+    }
+    status = 206;
+    response.setHeader(
+      "content-range",
+      `bytes ${offset}-${body.length - 1}/${body.length}`,
+    );
+  }
+  record.responseStatus = status;
+  record.responseBytes = 0;
+  response.writeHead(status, {
+    "content-length": String(body.length - offset),
+    ...headers,
+  });
+  const limit =
+    fixture.disconnectAfterBytes === undefined
+      ? body.length
+      : Math.min(body.length, offset + fixture.disconnectAfterBytes);
+  const chunkBytes = fixture.chunkBytes ?? (body.length || 1);
+  while (offset < limit && !response.destroyed) {
+    const chunk = body.subarray(offset, Math.min(offset + chunkBytes, limit));
+    response.write(chunk);
+    record.responseBytes += chunk.length;
+    offset += chunk.length;
+    if (fixture.chunkDelayMs)
+      await new Promise<void>((resolve) => {
+        const done = () => {
+          clearTimeout(timer);
+          response.off("close", done);
+          resolve();
+        };
+        const timer = setTimeout(done, fixture.chunkDelayMs);
+        response.once("close", done);
+      });
+  }
+  if (fixture.disconnectAfterBytes !== undefined) response.destroy();
+  else response.end();
 };
 
 const isSensitiveHeader = (name: string): boolean =>
@@ -73,6 +148,7 @@ export const startFixtureServer = async (
 ): Promise<FixtureServer> => {
   const journal: FixtureRequest[] = [];
   const unmatched: FixtureRequest[] = [];
+  const occurrences = new Map<FixtureRoute, number>();
   const server = createServer(async (request, response) => {
     let bodyBytes = 0;
     for await (const chunk of request) {
@@ -118,7 +194,11 @@ export const startFixtureServer = async (
         candidate.path === requestPath,
     );
     if (route) {
-      respond(response, route.status, route.body, route.headers);
+      const index = occurrences.get(route) ?? 0;
+      occurrences.set(route, index + 1);
+      const fixture =
+        route.sequence?.[Math.min(index, route.sequence.length - 1)] ?? route;
+      await sendFixture(request, response, fixture, record);
       return;
     }
     unmatched.push(record);
@@ -162,6 +242,7 @@ export const startFixtureServer = async (
   return {
     origin: `http://127.0.0.1:${address.port}`,
     unmatchedRequests: () => unmatched,
+    requests: () => journal,
     close: async (artifactsDirectory) => {
       await new Promise<void>((resolve, reject) =>
         server.close((error) => (error ? reject(error) : resolve())),

--- a/apps/desktop/e2e/support/profile-fixtures.ts
+++ b/apps/desktop/e2e/support/profile-fixtures.ts
@@ -30,7 +30,7 @@ export const profilePayload = (modId: string): Buffer =>
     },
   ]);
 
-const fixtureMod = (modId: string, index: number): LocalMod => ({
+export const fixtureMod = (modId: string, index: number): LocalMod => ({
   id: modId,
   remoteId: modId,
   name: modId,

--- a/apps/desktop/e2e/support/scenarios.ts
+++ b/apps/desktop/e2e/support/scenarios.ts
@@ -2,29 +2,49 @@ export type ScenarioId =
   | "about-smoke"
   | "local-mod-lifecycle"
   | "profiles-pointer"
-  | "profiles-keyboard";
+  | "profiles-keyboard"
+  | "downloads-pause"
+  | "downloads-range"
+  | "downloads-cancel"
+  | "downloads-restart"
+  | "downloads-redirect"
+  | "downloads-auth"
+  | "downloads-corrupt"
+  | "downloads-variants";
 
 export const parseScenarioId = (value = "about-smoke"): ScenarioId => {
   if (
     value === "about-smoke" ||
     value === "local-mod-lifecycle" ||
     value === "profiles-pointer" ||
-    value === "profiles-keyboard"
+    value === "profiles-keyboard" ||
+    value === "downloads-pause" ||
+    value === "downloads-range" ||
+    value === "downloads-cancel" ||
+    value === "downloads-auth" ||
+    value === "downloads-corrupt" ||
+    value === "downloads-variants" ||
+    value === "downloads-restart" ||
+    value === "downloads-redirect"
   )
     return value;
   throw new Error(`Unsupported E2E case '${value}'`);
 };
 
 export const scenarioPhases = (scenario: ScenarioId): readonly string[] =>
-  scenario === "local-mod-lifecycle"
-    ? ["import-toggle", "restart-delete"]
-    : scenario === "about-smoke"
-      ? ["smoke"]
-      : ["reorder-switch", "restart-profiles"];
+  scenario.startsWith("downloads-")
+    ? ["transfer", "restart-download"]
+    : scenario === "local-mod-lifecycle"
+      ? ["import-toggle", "restart-delete"]
+      : scenario === "about-smoke"
+        ? ["smoke"]
+        : ["reorder-switch", "restart-profiles"];
 
 export const scenarioSpec = (scenario: ScenarioId): string =>
-  scenario === "local-mod-lifecycle"
-    ? "./specs/local-mod-lifecycle.e2e.ts"
-    : scenario === "about-smoke"
-      ? "./specs/about.e2e.ts"
-      : "./specs/profiles-ordering.e2e.ts";
+  scenario.startsWith("downloads-")
+    ? "./specs/downloads.e2e.ts"
+    : scenario === "local-mod-lifecycle"
+      ? "./specs/local-mod-lifecycle.e2e.ts"
+      : scenario === "about-smoke"
+        ? "./specs/about.e2e.ts"
+        : "./specs/profiles-ordering.e2e.ts";

--- a/apps/desktop/e2e/support/supervisor.ts
+++ b/apps/desktop/e2e/support/supervisor.ts
@@ -5,6 +5,11 @@ import type { DriverProvider } from "./contracts";
 import { scenarioPhases, type ScenarioId } from "./scenarios";
 import { writeSyntheticVpk } from "./vpk";
 import { prepareProfileWorld } from "./profile-fixtures";
+import {
+  assertDownloadNetwork,
+  downloadRoutes,
+  prepareDownloadWorld,
+} from "./download-fixtures";
 import { startFilesystemJournal } from "./filesystem-journal";
 import { startFixtureServer, type FixtureRoute } from "./fixture-server";
 import {
@@ -195,6 +200,9 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
   try {
     fixtureServer = await startFixtureServer([
       ...(options.fixtureRoutes ?? []),
+      ...(options.caseId.startsWith("downloads-")
+        ? downloadRoutes(options.caseId)
+        : []),
       ...(options.caseId.startsWith("profiles-")
         ? [
             {
@@ -214,6 +222,8 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
       fixtureOrigin: fixtureServer.origin,
     });
     const roots = world.configuration.roots;
+    if (options.caseId.startsWith("downloads-"))
+      await prepareDownloadWorld(world, fixtureServer.origin, options.caseId);
     if (options.caseId.startsWith("profiles-"))
       await prepareProfileWorld(world);
     if (options.caseId === "local-mod-lifecycle") {
@@ -292,6 +302,8 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
       )
         break;
     }
+    if (wdioResult.exitCode === 0 && options.caseId.startsWith("downloads-"))
+      assertDownloadNetwork(options.caseId, fixtureServer.requests());
     await closeResources();
     const after = Object.fromEntries(
       await Promise.all(

--- a/apps/desktop/src-tauri/src/download_manager/downloader.rs
+++ b/apps/desktop/src-tauri/src/download_manager/downloader.rs
@@ -29,6 +29,12 @@ pub fn validate_download_url(url: &str) -> Result<(), Error> {
 }
 
 fn is_allowed_download_url(url: &reqwest::Url) -> bool {
+  #[cfg(feature = "e2e-harness")]
+  if crate::runtime_environment::is_e2e_active() {
+    return crate::runtime_environment::current()
+      .e2e()
+      .is_some_and(|configuration| configuration.permits_download_url(url));
+  }
   if url.scheme() != "https" || !url.username().is_empty() || url.password().is_some() {
     return false;
   }
@@ -530,6 +536,8 @@ mod tests {
     assert!(validate_download_url("http://gamebanana.com/dl/1").is_err());
     assert!(validate_download_url("https://gamebanana.com.evil.test/dl/1").is_err());
     assert!(validate_download_url("https://user@gamebanana.com/dl/1").is_err());
+    assert!(validate_download_url("http://127.0.0.1:43199/files/mod.vpk").is_err());
+    assert!(validate_download_url("https://127.0.0.1:43199/files/mod.vpk").is_err());
   }
 
   #[tokio::test]

--- a/apps/desktop/src-tauri/src/runtime_environment.rs
+++ b/apps/desktop/src-tauri/src/runtime_environment.rs
@@ -230,6 +230,15 @@ impl E2eConfiguration {
     self.roots.app_data.join("state.json")
   }
 
+  #[cfg(feature = "e2e-harness")]
+  pub fn permits_download_url(&self, url: &reqwest::Url) -> bool {
+    url.username().is_empty()
+      && url.password().is_none()
+      && self.endpoints.iter().any(|endpoint| {
+        reqwest::Url::parse(&endpoint.origin).is_ok_and(|origin| origin.origin() == url.origin())
+      })
+  }
+
   pub fn endpoint(&self, service: ServiceName) -> &str {
     self
       .endpoints
@@ -596,6 +605,29 @@ mod tests {
       configuration.endpoint(ServiceName::DmmApi),
       "http://127.0.0.1:43199"
     );
+  }
+
+  #[cfg(feature = "e2e-harness")]
+  #[test]
+  fn download_urls_must_match_a_configured_fixture_origin() {
+    let world = test_world(|_| {});
+    let configuration = E2eConfiguration::from_file(&world.config_path).unwrap();
+    assert!(
+      configuration.permits_download_url(
+        &reqwest::Url::parse("http://127.0.0.1:43199/files/mod.vpk").unwrap()
+      )
+    );
+    for value in [
+      "http://127.0.0.1:43200/files/mod.vpk",
+      "https://127.0.0.1:43199/files/mod.vpk",
+      "http://user:password@127.0.0.1:43199/files/mod.vpk",
+      "https://gamebanana.com/mod.vpk",
+    ] {
+      assert!(
+        !configuration.permits_download_url(&reqwest::Url::parse(value).unwrap()),
+        "accepted {value}"
+      );
+    }
   }
 
   #[test]


### PR DESCRIPTION
Adds M4 download coverage, stacked on #709. Eight scenarios drive real Rust HTTP transfers through UI retry/pause/resume, then verify state and files in a fresh application process. They cover interrupted-transfer Range recovery, cancellation, restart while paused, 401 responses, corrupt payloads, blocked external redirects, and preserving a selected variant through retry. Each scenario starts from a failed download recipe with persisted selection; initial catalog selection is outside this slice. Cancellation invokes the existing Rust command because the current UI has no cancel control.

The fixture server now serves binary bodies, deterministic response sequences, paced chunks, deliberate disconnects, and Range responses, recording response status/bytes alongside requests. Independent oracles check exact cache contents, SHA-256 payloads, partial prefixes and metadata, addon state, and protected game/Steam files. UI retry purges stale data; connection recovery within a running process uses Range.

E2E builds permit only exact configured fixture origins for downloads and redirects. The exception is compile-gated, and ordinary builds retain their HTTPS trusted-host allowlist. No dependencies added.

Validation:
- All eight scenarios passed twice without retries: 16 fresh worlds, two app processes per world, zero unmatched requests. Final pass took 19.7–29.7 seconds per world.
- Existing smoke regression passed in 10.3 seconds.
- All 17 harness unit tests pass, including truncated binary responses, Range boundaries, wrong-variant bytes, and leftover partial files.
- Rust fixture-origin test passed with `e2e-harness`; ordinary-build trusted-host test passed with explicit loopback rejection.
- E2E app build, download doctor, E2E type check, root `pnpm check-types`, `pnpm lint:fix`, and `pnpm format:fix` pass. Lint reports 147 warnings and no errors.

AI Assistance: Used Codex to implement the harness coverage, fixture-origin restriction, and automated validation.

## Stack tracking

Tracked in #673 (PR 15 of 19). Based on #709. Followed by #711.

