### PR TITLE
test(desktop): cover filesystem recovery and crash boundaries

### DIFF
--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -64,7 +64,33 @@ Each world starts with a failed download record and persisted file selection, so
 
 The E2E-only download policy accepts exact configured fixture origins (including port and scheme) for initial requests and redirects. Ordinary builds retain the HTTPS trusted-host allowlist. The same downloader, checksum checks, staging files, pause gate, and cancellation logic run in both builds.
 
+## Filesystem recovery scenarios
+
+M5 runs with the same `e2e:test -- --case <case> --keep` command after `e2e:build`. Run these serially on Windows/Wry.
+
+| Case | Behavior checked |
+| --- | --- |
+| `filesystem-backup-replace` | Create and restore through Settings; restore original VPK order, manifest, and overwritten sentinel; remove a file added after backup |
+| `filesystem-backup-merge` | Restore the backup's colliding files and manifest while preserving a file added after backup |
+| `filesystem-lock` | Hold the third VPK with Windows `FileShare.None`; fail after staging an earlier VPK, prove exact rollback, release the handle, and retry |
+| `filesystem-collision` | A protected directory occupies the next destination filename; fail during placement, prove exact rollback, remove only the fixture obstruction, and retry |
+| `filesystem-shards` | Rotate 100 distinct installed payloads across the 99-file boundary; verify ownership of identically named slots in different shards and both game search paths |
+| `filesystem-crash-placed` | Abrupt exit after the first real placement, leaving two parked VPKs; a fresh process restores the original layout |
+| `filesystem-crash-committed` | Abrupt exit after the manifest is saved but before staging cleanup; a fresh process retains the committed layout |
+
+Backups use UI controls. Filesystem mutations use the existing `reorder_mods_by_remote_id` IPC command so each fault lands at a precise boundary; M3 covers the native ordering gestures. Restart uses the production snapshot/recovery path, then switches Beta → Alpha through the profile selector to exercise frontend reconciliation. The oracle checks persisted order, exact file inventories, distinct payload hashes, manifest slots and shards, protected Beta/Steam files, and game search paths. Backup sources must match the initial recipe and remain unchanged after restore and restart. Opening Settings normally creates an empty `cfg/autoexec.cfg`; this exact write is included in the backup cases' expected inventory.
+
+The compile-gated `e2e_faults` module only accepts a PID-bound arm file for the matching crash case in its owned world. It writes and syncs a checkpoint marker, then exits without running destructors. The supervisor verifies the marker's PID/run/profile, the exact stage/place/manifest journal, and the payloads still on disk. There is no crash hook in an ordinary build, no mocked core IPC, and no harness rewrite of a failed transaction's files or manifest.
+
+Ordinary M5 restarts close the main window through Tauri, wait for the process to exit, and verify the persisted profile store. WDIO's Windows teardown sends a terminating signal that can interrupt a store write during background hero detection; it is unsuitable for an ordinary restart. After proving process exit, the worker retires its dead WebDriver session so teardown does not send DELETE to the closed embedded server. Every phase still requires a zero WDIO exit status. Normal-exit evidence is checked again by the supervisor; timeouts, signals, missing markers, or failed assertions fail the run. Switching profiles creates `gameinfo.gi.bak`, which must match the initial gameinfo bytes exactly.
+
+Artifacts include `filesystem-baseline.json`, per-step `filesystem-*.json`, `filesystem-rollback.json`, `phase-completed-*.json`, backup evidence, and crash marker/journal/disk evidence. Lock handles are released in `finally`; the helper also has a bounded lifetime. Worlds with failures remain available for diagnosis. Synthetic profile archives contain no hero assets and are seeded as already indexed, keeping unrelated background discovery out of these scenarios.
+
+These cases cover reorder interruption at placement and manifest commit, rather than every possible write boundary. Interrupting a backup restore during its copy phase and simulating power-loss durability remain additional coverage opportunities.
+
 ## Qualification status
+
+All seven M5 cases passed repeated retry-free Windows/Wry worlds, with a fresh process for recovery and independent disk/store evidence. The final backup replace and merge cases each passed two consecutive worlds; the 100-mod shard case passed three consecutive worlds after fixing normal shutdown and preindexing the synthetic fixtures. Successful M5 worlds took approximately 20–26 seconds and had no unmatched fixture requests. These cases exposed two production defects that are fixed here: completed rollbacks left their transaction journal behind, and reorder bypassed the journal-aware manifest commit method. The Rust mod-manager suite passes all 122 tests; the harness suite passes 19 tests, including checks that reject wrong payloads, false shard ownership, unexpected files, and foreign/live crash markers.
 
 All eight M4 cases passed two consecutive retry-free Windows/Wry worlds each, including a new application process in every world. The final pass took approximately 20–30 seconds per world with no unmatched requests. Harness unit tests cover binary Range responses, truncated streams, wrong-variant bytes, and leftover partial files; Rust tests cover fixture-origin restrictions and the ordinary-build allowlist.
 
@@ -88,7 +114,7 @@ Native Windows dialogs are outside the webview DOM and cannot be driven by WebDr
 | M2: complete local-mod lifecycle | Implemented and validated on Windows/Wry | Drive a synthetic VPK through a narrowly scoped FlaUI native-picker helper, the real Rust parser, import/install, enable/disable, delete, and application restart | UI state, VPK manifest, persisted store, and independent file hashes agree after every step; the final world matches its expected restored state |
 | M3: profiles and ordering | Implemented and validated on Windows/Wry | Two-profile switching plus native pointer and keyboard reorder flows | Inactive profiles and protected files remain unchanged; order and profile state survive restart without mocked core IPC |
 | M4: downloads and network failures | Implemented and validated on Windows/Wry | Real Rust downloads against binary fixtures: selected-variant retries, Range resume, pause, cancel, corrupt payloads, authentication failures, redirects, and interrupted-process recovery | Every request matches the strict journal; unexpected traffic fails; partial files and state recover correctly |
-| M5: recovery and hostile filesystem cases | Planned | Backup replace/merge, interrupted mutations, shard boundaries, collisions, Windows locks, and crash barriers | Restart recovers retained worlds and the independent oracle proves restoration without normalizing unexpected writes |
+| M5: recovery and hostile filesystem cases | Implemented and validated on Windows/Wry | Backup replace/merge, interrupted mutations, shard boundaries, collisions, Windows locks, and crash barriers | Restart recovers retained worlds and the independent oracle proves restoration without normalizing unexpected writes |
 | M6: CI and release coverage | Planned | Serial Windows PR lane, broader nightly matrix, packaged-app/native smoke, and ordinary-release exclusion checks | Clean runners reproduce required flows and ordinary builds contain no harness server, capability, control channel, or fixture policy |
 
 Keep scenarios independent and small even when they share recipes. The final routine-development gate is a composed import/download → enable → profile switch → reorder → backup → modify → restore → restart journey, supported by focused tests for each operation and failure boundary.

--- a/apps/desktop/e2e/specs/filesystem.e2e.ts
+++ b/apps/desktop/e2e/specs/filesystem.e2e.ts
@@ -11,6 +11,7 @@ import {
   filesystemManifestSchema,
   filesystemPaths,
   fingerprint,
+  shardSlot,
 } from "../support/filesystem-oracle";
 import { collectFileInventory } from "../support/world";
 import { holdVpkLock } from "../support/windows-lock";
@@ -151,9 +152,7 @@ describe("filesystem recovery", () => {
         remoteId,
         status: "installed",
         installOrder: index,
-        installedVpks: [
-          `pak${String((index % 99) + 1).padStart(2, "0")}_dir.vpk`,
-        ],
+        installedVpks: [shardSlot(index).filename],
       }));
       assert.deepEqual(
         state.localMods.toSorted((a, b) => a.installOrder - b.installOrder),

--- a/apps/desktop/e2e/specs/filesystem.e2e.ts
+++ b/apps/desktop/e2e/specs/filesystem.e2e.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile, unlink, rmdir } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { $, browser, expect } from "@wdio/globals";
+import { z } from "zod";
+import { ALPHA } from "../support/profile-fixtures";
+import { filesystemModIds } from "../support/filesystem-fixtures";
+import {
+  assertFilesystemLayout,
+  filesystemManifestSchema,
+  filesystemPaths,
+  fingerprint,
+} from "../support/filesystem-oracle";
+import { collectFileInventory } from "../support/world";
+import { holdVpkLock } from "../support/windows-lock";
+import { readProfileState } from "../support/profile-oracle";
+import {
+  closeApplication,
+  retireClosedApplication,
+} from "../support/application-exit";
+
+const reorder = async (
+  world: string,
+  order: string[],
+  crash = false,
+): Promise<string | null> => {
+  const { alpha } = await filesystemPaths(world);
+  const manifest = filesystemManifestSchema.parse(
+    JSON.parse(await readFile(path.join(alpha, ".dmm.json"), "utf8")),
+  );
+  const data: Array<[string, string[], number]> = order.map((id, index) => [
+    id,
+    manifest.mods[id].currentVpks,
+    index,
+  ]);
+  return browser.execute(
+    async (folder, modOrderData, abrupt) => {
+      if (abrupt) {
+        window.setTimeout(() => {
+          void window.__TAURI_INTERNALS__.invoke("reorder_mods_by_remote_id", {
+            profileFolder: folder,
+            modOrderData,
+          });
+        }, 100);
+        return null;
+      }
+      try {
+        await window.__TAURI_INTERNALS__.invoke("reorder_mods_by_remote_id", {
+          profileFolder: folder,
+          modOrderData,
+        });
+        return null;
+      } catch (error) {
+        return JSON.stringify(error);
+      }
+    },
+    ALPHA.folder,
+    data,
+    crash,
+  );
+};
+
+const openBackups = async (): Promise<void> => {
+  await $('a[href="/settings"]').click();
+  const tab = await $("button=Backups");
+  await tab.scrollIntoView({ block: "center" });
+  await tab.click();
+  await $("button=Create Backup").waitForDisplayed();
+};
+
+describe("filesystem recovery", () => {
+  it("preserves owned payloads through a filesystem failure and fresh process", async () => {
+    const dismiss = await $("button=Got it!");
+    const unseenVersion = await browser.execute(
+      async () =>
+        localStorage.getItem("lastSeenVersion") !==
+        (await window.__TAURI_INTERNALS__.invoke<string>("plugin:app|version")),
+    );
+    if (unseenVersion) {
+      await dismiss.waitForDisplayed();
+      await dismiss.click();
+      await expect(dismiss).not.toBeDisplayed();
+    }
+    const runtime = await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<{
+        processId: number;
+        roots: { world: string };
+      }>("e2e_status"),
+    );
+    const world = runtime.roots.world;
+    const { configuration, citadel, alpha, artifacts } =
+      await filesystemPaths(world);
+    const caseId = configuration.caseId;
+    const original = filesystemModIds(caseId);
+    const changed = [...original.slice(1), original[0]];
+    const processFile = path.join(artifacts, "filesystem-process.json");
+    const isBackup = caseId.startsWith("filesystem-backup-");
+    const expectedOrder =
+      isBackup || caseId === "filesystem-crash-placed" ? original : changed;
+    const extras =
+      caseId === "filesystem-backup-merge"
+        ? {
+            [`addons/${ALPHA.folder}/after-backup.txt`]: fingerprint(
+              Buffer.from("Created after backup\n"),
+            ),
+          }
+        : {};
+
+    if (process.env.DMM_E2E_PHASE === "restart-filesystem") {
+      const prior = z
+        .object({ processId: z.number() })
+        .parse(JSON.parse(await readFile(processFile, "utf8")));
+      assert.notEqual(runtime.processId, prior.processId);
+      // The production snapshot command performs journal recovery on the launch path.
+      await browser.execute(
+        (folder) =>
+          window.__TAURI_INTERNALS__.invoke("get_profile_vpk_snapshot", {
+            profileFolder: folder,
+          }),
+        ALPHA.folder,
+      );
+      await assertFilesystemLayout(world, "restarted", expectedOrder, extras);
+      // Opening the profile selector and reactivating Alpha runs the normal frontend
+      // manifest reconciliation, including a commit that outlived its IPC response.
+      await $('a[href="/my-mods"]').click();
+      await $('button[aria-label="Active Profile"]').click();
+      await $(
+        '[role="switch"][aria-label="Activate E2E Beta profile"]',
+      ).click();
+      await browser.waitUntil(
+        async () =>
+          (await readProfileState(world)).activeProfileId !== ALPHA.id,
+      );
+      await browser.keys("Escape");
+      await $('button[aria-label="Active Profile"]').click();
+      await $(
+        '[role="switch"][aria-label="Activate E2E Alpha profile"]',
+      ).click();
+      await browser.waitUntil(async () => {
+        const state = await readProfileState(world);
+        return (
+          state.activeProfileId === ALPHA.id &&
+          state.localMods.find((mod) => mod.remoteId === expectedOrder[0])
+            ?.installOrder === 0
+        );
+      });
+      await browser.keys("Escape");
+      const state = await readProfileState(world);
+      const expectedMods = expectedOrder.map((remoteId, index) => ({
+        remoteId,
+        status: "installed",
+        installOrder: index,
+        installedVpks: [
+          `pak${String((index % 99) + 1).padStart(2, "0")}_dir.vpk`,
+        ],
+      }));
+      assert.deepEqual(
+        state.localMods.toSorted((a, b) => a.installOrder - b.installOrder),
+        expectedMods,
+      );
+      assert.deepEqual(
+        state.profiles[ALPHA.id].mods.toSorted(
+          (a, b) => a.installOrder - b.installOrder,
+        ),
+        expectedMods,
+      );
+      assert.deepEqual(
+        state.profiles[ALPHA.id].enabledMods,
+        Object.fromEntries(expectedOrder.map((id) => [id, { enabled: true }])),
+      );
+      await expect($(`[title="${expectedOrder[0]}"]`)).toBeDisplayed();
+      await assertFilesystemLayout(world, "reconciled", expectedOrder, extras);
+      await closeApplication(world, runtime.processId, original);
+      return;
+    }
+    assert.equal(process.env.DMM_E2E_PHASE, "mutate");
+    if (caseId !== "filesystem-collision")
+      await assertFilesystemLayout(world, "initial", original);
+    await writeFile(
+      processFile,
+      JSON.stringify({ processId: runtime.processId }),
+    );
+
+    if (caseId.startsWith("filesystem-crash-")) {
+      const point =
+        caseId === "filesystem-crash-placed" ? "placed" : "committed";
+      await writeFile(
+        path.join(artifacts, "crash-arm.txt"),
+        `${runtime.processId}:${point}`,
+      );
+      await reorder(world, changed, true);
+      // Poll disk without making another request to the deliberately dying webview.
+      for (let attempt = 0; attempt < 100; attempt++) {
+        try {
+          await readFile(path.join(artifacts, "crash-observed.json"));
+          await retireClosedApplication(runtime.processId);
+          return;
+        } catch (error) {
+          if (
+            !(error instanceof Error) ||
+            !("code" in error) ||
+            error.code !== "ENOENT"
+          )
+            throw error;
+        }
+        await setTimeout(100);
+      }
+      throw new Error("Armed transaction did not reach the crash checkpoint");
+    }
+
+    if (isBackup) {
+      await openBackups();
+      await $("button=Create Backup").click();
+      await $("button=Restore").waitForDisplayed();
+      const backups = await browser.execute(() =>
+        window.__TAURI_INTERNALS__.invoke<
+          Array<{ file_name: string; file_path: string; addons_count: number }>
+        >("list_addons_backups"),
+      );
+      assert.equal(backups.length, 1);
+      assert.equal(backups[0].addons_count, 5);
+      const backupPath = path.resolve(backups[0].file_path);
+      assert(
+        backupPath.startsWith(world + path.sep),
+        "Backup must remain in the owned world",
+      );
+      assert.equal(
+        backupPath,
+        path.join(citadel, "addons-backups", backups[0].file_name),
+      );
+      const backupBefore = await collectFileInventory(backupPath);
+      await writeFile(
+        path.join(artifacts, "filesystem-backup.json"),
+        JSON.stringify({
+          fileName: backups[0].file_name,
+          inventory: backupBefore,
+        }),
+      );
+      assert.equal(await reorder(world, changed), null);
+      await assertFilesystemLayout(world, "before-restore", changed);
+      await writeFile(
+        path.join(alpha, "protected.txt"),
+        "Changed after backup\n",
+      );
+      await writeFile(
+        path.join(alpha, "after-backup.txt"),
+        "Created after backup\n",
+      );
+      await $("button=Restore").click();
+      if (caseId === "filesystem-backup-merge")
+        await $('[role="dialog"]').$("#merge").click();
+      await $('[role="dialog"]').$("button=Restore").click();
+      await $(
+        '//*[@data-sonner-toast]//*[@data-title and normalize-space()="Backup restored successfully"]',
+      ).waitForDisplayed();
+      await assertFilesystemLayout(world, "restored", original, extras);
+      assert.deepEqual(
+        await collectFileInventory(backupPath),
+        backupBefore,
+        "Restore cannot mutate its source snapshot",
+      );
+    } else {
+      const before = await collectFileInventory(citadel);
+      if (caseId === "filesystem-lock" || caseId === "filesystem-collision") {
+        const release =
+          caseId === "filesystem-lock"
+            ? await holdVpkLock(world)
+            : async () => {};
+        let failure: string | null;
+        try {
+          failure = await reorder(world, changed);
+        } finally {
+          await release();
+        }
+        assert.match(
+          failure ?? "",
+          caseId === "filesystem-lock"
+            ? /os error 32|being used by another process/i
+            : /already exists/i,
+        );
+        assert.deepEqual(
+          await collectFileInventory(citadel),
+          before,
+          "Failure must restore every original file and manifest",
+        );
+        await writeFile(
+          path.join(artifacts, "filesystem-rollback.json"),
+          JSON.stringify({ failure, inventory: before }, null, 2),
+        );
+        if (caseId === "filesystem-collision") {
+          await unlink(path.join(alpha, "pak03_dir.vpk", "protected.txt"));
+          await rmdir(path.join(alpha, "pak03_dir.vpk"));
+        }
+      }
+      assert.equal(await reorder(world, changed), null);
+      await assertFilesystemLayout(world, "retry-succeeded", changed);
+    }
+    await closeApplication(world, runtime.processId, original);
+  });
+});

--- a/apps/desktop/e2e/support/application-exit.ts
+++ b/apps/desktop/e2e/support/application-exit.ts
@@ -1,0 +1,64 @@
+import { browser } from "@wdio/globals";
+import { setTimeout } from "node:timers/promises";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { filesystemPaths, processExists } from "./filesystem-oracle";
+import { readProfileState } from "./profile-oracle";
+import { ALPHA } from "./profile-fixtures";
+
+export const retireClosedApplication = async (pid: number): Promise<void> => {
+  for (let attempt = 0; attempt < 150; attempt++) {
+    if (!processExists(pid)) {
+      // The embedded server died with its app. Retire the client session so
+      // WDIO does not send DELETE to a server whose exit we just verified.
+      // @wdio/globals only proxies reads; update the injected instance itself.
+      globalThis.browser.sessionId = "";
+      assert.equal(browser.sessionId, "");
+      return;
+    }
+    await setTimeout(100);
+  }
+  throw new Error("Application did not exit");
+};
+
+export const closeApplication = async (
+  world: string,
+  pid: number,
+  modIds: string[],
+): Promise<void> => {
+  // Return the WebDriver response before closing its webview. Normal window
+  // close lets Tauri finish its exit-time store save; Windows SIGTERM does not.
+  await browser.execute(() => {
+    window.setTimeout(() => {
+      void window.__TAURI_INTERNALS__.invoke("plugin:window|close", {
+        label: "main",
+      });
+    }, 100);
+  });
+  await retireClosedApplication(pid);
+  const { configuration, artifacts } = await filesystemPaths(world);
+  const state = await readProfileState(world);
+  assert.equal(state.activeProfileId, ALPHA.id);
+  assert.deepEqual(
+    state.localMods.map((mod) => mod.remoteId).sort(),
+    modIds.toSorted(),
+  );
+  assert.deepEqual(
+    state.profiles[ALPHA.id].mods.map((mod) => mod.remoteId).sort(),
+    modIds.toSorted(),
+  );
+  const phase = process.env.DMM_E2E_PHASE;
+  assert(phase === "mutate" || phase === "restart-filesystem");
+  // Written only after every scenario assertion and the exit/store checks.
+  await writeFile(
+    path.join(artifacts, `phase-completed-${phase}.json`),
+    JSON.stringify({
+      processId: pid,
+      runId: configuration.runId,
+      caseId: configuration.caseId,
+      phase,
+      state,
+    }),
+  );
+};

--- a/apps/desktop/e2e/support/filesystem-fixtures.ts
+++ b/apps/desktop/e2e/support/filesystem-fixtures.ts
@@ -1,0 +1,43 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { ALPHA, ALPHA_MODS, prepareProfileWorld } from "./profile-fixtures";
+import { collectFileInventory, type CreatedWorld } from "./world";
+
+export const filesystemModIds = (caseId: string): string[] =>
+  caseId === "filesystem-shards"
+    ? Array.from({ length: 100 }, (_, index) => `local-boundary-${index}`)
+    : ALPHA_MODS;
+
+export const prepareFilesystemWorld = async (
+  world: CreatedWorld,
+): Promise<void> => {
+  const caseId = world.configuration.caseId;
+  await prepareProfileWorld(
+    world,
+    filesystemModIds(caseId),
+    caseId === "filesystem-collision" ? [1, 2, 4] : undefined,
+  );
+  const citadel = path.join(world.configuration.roots.game, "game", "citadel");
+  if (caseId === "filesystem-collision") {
+    const blocker = path.join(citadel, "addons", ALPHA.folder, "pak03_dir.vpk");
+    await mkdir(blocker);
+    await writeFile(
+      path.join(blocker, "protected.txt"),
+      "Destination collision sentinel\n",
+    );
+  }
+  await writeFile(
+    path.join(world.artifactsDirectory, "filesystem-baseline.json"),
+    JSON.stringify(
+      {
+        citadel: await collectFileInventory(citadel),
+        steam: await collectFileInventory(world.configuration.roots.steam),
+        steamHttpCache: await collectFileInventory(
+          world.configuration.roots.steamHttpCache,
+        ),
+      },
+      null,
+      2,
+    ),
+  );
+};

--- a/apps/desktop/e2e/support/filesystem-oracle.test.ts
+++ b/apps/desktop/e2e/support/filesystem-oracle.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, expect, it } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  prepareFilesystemWorld,
+  filesystemModIds,
+} from "./filesystem-fixtures";
+import {
+  assertFilesystemLayout,
+  filesystemPaths,
+  filesystemManifestSchema,
+  assertCrashEvidence,
+} from "./filesystem-oracle";
+import { createWorld, removeOwnedWorld } from "./world";
+
+const worlds: string[] = [];
+afterEach(async () => {
+  for (const world of worlds.splice(0)) await removeOwnedWorld(world);
+});
+
+it("rejects swapped shard payloads, false manifest ownership, and unexpected files", async () => {
+  const world = await createWorld({
+    runId: "unit-run",
+    caseId: "filesystem-shards",
+    attempt: 1,
+    fixtureOrigin: "http://127.0.0.1:43123",
+  });
+  worlds.push(world.directory);
+  await prepareFilesystemWorld(world);
+  const order = filesystemModIds("filesystem-shards");
+  const check = () => assertFilesystemLayout(world.directory, "unit", order);
+  await check();
+  const { alpha, citadel } = await filesystemPaths(world.directory);
+  const first = path.join(alpha, "pak01_dir.vpk");
+  const original = await readFile(first);
+  await writeFile(
+    first,
+    await readFile(
+      path.join(citadel, "addons2", path.basename(alpha), "pak01_dir.vpk"),
+    ),
+  );
+  await expect(check()).rejects.toThrow();
+  await writeFile(first, original);
+  const manifestPath = path.join(alpha, ".dmm.json");
+  const manifestBytes = await readFile(manifestPath);
+  const manifest = filesystemManifestSchema.parse(
+    JSON.parse(manifestBytes.toString()),
+  );
+  manifest.mods[order[99]].shard = 1;
+  await writeFile(manifestPath, JSON.stringify(manifest));
+  await expect(check()).rejects.toThrow();
+  await writeFile(manifestPath, manifestBytes);
+  await writeFile(path.join(citadel, "unexpected.txt"), "unexpected");
+  await expect(check()).rejects.toThrow();
+});
+
+it("cannot excuse a failed driver run with a marker from a foreign or live process", async () => {
+  const world = await createWorld({
+    runId: "unit-run",
+    caseId: "filesystem-crash-placed",
+    attempt: 1,
+    fixtureOrigin: "http://127.0.0.1:43123",
+  });
+  worlds.push(world.directory);
+  await prepareFilesystemWorld(world);
+  const { alpha, artifacts } = await filesystemPaths(world.directory);
+  await writeFile(
+    path.join(artifacts, "filesystem-process.json"),
+    JSON.stringify({ processId: 123 }),
+  );
+  await writeFile(
+    path.join(artifacts, "crash-observed.json"),
+    JSON.stringify({
+      processId: 124,
+      checkpoint: "placed",
+      profile: alpha,
+      runId: "unit-run",
+    }),
+  );
+  await expect(assertCrashEvidence(world.directory)).rejects.toThrow();
+  await writeFile(
+    path.join(artifacts, "filesystem-process.json"),
+    JSON.stringify({ processId: process.pid }),
+  );
+  await writeFile(
+    path.join(artifacts, "crash-observed.json"),
+    JSON.stringify({
+      processId: process.pid,
+      checkpoint: "placed",
+      profile: alpha,
+      runId: "unit-run",
+    }),
+  );
+  await expect(assertCrashEvidence(world.directory)).rejects.toThrow(
+    "The checkpoint process must have exited",
+  );
+});

--- a/apps/desktop/e2e/support/filesystem-oracle.ts
+++ b/apps/desktop/e2e/support/filesystem-oracle.ts
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { ALPHA, ALPHA_MODS, profilePayload } from "./profile-fixtures";
+import { assertOwnedWorld, collectFileInventory } from "./world";
+import { readProfileState } from "./profile-oracle";
+
+export const processExists = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !("code" in error) ||
+      error.code !== "ESRCH"
+    )
+      throw error;
+    return false;
+  }
+};
+
+export const assertNormalExit = async (
+  world: string,
+  phase: string,
+): Promise<void> => {
+  const { configuration, artifacts } = await filesystemPaths(world);
+  const completed = z
+    .object({
+      processId: z.number().int().positive(),
+      runId: z.string(),
+      caseId: z.string(),
+      phase: z.string(),
+      state: z.json(),
+    })
+    .parse(
+      JSON.parse(
+        await readFile(
+          path.join(artifacts, `phase-completed-${phase}.json`),
+          "utf8",
+        ),
+      ),
+    );
+  assert.equal(completed.runId, configuration.runId);
+  assert.equal(completed.caseId, configuration.caseId);
+  assert.equal(completed.phase, phase);
+  assert.equal(
+    processExists(completed.processId),
+    false,
+    "Normal close must finish before restart",
+  );
+  assert.deepEqual(
+    await readProfileState(world),
+    completed.state,
+    "Store remains intact after normal exit",
+  );
+};
+
+const inventorySchema = z.record(z.string(), z.string());
+const backupEvidenceSchema = z.object({
+  fileName: z.string().regex(/^addons-backup-[\d_-]+$/),
+  inventory: inventorySchema,
+});
+export const filesystemManifestSchema = z.object({
+  version: z.literal(3),
+  mods: z.record(
+    z.string(),
+    z.object({
+      enabled: z.boolean(),
+      order: z.number(),
+      shard: z.number(),
+      currentVpks: z.array(z.string()),
+      disabledVpks: z.array(z.string()),
+      originalVpkNames: z.array(z.string()),
+    }),
+  ),
+});
+export const fingerprint = (bytes: Buffer): string =>
+  `${bytes.length}:${createHash("sha256").update(bytes).digest("hex")}`;
+
+const protectedFiles = (files: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(files).filter(
+      ([name]) => name.split("/")[1] !== ALPHA.folder && name !== "gameinfo.gi",
+    ),
+  );
+
+export const filesystemPaths = async (world: string) => {
+  const { configuration } = await assertOwnedWorld(world);
+  const citadel = path.join(configuration.roots.game, "game", "citadel");
+  return {
+    configuration,
+    citadel,
+    alpha: path.join(citadel, "addons", ALPHA.folder),
+    artifacts: path.join(world, "artifacts"),
+  };
+};
+
+export const assertFilesystemLayout = async (
+  world: string,
+  step: string,
+  order: string[],
+  extras: Record<string, string> = {},
+): Promise<Record<string, string>> => {
+  const { configuration, citadel, alpha, artifacts } =
+    await filesystemPaths(world);
+  const manifest = filesystemManifestSchema.parse(
+    JSON.parse(await readFile(path.join(alpha, ".dmm.json"), "utf8")),
+  );
+  assert.deepEqual(Object.keys(manifest.mods).sort(), order.toSorted());
+  const inventory = await collectFileInventory(citadel);
+  const expected: Record<string, string> = {
+    [`addons/${ALPHA.folder}/protected.txt`]: fingerprint(
+      Buffer.from(`Protected ${ALPHA.name}\n`),
+    ),
+    ...extras,
+  };
+  for (const [index, id] of order.entries()) {
+    const shard = Math.floor(index / 99) + 1;
+    const filename = `pak${String((index % 99) + 1).padStart(2, "0")}_dir.vpk`;
+    assert.deepEqual(manifest.mods[id], {
+      enabled: true,
+      order: index,
+      shard,
+      currentVpks: [filename],
+      disabledVpks: [],
+      originalVpkNames: [`${id}.vpk`],
+    });
+    expected[
+      `${shard === 1 ? "addons" : `addons${shard}`}/${ALPHA.folder}/${filename}`
+    ] = fingerprint(profilePayload(id));
+  }
+  const alphaFiles = Object.fromEntries(
+    Object.entries(inventory).filter(
+      ([name]) =>
+        name.split("/")[1] === ALPHA.folder &&
+        name !== `addons/${ALPHA.folder}/.dmm.json`,
+    ),
+  );
+  assert.deepEqual(
+    alphaFiles,
+    expected,
+    "Exact active profile files and hashes",
+  );
+  const initial = z
+    .object({
+      citadel: inventorySchema,
+      steam: inventorySchema,
+      steamHttpCache: inventorySchema,
+    })
+    .parse(
+      JSON.parse(
+        await readFile(
+          path.join(artifacts, "filesystem-baseline.json"),
+          "utf8",
+        ),
+      ),
+    );
+  const expectedProtected = protectedFiles(initial.citadel);
+  if (step === "reconciled")
+    expectedProtected["gameinfo.gi.bak"] = initial.citadel["gameinfo.gi"];
+  if (
+    configuration.caseId.startsWith("filesystem-backup-") &&
+    step !== "initial"
+  ) {
+    const backup = backupEvidenceSchema.parse(
+      JSON.parse(
+        await readFile(path.join(artifacts, "filesystem-backup.json"), "utf8"),
+      ),
+    );
+    const expectedBackup = Object.fromEntries(
+      Object.entries(initial.citadel).filter(([name]) =>
+        /^addons\d*\//.test(name),
+      ),
+    );
+    assert.deepEqual(
+      backup.inventory,
+      expectedBackup,
+      "Backup is an exact snapshot of all addon profiles",
+    );
+    assert.deepEqual(
+      await collectFileInventory(
+        path.join(citadel, "addons-backups", backup.fileName),
+      ),
+      expectedBackup,
+      "Backup source remains unchanged",
+    );
+    for (const [name, hash] of Object.entries(expectedBackup))
+      expectedProtected[`addons-backups/${backup.fileName}/${name}`] = hash;
+    // Opening Settings initializes the real autoexec manager with an empty file.
+    expectedProtected["cfg/autoexec.cfg"] = fingerprint(Buffer.alloc(0));
+  }
+  assert.deepEqual(protectedFiles(inventory), expectedProtected);
+  assert.deepEqual(
+    await collectFileInventory(configuration.roots.steam),
+    initial.steam,
+  );
+  assert.deepEqual(
+    await collectFileInventory(configuration.roots.steamHttpCache),
+    initial.steamHttpCache,
+  );
+  const gameinfo = await readFile(path.join(citadel, "gameinfo.gi"), "utf8");
+  assert.deepEqual(
+    [...gameinfo.matchAll(/^\s*Game\s+(citadel\/addons\S*)\s*$/gm)].map(
+      (match) => match[1],
+    ),
+    Array.from(
+      { length: Math.ceil(order.length / 99) },
+      (_, index) =>
+        `citadel/${index === 0 ? "addons" : `addons${index + 1}`}/${ALPHA.folder}`,
+    ),
+  );
+  assert(
+    !Object.keys(inventory).some((name) =>
+      /\.dmm-(reorder|restore-staging)|\.pending$|\.dmm\.json\.tmp$/.test(name),
+    ),
+    "No transaction debris",
+  );
+  await writeFile(
+    path.join(artifacts, `filesystem-${step}.json`),
+    JSON.stringify({ manifest, inventory }, null, 2),
+  );
+  return inventory;
+};
+
+export const assertCrashEvidence = async (world: string): Promise<void> => {
+  const { configuration, alpha, artifacts } = await filesystemPaths(world);
+  const checkpoint =
+    configuration.caseId === "filesystem-crash-placed" ? "placed" : "committed";
+  const expected = z
+    .object({ processId: z.number().int().positive() })
+    .parse(
+      JSON.parse(
+        await readFile(path.join(artifacts, "filesystem-process.json"), "utf8"),
+      ),
+    );
+  const marker = z
+    .object({
+      processId: z.number(),
+      checkpoint: z.string(),
+      profile: z.string(),
+      runId: z.string(),
+    })
+    .parse(
+      JSON.parse(
+        await readFile(path.join(artifacts, "crash-observed.json"), "utf8"),
+      ),
+    );
+  assert.deepEqual(marker, {
+    ...expected,
+    checkpoint,
+    profile: alpha,
+    runId: configuration.runId,
+  });
+  assert.equal(
+    processExists(marker.processId),
+    false,
+    "The checkpoint process must have exited",
+  );
+  const journal = (
+    await readFile(
+      path.join(alpha, ".dmm-reorder", ".transaction.jsonl"),
+      "utf8",
+    )
+  )
+    .trimEnd()
+    .split("\n")
+    .map((line) => z.record(z.string(), z.json()).parse(JSON.parse(line)));
+  const expectedEvents = [
+    ...[2, 3, 1].map((slot) => ({
+      event: "stage",
+      original: `pak0${slot}_dir.vpk`,
+    })),
+    ...[2, 3, 1]
+      .slice(0, checkpoint === "placed" ? 1 : 3)
+      .map((slot, index) => ({
+        event: "place",
+        original: `pak0${slot}_dir.vpk`,
+        destination: `pak0${index + 1}_dir.vpk`,
+      })),
+  ];
+  assert.deepEqual(journal.slice(0, expectedEvents.length), expectedEvents);
+  assert.equal(
+    journal.length,
+    expectedEvents.length + (checkpoint === "committed" ? 1 : 0),
+  );
+  const manifest = filesystemManifestSchema.parse(
+    JSON.parse(await readFile(path.join(alpha, ".dmm.json"), "utf8")),
+  );
+  if (checkpoint === "committed") {
+    const event = z
+      .object({
+        event: z.literal("manifest"),
+        manifest: filesystemManifestSchema,
+      })
+      .parse(journal.at(-1));
+    assert.deepEqual(event.manifest, manifest);
+  }
+  const order =
+    checkpoint === "placed"
+      ? ALPHA_MODS
+      : [ALPHA_MODS[1], ALPHA_MODS[2], ALPHA_MODS[0]];
+  for (const [index, id] of order.entries()) {
+    assert.equal(manifest.mods[id].order, index);
+    assert.deepEqual(manifest.mods[id].currentVpks, [
+      `pak0${index + 1}_dir.vpk`,
+    ]);
+  }
+  const inventory = await collectFileInventory(alpha);
+  const payloads = Object.fromEntries(
+    Object.entries(inventory).filter(
+      ([name]) => name.endsWith(".vpk") || name.endsWith(".pending"),
+    ),
+  );
+  assert.deepEqual(
+    payloads,
+    checkpoint === "placed"
+      ? {
+          "pak01_dir.vpk": fingerprint(profilePayload(ALPHA_MODS[1])),
+          ".dmm-reorder/s1__pak01_dir.vpk.pending": fingerprint(
+            profilePayload(ALPHA_MODS[0]),
+          ),
+          ".dmm-reorder/s1__pak03_dir.vpk.pending": fingerprint(
+            profilePayload(ALPHA_MODS[2]),
+          ),
+        }
+      : Object.fromEntries(
+          order.map((id, index) => [
+            `pak0${index + 1}_dir.vpk`,
+            fingerprint(profilePayload(id)),
+          ]),
+        ),
+  );
+  await writeFile(
+    path.join(artifacts, "filesystem-crash-disk.json"),
+    JSON.stringify(
+      { marker, journal, inventory: await collectFileInventory(alpha) },
+      null,
+      2,
+    ),
+  );
+};

--- a/apps/desktop/e2e/support/filesystem-oracle.ts
+++ b/apps/desktop/e2e/support/filesystem-oracle.ts
@@ -7,6 +7,11 @@ import { ALPHA, ALPHA_MODS, profilePayload } from "./profile-fixtures";
 import { assertOwnedWorld, collectFileInventory } from "./world";
 import { readProfileState } from "./profile-oracle";
 
+export const shardSlot = (index: number) => ({
+  shard: Math.floor(index / 99) + 1,
+  filename: `pak${String((index % 99) + 1).padStart(2, "0")}_dir.vpk`,
+});
+
 export const processExists = (pid: number): boolean => {
   try {
     process.kill(pid, 0);
@@ -118,8 +123,7 @@ export const assertFilesystemLayout = async (
     ...extras,
   };
   for (const [index, id] of order.entries()) {
-    const shard = Math.floor(index / 99) + 1;
-    const filename = `pak${String((index % 99) + 1).padStart(2, "0")}_dir.vpk`;
+    const { shard, filename } = shardSlot(index);
     assert.deepEqual(manifest.mods[id], {
       enabled: true,
       order: index,
@@ -335,10 +339,6 @@ export const assertCrashEvidence = async (world: string): Promise<void> => {
   );
   await writeFile(
     path.join(artifacts, "filesystem-crash-disk.json"),
-    JSON.stringify(
-      { marker, journal, inventory: await collectFileInventory(alpha) },
-      null,
-      2,
-    ),
+    JSON.stringify({ marker, journal, inventory }, null, 2),
   );
 };

--- a/apps/desktop/e2e/support/profile-fixtures.ts
+++ b/apps/desktop/e2e/support/profile-fixtures.ts
@@ -41,6 +41,8 @@ export const fixtureMod = (modId: string, index: number): LocalMod => ({
   author: "E2E",
   downloadable: false,
   tags: [],
+  dependencies: [],
+  metadata: null,
   images: [],
   hero: null,
   isAudio: false,

--- a/apps/desktop/e2e/support/profile-fixtures.ts
+++ b/apps/desktop/e2e/support/profile-fixtures.ts
@@ -62,10 +62,16 @@ export const fixtureMod = (modId: string, index: number): LocalMod => ({
   status: ModStatus.Installed,
   installedVpks: [`pak${String(index + 1).padStart(2, "0")}_dir.vpk`],
   installOrder: index,
+  // These synthetic script archives contain no hero assets. Model them as
+  // already indexed so unrelated background scans cannot race a test restart.
+  detectedHero: null,
+  usesCriticalPaths: false,
 });
 
 export const prepareProfileWorld = async (
   world: CreatedWorld,
+  alphaModIds: string[] = ALPHA_MODS,
+  alphaSlots?: number[],
 ): Promise<void> => {
   const profiles: Record<
     string,
@@ -93,7 +99,7 @@ export const prepareProfileWorld = async (
     },
   };
   for (const { profile, modIds } of [
-    { profile: ALPHA, modIds: ALPHA_MODS },
+    { profile: ALPHA, modIds: alphaModIds },
     { profile: BETA, modIds: BETA_MODS },
   ]) {
     const directory = path.join(
@@ -104,7 +110,14 @@ export const prepareProfileWorld = async (
       profile.folder,
     );
     await mkdir(directory, { recursive: true });
-    const mods = modIds.map(fixtureMod);
+    const mods = modIds.map((id, index) =>
+      fixtureMod(
+        id,
+        profile.id === ALPHA.id && alphaSlots
+          ? alphaSlots[index] - 1
+          : index % 99,
+      ),
+    );
     const entries: Record<
       string,
       {
@@ -117,15 +130,28 @@ export const prepareProfileWorld = async (
       }
     > = {};
     for (const [index, mod] of mods.entries()) {
-      const filename = `pak${String(index + 1).padStart(2, "0")}_dir.vpk`;
+      mod.installOrder = index;
+      const filename = `pak${String(profile.id === ALPHA.id && alphaSlots ? alphaSlots[index] : (index % 99) + 1).padStart(2, "0")}_dir.vpk`;
+      const shard = Math.floor(index / 99) + 1;
+      const shardDirectory =
+        shard === 1
+          ? directory
+          : path.join(
+              world.configuration.roots.game,
+              "game",
+              "citadel",
+              `addons${shard}`,
+              profile.folder,
+            );
+      await mkdir(shardDirectory, { recursive: true });
       await writeFile(
-        path.join(directory, filename),
+        path.join(shardDirectory, filename),
         profilePayload(mod.remoteId),
       );
       entries[mod.remoteId] = {
         enabled: true,
         order: index,
-        shard: 1,
+        shard,
         currentVpks: [filename],
         disabledVpks: [],
         originalVpkNames: [`${mod.remoteId}.vpk`],
@@ -185,7 +211,7 @@ export const prepareProfileWorld = async (
     gameinfo,
     (await readFile(gameinfo, "utf8")).replace(
       "Game citadel",
-      `Game citadel/addons/${ALPHA.folder}\n      Game citadel`,
+      `${Array.from({ length: Math.ceil(alphaModIds.length / 99) }, (_, index) => `Game citadel/${index === 0 ? "addons" : `addons${index + 1}`}/${ALPHA.folder}`).join("\n      ")}\n      Game citadel`,
     ),
   );
   await writeFile(

--- a/apps/desktop/e2e/support/scenarios.ts
+++ b/apps/desktop/e2e/support/scenarios.ts
@@ -1,4 +1,11 @@
 export type ScenarioId =
+  | "filesystem-backup-replace"
+  | "filesystem-backup-merge"
+  | "filesystem-lock"
+  | "filesystem-collision"
+  | "filesystem-shards"
+  | "filesystem-crash-placed"
+  | "filesystem-crash-committed"
   | "about-smoke"
   | "local-mod-lifecycle"
   | "profiles-pointer"
@@ -14,6 +21,13 @@ export type ScenarioId =
 
 export const parseScenarioId = (value = "about-smoke"): ScenarioId => {
   if (
+    value === "filesystem-backup-replace" ||
+    value === "filesystem-backup-merge" ||
+    value === "filesystem-lock" ||
+    value === "filesystem-collision" ||
+    value === "filesystem-shards" ||
+    value === "filesystem-crash-placed" ||
+    value === "filesystem-crash-committed" ||
     value === "about-smoke" ||
     value === "local-mod-lifecycle" ||
     value === "profiles-pointer" ||
@@ -32,19 +46,23 @@ export const parseScenarioId = (value = "about-smoke"): ScenarioId => {
 };
 
 export const scenarioPhases = (scenario: ScenarioId): readonly string[] =>
-  scenario.startsWith("downloads-")
-    ? ["transfer", "restart-download"]
-    : scenario === "local-mod-lifecycle"
-      ? ["import-toggle", "restart-delete"]
-      : scenario === "about-smoke"
-        ? ["smoke"]
-        : ["reorder-switch", "restart-profiles"];
+  scenario.startsWith("filesystem-")
+    ? ["mutate", "restart-filesystem"]
+    : scenario.startsWith("downloads-")
+      ? ["transfer", "restart-download"]
+      : scenario === "local-mod-lifecycle"
+        ? ["import-toggle", "restart-delete"]
+        : scenario === "about-smoke"
+          ? ["smoke"]
+          : ["reorder-switch", "restart-profiles"];
 
 export const scenarioSpec = (scenario: ScenarioId): string =>
-  scenario.startsWith("downloads-")
-    ? "./specs/downloads.e2e.ts"
-    : scenario === "local-mod-lifecycle"
-      ? "./specs/local-mod-lifecycle.e2e.ts"
-      : scenario === "about-smoke"
-        ? "./specs/about.e2e.ts"
-        : "./specs/profiles-ordering.e2e.ts";
+  scenario.startsWith("filesystem-")
+    ? "./specs/filesystem.e2e.ts"
+    : scenario.startsWith("downloads-")
+      ? "./specs/downloads.e2e.ts"
+      : scenario === "local-mod-lifecycle"
+        ? "./specs/local-mod-lifecycle.e2e.ts"
+        : scenario === "about-smoke"
+          ? "./specs/about.e2e.ts"
+          : "./specs/profiles-ordering.e2e.ts";

--- a/apps/desktop/e2e/support/supervisor.ts
+++ b/apps/desktop/e2e/support/supervisor.ts
@@ -5,6 +5,8 @@ import type { DriverProvider } from "./contracts";
 import { scenarioPhases, type ScenarioId } from "./scenarios";
 import { writeSyntheticVpk } from "./vpk";
 import { prepareProfileWorld } from "./profile-fixtures";
+import { prepareFilesystemWorld } from "./filesystem-fixtures";
+import { assertCrashEvidence, assertNormalExit } from "./filesystem-oracle";
 import {
   assertDownloadNetwork,
   downloadRoutes,
@@ -157,7 +159,10 @@ const spawnWdio = async (
     process.removeListener("SIGTERM", onTermination);
   }
   await writeFile(outputPath, output);
-  return { exitCode: supervisorTerminated ? 1 : exitCode, output };
+  return {
+    exitCode: supervisorTerminated ? 1 : exitCode,
+    output,
+  };
 };
 
 const terminateProcessTree = (child: ChildProcess): void => {
@@ -203,7 +208,8 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
       ...(options.caseId.startsWith("downloads-")
         ? downloadRoutes(options.caseId)
         : []),
-      ...(options.caseId.startsWith("profiles-")
+      ...(options.caseId.startsWith("profiles-") ||
+      options.caseId.startsWith("filesystem-")
         ? [
             {
               method: "GET",
@@ -222,6 +228,8 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
       fixtureOrigin: fixtureServer.origin,
     });
     const roots = world.configuration.roots;
+    if (options.caseId.startsWith("filesystem-"))
+      await prepareFilesystemWorld(world);
     if (options.caseId.startsWith("downloads-"))
       await prepareDownloadWorld(world, fixtureServer.origin, options.caseId);
     if (options.caseId.startsWith("profiles-"))
@@ -292,6 +300,18 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
         },
         path.join(world.artifactsDirectory, `wdio-${phase}.log`),
       );
+      if (
+        phaseResult.exitCode === 0 &&
+        phase === "mutate" &&
+        options.caseId.startsWith("filesystem-crash-")
+      ) {
+        await assertCrashEvidence(world.directory);
+      } else if (
+        phaseResult.exitCode === 0 &&
+        options.caseId.startsWith("filesystem-")
+      ) {
+        await assertNormalExit(world.directory, phase);
+      }
       wdioResult = {
         exitCode: phaseResult.exitCode,
         output: wdioResult.output + phaseResult.output,

--- a/apps/desktop/e2e/support/windows-lock.ts
+++ b/apps/desktop/e2e/support/windows-lock.ts
@@ -19,12 +19,18 @@ export const holdVpkLock = async (
     [
       "-NoProfile",
       "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
       "-File",
       script,
       path.join(alpha, "pak03_dir.vpk"),
     ],
     { windowsHide: true, stdio: ["ignore", "pipe", "pipe"] },
   );
+  let stderr = "";
+  child.stderr.on("data", (data: Buffer) => {
+    stderr += data.toString();
+  });
   const closed = new Promise<void>((resolve) =>
     child.once("close", () => resolve()),
   );
@@ -47,9 +53,9 @@ export const holdVpkLock = async (
         clearTimeout(deadline);
         reject(error);
       });
-      child.once("exit", (code) => {
+      child.once("close", (code) => {
         clearTimeout(deadline);
-        reject(new Error(`Windows lock exited: ${code}`));
+        reject(new Error(`Windows lock exited: ${code}\n${stderr.trim()}`));
       });
     });
     return release;

--- a/apps/desktop/e2e/support/windows-lock.ts
+++ b/apps/desktop/e2e/support/windows-lock.ts
@@ -1,0 +1,60 @@
+import { spawn } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { filesystemPaths } from "./filesystem-oracle";
+
+export const holdVpkLock = async (
+  world: string,
+): Promise<() => Promise<void>> => {
+  if (process.platform !== "win32")
+    throw new Error("The lock scenario requires Windows");
+  const { alpha, artifacts } = await filesystemPaths(world);
+  const script = path.join(artifacts, "hold-vpk-lock.ps1");
+  await writeFile(
+    script,
+    'param([string]$FilePath)\n$ErrorActionPreference = "Stop"\n$stream = [IO.File]::Open($FilePath, [IO.FileMode]::Open, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)\ntry { [Console]::WriteLine("locked"); Start-Sleep -Seconds 25 } finally { $stream.Dispose() }\n',
+  );
+  const child = spawn(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-File",
+      script,
+      path.join(alpha, "pak03_dir.vpk"),
+    ],
+    { windowsHide: true, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const closed = new Promise<void>((resolve) =>
+    child.once("close", () => resolve()),
+  );
+  const release = async (): Promise<void> => {
+    if (child.exitCode === null) child.kill();
+    await closed;
+  };
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const deadline = setTimeout(
+        () => reject(new Error("Windows lock readiness timed out")),
+        10_000,
+      );
+      child.stdout.once("data", (data: Buffer) => {
+        clearTimeout(deadline);
+        if (data.toString().trim() === "locked") resolve();
+        else reject(new Error("Unexpected Windows lock readiness response"));
+      });
+      child.once("error", (error) => {
+        clearTimeout(deadline);
+        reject(error);
+      });
+      child.once("exit", (code) => {
+        clearTimeout(deadline);
+        reject(new Error(`Windows lock exited: ${code}`));
+      });
+    });
+    return release;
+  } catch (error) {
+    await release();
+    throw error;
+  }
+};

--- a/apps/desktop/src-tauri/src/e2e_faults.rs
+++ b/apps/desktop/src-tauri/src/e2e_faults.rs
@@ -1,0 +1,49 @@
+//! Abrupt transaction exits, available only in the isolated E2E binary.
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+pub fn checkpoint(name: &str, profile: &Path) -> std::io::Result<()> {
+  let Some(configuration) = crate::runtime_environment::current().e2e() else {
+    return Ok(());
+  };
+  let expected = match configuration.case_id.as_str() {
+    "filesystem-crash-placed" => "placed",
+    "filesystem-crash-committed" => "committed",
+    _ => return Ok(()),
+  };
+  if name != expected {
+    return Ok(());
+  }
+  let artifacts = configuration.roots.world.join("artifacts");
+  let arm = artifacts.join("crash-arm.txt");
+  if !arm.exists() {
+    return Ok(());
+  }
+  for path in [profile, artifacts.as_path(), arm.as_path()] {
+    crate::runtime_environment::ensure_e2e_managed_path(path).map_err(std::io::Error::other)?;
+  }
+  if fs::read_to_string(&arm)? != format!("{}:{name}", std::process::id()) {
+    return Err(std::io::Error::other(
+      "E2E crash arm does not match this process",
+    ));
+  }
+  fs::remove_file(arm)?;
+  let mut evidence = fs::OpenOptions::new()
+    .write(true)
+    .create_new(true)
+    .open(artifacts.join("crash-observed.json"))?;
+  serde_json::to_writer(
+    &mut evidence,
+    &serde_json::json!({
+      "processId": std::process::id(),
+      "checkpoint": name,
+      "profile": profile,
+      "runId": configuration.run_id,
+    }),
+  )?;
+  evidence.flush()?;
+  evidence.sync_all()?;
+  // Do not unwind: Drop would roll the transaction back and mask crash recovery.
+  std::process::exit(86);
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,8 @@ mod commands;
 mod deep_link;
 mod download_manager;
 mod dropped_mod_file;
+#[cfg(feature = "e2e-harness")]
+mod e2e_faults;
 mod errors;
 mod flatpak;
 mod forge_bridge;

--- a/apps/desktop/src-tauri/src/mod_manager/manager/reorder.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/manager/reorder.rs
@@ -326,10 +326,7 @@ impl ModManager {
         &mapped_mod_ids,
         &pending.value().orphan_renames,
       );
-      if let Err(error) = manifest.save(base) {
-        return Err(pending.rollback(error));
-      }
-      placements.extend(pending.commit().placements);
+      placements.extend(pending.commit_manifest(manifest, base)?.placements);
     }
 
     for placement in &placements {

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
@@ -582,7 +582,7 @@ impl VpkSnapshot {
   }
 
   /// Take a copy of `path` if it exists, and mark it for removal on rollback
-  /// either way — so a path that is about to be created is restored by deleting
+  /// either way â€” so a path that is about to be created is restored by deleting
   /// it, and one that is about to be overwritten is restored from the copy.
   pub fn capture(&mut self, path: &Path) -> Result<(), Error> {
     if !self.touched.insert(path.to_path_buf()) || !path.is_file() {
@@ -718,24 +718,6 @@ mod tests {
     assert_eq!(fs::read(original).unwrap(), b"vpk");
     assert!(!placed.exists());
     assert!(!base.join(".test-staging").exists());
-  }
-
-  #[test]
-  fn incomplete_rollback_retains_journal_and_payload_for_recovery() {
-    let temp = tempfile::tempdir().unwrap();
-    let base = base(&temp);
-    let original = base.join("pak01_dir.vpk");
-    fs::write(&original, b"retained").unwrap();
-    let mut staging = VpkStaging::claim(&base, ".test-staging").unwrap();
-    let parked = staging.stage(&base, &original).unwrap();
-    fs::create_dir(&original).unwrap();
-    fs::write(original.join("blocker"), b"protected").unwrap();
-
-    let error = staging.rollback(Error::InvalidInput("interrupted".into()));
-    assert!(matches!(error, Error::RollbackFailed(_)));
-    assert_eq!(fs::read(&parked).unwrap(), b"retained");
-    assert!(base.join(".test-staging").join(JOURNAL_FILENAME).is_file());
-    assert_eq!(fs::read(original.join("blocker")).unwrap(), b"protected");
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
@@ -320,6 +320,8 @@ impl VpkStaging {
     })?;
     fs::rename(staged, destination)?;
     self.files[index].current = destination.to_path_buf();
+    #[cfg(feature = "e2e-harness")]
+    crate::e2e_faults::checkpoint("placed", &self.base)?;
     Ok(())
   }
 
@@ -496,6 +498,8 @@ impl<T> PendingVpkOperation<T> {
     if let Err(error) = manifest.save(addons_path) {
       return Err(self.rollback(error));
     }
+    #[cfg(feature = "e2e-harness")]
+    crate::e2e_faults::checkpoint("committed", addons_path)?;
     Ok(self.commit())
   }
 
@@ -713,6 +717,25 @@ mod tests {
     assert!(matches!(error, Error::InvalidInput(_)));
     assert_eq!(fs::read(original).unwrap(), b"vpk");
     assert!(!placed.exists());
+    assert!(!base.join(".test-staging").exists());
+  }
+
+  #[test]
+  fn incomplete_rollback_retains_journal_and_payload_for_recovery() {
+    let temp = tempfile::tempdir().unwrap();
+    let base = base(&temp);
+    let original = base.join("pak01_dir.vpk");
+    fs::write(&original, b"retained").unwrap();
+    let mut staging = VpkStaging::claim(&base, ".test-staging").unwrap();
+    let parked = staging.stage(&base, &original).unwrap();
+    fs::create_dir(&original).unwrap();
+    fs::write(original.join("blocker"), b"protected").unwrap();
+
+    let error = staging.rollback(Error::InvalidInput("interrupted".into()));
+    assert!(matches!(error, Error::RollbackFailed(_)));
+    assert_eq!(fs::read(&parked).unwrap(), b"retained");
+    assert!(base.join(".test-staging").join(JOURNAL_FILENAME).is_file());
+    assert_eq!(fs::read(original.join("blocker")).unwrap(), b"protected");
   }
 
   #[test]

--- a/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
+++ b/apps/desktop/src-tauri/src/mod_manager/vpk_manager/staging.rs
@@ -488,9 +488,22 @@ impl<T> PendingVpkOperation<T> {
   }
 
   pub fn commit_manifest(
+    self,
+    manifest: &ProfileVpkManifest,
+    addons_path: &Path,
+  ) -> Result<T, Error> {
+    self.commit_manifest_with_checkpoint(manifest, addons_path, || {
+      #[cfg(feature = "e2e-harness")]
+      crate::e2e_faults::checkpoint("committed", addons_path)?;
+      Ok(())
+    })
+  }
+
+  fn commit_manifest_with_checkpoint(
     mut self,
     manifest: &ProfileVpkManifest,
     addons_path: &Path,
+    checkpoint: impl FnOnce() -> Result<(), Error>,
   ) -> Result<T, Error> {
     if let PendingGuard::Staging(staging) = &mut self.guard {
       staging.prepare_manifest_commit(manifest)?;
@@ -498,9 +511,11 @@ impl<T> PendingVpkOperation<T> {
     if let Err(error) = manifest.save(addons_path) {
       return Err(self.rollback(error));
     }
-    #[cfg(feature = "e2e-harness")]
-    crate::e2e_faults::checkpoint("committed", addons_path)?;
-    Ok(self.commit())
+    let checkpoint_result = checkpoint();
+    // The manifest is durable. A returning checkpoint error must not undo its files.
+    let value = self.commit();
+    checkpoint_result?;
+    Ok(value)
   }
 
   pub fn rollback(self, original_error: Error) -> Error {
@@ -801,6 +816,31 @@ mod tests {
 
     assert!(!original.exists());
     assert!(!base.join(".test-staging").exists());
+  }
+
+  #[test]
+  fn checkpoint_error_preserves_files_after_manifest_commit() {
+    let temp = tempfile::tempdir().unwrap();
+    let base = base(&temp);
+    let original = base.join("pak01_dir.vpk");
+    fs::write(&original, b"vpk").unwrap();
+    let mut staging = VpkStaging::claim(&base, ".test-staging").unwrap();
+    staging.stage(&base, &original).unwrap();
+    let manifest = ProfileVpkManifest::default();
+    let pending = PendingVpkOperation::with_staging((), staging);
+
+    let error = pending
+      .commit_manifest_with_checkpoint(&manifest, base.path(), || {
+        Err(Error::InvalidInput("crash marker write failed".to_string()))
+      })
+      .unwrap_err();
+
+    assert!(matches!(error, Error::InvalidInput(_)));
+    assert!(!original.exists(), "committed deletion must not roll back");
+    assert!(!base.join(".test-staging").exists());
+    let saved: ProfileVpkManifest =
+      serde_json::from_slice(&fs::read(base.join(".dmm.json")).unwrap()).unwrap();
+    assert_eq!(saved, manifest);
   }
 
   #[test]


### PR DESCRIPTION
Stacked on #710 (`feature/tauri-e2e-download-recovery`). Implements M5 of the Tauri E2E roadmap.

## What changed

Adds seven isolated Windows/Wry cases covering backup replace/merge, Windows file locks, destination collisions, the 99-file shard boundary, and abrupt exits during placement and after manifest commit. Each case restarts the real application and verifies payload hashes, manifest ownership, protected files, and persisted profile state after UI reconciliation.

The cases exposed two production bugs: successful rollback left its transaction journal behind, and reorder saved the manifest without recording its commit in the journal. Rollback now removes the journal only after restoration succeeds, and reorder uses the existing journal-aware commit method. Incomplete rollback retains recovery evidence and payloads.

Crash checkpoints are compiled only with `e2e-harness`, require a PID-bound arm in the owned world, and exit without running rollback destructors. The supervisor independently checks the journal and disk state. Ordinary M5 restarts use Tauri window close and verify the store after process exit; workers retire the dead driver session without suppressing test failures. Synthetic profile fixtures are preindexed to keep unrelated hero scans out of filesystem tests.

## Validation

- Repeated retry-free native runs of all seven M5 cases, with a new application process in every world and no unmatched network requests. Final backup replace/merge qualification: two consecutive worlds each; final 100-mod shard qualification: three consecutive worlds.
- Native profile pointer ordering and local-mod lifecycle regressions passed.
- 19 harness unit tests and 122 Rust mod-manager tests passed. Oracle tests reject swapped bytes, false shard ownership, unexpected files, and foreign/live crash markers; Rust tests verify failed rollback retains its journal and payload.
- Root `pnpm lint:fix`, `pnpm format:fix`, and `pnpm check-types`; E2E type checks; E2E build; `cargo clippy --all-targets --features e2e-harness` passed. Lint/compiler warnings remain. The full Rust formatter check reports pre-existing formatting differences in the stack.

The README records coverage and limits. Mid-copy backup restore interruption and power-loss durability remain additional coverage opportunities; M6 is the CI/release milestone.

## AI assistance

Implementation, tests, and this description were prepared with OpenAI Codex. Human review is required before merge.

## Stack tracking

Tracked in #673 (PR 16 of 19). Based on #710. Followed by #712.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added seven Windows/Wry filesystem recovery E2E scenarios for the desktop app.
- Covered backup replacement and merging, file locks, filename collisions, 99-file shard rotation, and crash recovery.
- Improved rollback safety by retaining transaction journals and payloads until restoration succeeds.
- Recorded manifest commits through the journal-aware reorder transaction.
- Added PID-bound crash checkpoints for the `e2e-harness` build.
- Added filesystem fixtures, oracle checks, process lifecycle helpers, and Windows lock support.
- Updated the E2E README with coverage, qualification status, and limitations.

## Validation

- Ran all seven native Windows/Wry scenarios repeatedly.
- Ran profile, local-mod, harness, Rust, lint, formatting, type-check, build, and Clippy validation.

Only the desktop app and its E2E support code changed. No API, bot, www, shared package, database, Tauri plugin, or Rust FFI changes were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->