### PR TITLE
test(desktop): cover GameBanana downloads and installation

### DIFF
--- a/.changeset/quiet-otters-select.md
+++ b/.changeset/quiet-otters-select.md
@@ -1,0 +1,5 @@
+---
+"@deadlock-mods/desktop": patch
+---
+
+Show only selected VPKs in the mod page's installed files list.

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -64,6 +64,20 @@ Each world starts with a failed download record and persisted file selection, so
 
 The E2E-only download policy accepts exact configured fixture origins (including port and scheme) for initial requests and redirects. Ordinary builds retain the HTTPS trusted-host allowlist. The same downloader, checksum checks, staging files, pause gate, and cancellation logic run in both builds.
 
+## GameBanana catalog installation scenarios
+
+These cases start with an empty library and use the real catalog UI, GameBanana provider, downloader, archive extraction, and installation commands. Only HTTP responses are mocked. Run each with `pnpm --filter @deadlock-mods/desktop e2e:test -- --case <case> --keep` after `e2e:build`.
+
+| Case | Behavior checked |
+| --- | --- |
+| `gamebanana-single` | Browse a synthetic GameBanana submission, download its ZIP, and enable its single VPK |
+| `gamebanana-multifile` | Choose two of three downloads, install both VPKs, and show their respective source archives; the unselected download has no route |
+| `gamebanana-variants` | Download an archive with common, blue, and red VPKs; deselect red and install only common and blue |
+
+Every case checks the mod page's Installed Files list and Active Mod files section, closes the application normally, and repeats the rendering and disk checks in a new process. Installed filenames, archive groups, selected downloads, profile state, manifest entries, and exact VPK bytes must agree. Network assertions require the real provider metadata endpoints and exactly the selected payload requests, with no download repeated on restart. Screenshots, DOM snapshots, and `catalog-*.json` disk evidence are retained with `--keep`.
+
+The variant scenario caught an Installed Files rendering bug: the stored file tree retains unselected options, and the page previously displayed all of them. The display now groups only selected files, including the per-archive file counts.
+
 ## Filesystem recovery scenarios
 
 M5 runs with the same `e2e:test -- --case <case> --keep` command after `e2e:build`. Run these serially on Windows/Wry.
@@ -113,7 +127,7 @@ Native Windows dialogs are outside the webview DOM and cannot be driven by WebDr
 | M1: safe harness foundation | Complete in PR #707 (replaces #706) | Compile-gated runtime configuration, owned worlds, root routing, fixture network, filesystem oracle, synthetic VPK builder, supervisor, doctor, and embedded-driver qualification | Ten retry-free fresh UI/IPC runs pass; intentional timeout cleanup succeeds; production cannot activate E2E mode |
 | M2: complete local-mod lifecycle | Implemented and validated on Windows/Wry | Drive a synthetic VPK through a narrowly scoped FlaUI native-picker helper, the real Rust parser, import/install, enable/disable, delete, and application restart | UI state, VPK manifest, persisted store, and independent file hashes agree after every step; the final world matches its expected restored state |
 | M3: profiles and ordering | Implemented and validated on Windows/Wry | Two-profile switching plus native pointer and keyboard reorder flows | Inactive profiles and protected files remain unchanged; order and profile state survive restart without mocked core IPC |
-| M4: downloads and network failures | Implemented and validated on Windows/Wry | Real Rust downloads against binary fixtures: selected-variant retries, Range resume, pause, cancel, corrupt payloads, authentication failures, redirects, and interrupted-process recovery | Every request matches the strict journal; unexpected traffic fails; partial files and state recover correctly |
+| M4: downloads and network failures | Implemented and validated on Windows/Wry | GameBanana catalog downloads and installation, multi-file and VPK variant selection, installed-file rendering, selected-variant retries, Range resume, pause, cancel, corrupt payloads, authentication failures, redirects, and interrupted-process recovery | Every request matches the strict journal; unexpected traffic fails; installed files and selections survive restart; partial files and state recover correctly |
 | M5: recovery and hostile filesystem cases | Implemented and validated on Windows/Wry | Backup replace/merge, interrupted mutations, shard boundaries, collisions, Windows locks, and crash barriers | Restart recovers retained worlds and the independent oracle proves restoration without normalizing unexpected writes |
 | M6: CI and release coverage | Planned | Serial Windows PR lane, broader nightly matrix, packaged-app/native smoke, and ordinary-release exclusion checks | Clean runners reproduce required flows and ordinary builds contain no harness server, capability, control channel, or fixture policy |
 

--- a/apps/desktop/e2e/specs/gamebanana.e2e.ts
+++ b/apps/desktop/e2e/specs/gamebanana.e2e.ts
@@ -1,0 +1,169 @@
+import { $, browser, expect } from "@wdio/globals";
+import assert from "node:assert/strict";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { retireClosedApplication } from "../support/application-exit";
+import {
+  catalogRecipe,
+  CATALOG_MOD_NAME,
+  installedCatalogFiles,
+} from "../support/gamebanana-fixtures";
+import {
+  assertCatalogDisk,
+  readCatalogState,
+} from "../support/gamebanana-oracle";
+
+describe("GameBanana catalog installation", () => {
+  it("renders exactly the installed files and preserves them in a new process", async () => {
+    const scenario = process.env.DMM_E2E_CASE_ID ?? "";
+    const phase = process.env.DMM_E2E_PHASE;
+    assert(phase === "catalog-install" || phase === "restart-catalog");
+    const runtime = await browser.execute(() =>
+      window.__TAURI_INTERNALS__.invoke<{
+        processId: number;
+        roots: { world: string };
+      }>("e2e_status"),
+    );
+    const world = runtime.roots.world;
+    const checkpoint = path.join(world, "artifacts", "catalog-process.json");
+    const unseenVersion = await browser.execute(
+      async () =>
+        localStorage.getItem("lastSeenVersion") !==
+        (await window.__TAURI_INTERNALS__.invoke<string>("plugin:app|version")),
+    );
+    if (unseenVersion) {
+      const dismiss = await $("button=Got it!");
+      await dismiss.waitForDisplayed();
+      await dismiss.click();
+      await expect(dismiss).not.toBeDisplayed();
+    }
+    await $('a[href="/mods"]').click();
+    const card = await $(`[title="${CATALOG_MOD_NAME}"]`);
+    await card.waitForDisplayed();
+    await card.click();
+    await expect(
+      $(`//div[normalize-space()="${CATALOG_MOD_NAME}"]`),
+    ).toBeDisplayed();
+    if (phase === "catalog-install") {
+      assert.deepEqual((await readCatalogState(world)).localMods, []);
+      await $('button[aria-label="Download Mod"]').click();
+      const recipe = catalogRecipe(scenario);
+      if (recipe.length > 1) {
+        const dialog = await $('[role="dialog"]');
+        await dialog.waitForDisplayed();
+        await expect(dialog.$("button=Download Selected")).toBeDisabled();
+        for (const archive of recipe) {
+          const checkbox = await dialog.$(`[id="file-${archive.name}"]`);
+          await expect(checkbox).toHaveAttribute("aria-checked", "false");
+          if (archive.selected) await checkbox.click();
+        }
+        await dialog.$("button=Download Selected").click();
+        await expect(dialog).not.toBeDisplayed();
+      }
+      const toggle = await $('[role="switch"]');
+      await toggle.waitForClickable();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+      await toggle.click();
+      if (scenario === "gamebanana-variants") {
+        const dialog = await $('[role="dialog"]');
+        await dialog.waitForDisplayed();
+        const red = await dialog.$(
+          './/button[.//div[normalize-space()="red.vpk"]]',
+        );
+        await red.click();
+        await expect(red.$('[role="checkbox"]')).toHaveAttribute(
+          "aria-checked",
+          "false",
+        );
+        await dialog.$("button=Install Selected").click();
+        await expect(dialog).not.toBeDisplayed();
+      }
+      await writeFile(
+        checkpoint,
+        JSON.stringify({ processId: runtime.processId }),
+      );
+    } else {
+      const previous = z
+        .object({ processId: z.number() })
+        .parse(JSON.parse(await readFile(checkpoint, "utf8")));
+      assert.notEqual(runtime.processId, previous.processId);
+    }
+    await expect($('[role="switch"]')).toHaveAttribute("aria-checked", "true");
+    const installed = await $(
+      '//*[normalize-space()="Installed Files"]/parent::div/parent::div',
+    );
+    await browser.execute(
+      (element: HTMLElement) =>
+        element.scrollIntoView({ block: "center", behavior: "instant" }),
+      installed,
+    );
+    await expect(installed).toBeDisplayed();
+    const names = await installed
+      .$$(".font-mono")
+      .map((element) => element.getText());
+    assert.deepEqual(names.sort(), installedCatalogFiles(scenario));
+    for (const archive of catalogRecipe(scenario).filter(
+      (item) => item.selected,
+    )) {
+      const group = await installed.$(
+        `.//span[normalize-space()="${archive.name}"]/parent::div/parent::div`,
+      );
+      const expectedFiles = archive.files.filter((name) =>
+        installedCatalogFiles(scenario).includes(name),
+      );
+      assert.deepEqual(
+        (
+          await group.$$(".font-mono").map((element) => element.getText())
+        ).sort(),
+        expectedFiles.sort(),
+      );
+      await expect(group).toHaveText(
+        expect.stringContaining(
+          `${expectedFiles.length} file${expectedFiles.length === 1 ? "" : "s"}`,
+        ),
+      );
+    }
+    const active = await $(
+      '//*[normalize-space()="Active Mod files"]/parent::div/parent::div',
+    );
+    await browser.execute(
+      (element: HTMLElement) =>
+        element.scrollIntoView({ block: "center", behavior: "instant" }),
+      active,
+    );
+    await expect(active).toBeDisplayed();
+    const activeNames = await active
+      .$$(".font-mono")
+      .map((element) => element.getText());
+    assert.equal(activeNames.length, installedCatalogFiles(scenario).length);
+    await browser.execute(
+      (element: HTMLElement) =>
+        element.scrollIntoView({ block: "center", behavior: "instant" }),
+      installed,
+    );
+    await browser.waitUntil(() =>
+      installed.isDisplayed({ withinViewport: true }),
+    );
+    await browser.saveScreenshot(
+      path.join(world, "artifacts", `catalog-${phase}.png`),
+    );
+    await writeFile(
+      path.join(world, "artifacts", `catalog-${phase}.html`),
+      await browser.getPageSource(),
+    );
+    await browser.execute(() => {
+      window.setTimeout(() => {
+        void window.__TAURI_INTERNALS__.invoke("plugin:window|close", {
+          label: "main",
+        });
+      }, 100);
+    });
+    await retireClosedApplication(runtime.processId);
+    await assertCatalogDisk(world, scenario, phase);
+    assert.deepEqual(
+      activeNames.sort(),
+      (await readCatalogState(world)).localMods[0].installedVpks?.toSorted(),
+    );
+  });
+});

--- a/apps/desktop/e2e/support/fixture-server.ts
+++ b/apps/desktop/e2e/support/fixture-server.ts
@@ -29,6 +29,7 @@ export type FixtureResponse = {
 export type FixtureRoute = FixtureResponse & {
   method: string;
   path: string;
+  query?: Record<string, string>;
   sequence?: readonly FixtureResponse[];
 };
 
@@ -144,8 +145,11 @@ const respond = (
 };
 
 export const startFixtureServer = async (
-  routes: readonly FixtureRoute[] = [],
+  recipe:
+    | readonly FixtureRoute[]
+    | ((origin: string) => readonly FixtureRoute[]) = [],
 ): Promise<FixtureServer> => {
+  let routes: readonly FixtureRoute[] = [];
   const journal: FixtureRequest[] = [];
   const unmatched: FixtureRequest[] = [];
   const occurrences = new Map<FixtureRoute, number>();
@@ -186,12 +190,14 @@ export const startFixtureServer = async (
       );
       return;
     }
-    const requestPath = new URL(request.url ?? "/", "http://127.0.0.1")
-      .pathname;
+    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
     const route = routes.find(
       (candidate) =>
         candidate.method.toUpperCase() === record.method.toUpperCase() &&
-        candidate.path === requestPath,
+        candidate.path === requestUrl.pathname &&
+        Object.entries(candidate.query ?? {}).every(([key, value]) =>
+          requestUrl.searchParams.getAll(key).includes(value),
+        ),
     );
     if (route) {
       const index = occurrences.get(route) ?? 0;
@@ -239,8 +245,10 @@ export const startFixtureServer = async (
   if (address === null || typeof address === "string") {
     throw new Error("Fixture server did not bind a TCP port");
   }
+  const origin = `http://127.0.0.1:${address.port}`;
+  routes = typeof recipe === "function" ? recipe(origin) : recipe;
   return {
-    origin: `http://127.0.0.1:${address.port}`,
+    origin,
     unmatchedRequests: () => unmatched,
     requests: () => journal,
     close: async (artifactsDirectory) => {

--- a/apps/desktop/e2e/support/gamebanana-fixtures.test.ts
+++ b/apps/desktop/e2e/support/gamebanana-fixtures.test.ts
@@ -1,0 +1,66 @@
+import { expect, it } from "bun:test";
+import JSZip from "jszip";
+import { z } from "zod";
+import {
+  assertCatalogNetwork,
+  catalogVpk,
+  createCatalogRoutes,
+} from "./gamebanana-fixtures";
+import { startFixtureServer } from "./fixture-server";
+
+it("serves origin-bound GameBanana files, separates bulk queries, and rejects an unselected download", async () => {
+  const server = await startFixtureServer(
+    await createCatalogRoutes("gamebanana-multifile"),
+  );
+  try {
+    const profile = await fetch(
+      `${server.origin}/apiv11/Mod/900001/ProfilePage`,
+    );
+    const parsed = z
+      .object({ _aFiles: z.array(z.object({ _sDownloadUrl: z.string() })) })
+      .parse(await profile.json());
+    const download = await fetch(parsed._aFiles[0]._sDownloadUrl);
+    const zip = await JSZip.loadAsync(await download.arrayBuffer());
+    expect(await zip.file("base.vpk")?.async("nodebuffer")).toEqual(
+      catalogVpk("base.vpk"),
+    );
+    const hydration = await fetch(
+      `${server.origin}/apiv11/Core/Item/Data?fields[]=name`,
+    );
+    const updates = await fetch(
+      `${server.origin}/apiv11/Core/Item/Data?fields[]=Url().sProfileUrl()`,
+    );
+    expect(await hydration.text()).not.toEqual(await updates.text());
+    const rejected = await fetch(parsed._aFiles[2]._sDownloadUrl);
+    expect(rejected.status).toBe(501);
+    await rejected.text();
+    expect(server.unmatchedRequests()).toHaveLength(1);
+    expect(() =>
+      assertCatalogNetwork("gamebanana-multifile", server.requests()),
+    ).toThrow();
+  } finally {
+    await server.close();
+  }
+});
+
+it("requires exactly the chosen archive downloads and actual provider metadata requests", async () => {
+  const server = await startFixtureServer(
+    await createCatalogRoutes("gamebanana-single"),
+  );
+  try {
+    for (const endpoint of [
+      "/apiv11/Mod/Index",
+      "/apiv11/Mod/900001/ProfilePage",
+      "/apiv11/Mod/900001/DownloadPage",
+      "/dl/910001",
+    ])
+      await (await fetch(`${server.origin}${endpoint}`)).arrayBuffer();
+    assertCatalogNetwork("gamebanana-single", server.requests());
+    await (await fetch(`${server.origin}/dl/910001`)).arrayBuffer();
+    expect(() =>
+      assertCatalogNetwork("gamebanana-single", server.requests()),
+    ).toThrow();
+  } finally {
+    await server.close();
+  }
+});

--- a/apps/desktop/e2e/support/gamebanana-fixtures.ts
+++ b/apps/desktop/e2e/support/gamebanana-fixtures.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import JSZip from "jszip";
+import type { FixtureRequest, FixtureRoute } from "./fixture-server";
+import { buildSyntheticVpk } from "./vpk";
+
+export const CATALOG_MOD_ID = "900001";
+export const CATALOG_MOD_NAME = "E2E GameBanana Mod";
+const timestamp = 1_780_000_000;
+
+export const catalogRecipe = (scenario: string) => {
+  if (scenario === "gamebanana-single")
+    return [
+      { id: 910001, name: "base.zip", files: ["base.vpk"], selected: true },
+    ];
+  if (scenario === "gamebanana-multifile")
+    return [
+      { id: 910001, name: "base.zip", files: ["base.vpk"], selected: true },
+      {
+        id: 910002,
+        name: "effects.zip",
+        files: ["effects.vpk"],
+        selected: true,
+      },
+      {
+        id: 910003,
+        name: "alternate.zip",
+        files: ["alternate.vpk"],
+        selected: false,
+      },
+    ];
+  if (scenario === "gamebanana-variants")
+    return [
+      {
+        id: 910001,
+        name: "variants.zip",
+        files: ["common.vpk", "blue.vpk", "red.vpk"],
+        selected: true,
+      },
+    ];
+  throw new Error(`Unsupported catalog scenario '${scenario}'`);
+};
+
+export const catalogVpk = (name: string): Buffer =>
+  buildSyntheticVpk([
+    {
+      path: "scripts/e2e-catalog.txt",
+      contents: `GameBanana fixture: ${name}\n`,
+    },
+  ]);
+
+export const installedCatalogFiles = (scenario: string): string[] =>
+  catalogRecipe(scenario)
+    .filter((archive) => archive.selected)
+    .flatMap((archive) => archive.files)
+    .filter((name) => name !== "red.vpk")
+    .sort();
+
+export const createCatalogRoutes = async (scenario: string) => {
+  const archives = await Promise.all(
+    catalogRecipe(scenario).map(async (recipe) => {
+      const zip = new JSZip();
+      for (const name of recipe.files)
+        zip.file(name, catalogVpk(name), {
+          date: new Date("2020-01-01T00:00:00Z"),
+        });
+      return {
+        ...recipe,
+        body: await zip.generateAsync({
+          type: "nodebuffer",
+          compression: "STORE",
+        }),
+      };
+    }),
+  );
+  return (origin: string): FixtureRoute[] => {
+    const files = archives.map((archive) => ({
+      _idRow: archive.id,
+      _sFile: archive.name,
+      _nFilesize: archive.body.length,
+      _sDownloadUrl: `${origin}/dl/${archive.id}`,
+      _tsDateAdded: timestamp,
+      _sMd5Checksum: createHash("md5").update(archive.body).digest("hex"),
+    }));
+    const profile = {
+      _idRow: Number(CATALOG_MOD_ID),
+      _sModelName: "Mod",
+      _sName: CATALOG_MOD_NAME,
+      _sProfileUrl: `https://gamebanana.com/mods/${CATALOG_MOD_ID}`,
+      _tsDateAdded: timestamp,
+      _tsDateModified: timestamp,
+      _bHasFiles: true,
+      _aSubmitter: { _sName: "E2E Author" },
+      _aRootCategory: { _sName: "Skins" },
+      _aCategory: { _sName: "Skins" },
+      _sText: "Synthetic catalog installation fixture.",
+      _aFiles: files,
+    };
+    const json = (path: string, body: string): FixtureRoute => ({
+      method: "GET",
+      path,
+      status: 200,
+      body,
+    });
+    return [
+      json(
+        "/apiv11/Mod/Index",
+        JSON.stringify({
+          _aMetadata: { _nRecordCount: 1, _nPerpage: 50, _bIsComplete: true },
+          _aRecords: [profile],
+        }),
+      ),
+      json(
+        `/apiv11/Mod/${CATALOG_MOD_ID}/ProfilePage`,
+        JSON.stringify(profile),
+      ),
+      json(
+        `/apiv11/Mod/${CATALOG_MOD_ID}/DownloadPage`,
+        JSON.stringify({ _aFiles: files }),
+      ),
+      {
+        ...json(
+          "/apiv11/Core/Item/Data",
+          JSON.stringify([
+            [
+              CATALOG_MOD_NAME,
+              0,
+              "Skins",
+              "Skins",
+              false,
+              profile._sText,
+              profile._sText,
+            ],
+          ]),
+        ),
+        query: { "fields[]": "name" },
+      },
+      {
+        ...json(
+          "/apiv11/Core/Item/Data",
+          JSON.stringify([profile._sProfileUrl, timestamp, files]),
+        ),
+        query: { "fields[]": "Url().sProfileUrl()" },
+      },
+      json("/apiv11/Util/Fileservers", '{"_aRecords":[]}'),
+      json(
+        `/api/v2/reports/mod/${CATALOG_MOD_ID}/counts`,
+        '{"total":0,"open":0,"resolved":0,"dismissed":0}',
+      ),
+      ...archives
+        .filter((archive) => archive.selected)
+        .map((archive) => ({
+          method: "GET",
+          path: `/dl/${archive.id}`,
+          status: 200,
+          body: archive.body,
+        })),
+    ];
+  };
+};
+
+export const assertCatalogNetwork = (
+  scenario: string,
+  requests: readonly FixtureRequest[],
+): void => {
+  assert.deepEqual(
+    requests
+      .filter((request) => request.url.startsWith("/dl/"))
+      .map((request) => ({ path: request.url, status: request.responseStatus }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+    catalogRecipe(scenario)
+      .filter((archive) => archive.selected)
+      .map((archive) => ({ path: `/dl/${archive.id}`, status: 200 })),
+  );
+  for (const endpoint of [
+    "/apiv11/Mod/Index",
+    `/apiv11/Mod/${CATALOG_MOD_ID}/ProfilePage`,
+    `/apiv11/Mod/${CATALOG_MOD_ID}/DownloadPage`,
+  ])
+    assert(
+      requests.some(
+        (request) =>
+          request.url.split("?")[0] === endpoint &&
+          request.responseStatus === 200,
+      ),
+      `Missing real provider request: ${endpoint}`,
+    );
+};

--- a/apps/desktop/e2e/support/gamebanana-oracle.test.ts
+++ b/apps/desktop/e2e/support/gamebanana-oracle.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, expect, it } from "bun:test";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { assertCatalogDisk } from "./gamebanana-oracle";
+import {
+  catalogVpk,
+  CATALOG_MOD_ID,
+  CATALOG_MOD_NAME,
+} from "./gamebanana-fixtures";
+import { collectFileInventory, createWorld, removeOwnedWorld } from "./world";
+
+const worlds: string[] = [];
+afterEach(async () => {
+  for (const world of worlds.splice(0)) await removeOwnedWorld(world);
+});
+
+it("rejects wrong variant bytes and extra installed files even when UI state says installed", async () => {
+  const world = await createWorld({
+    runId: "catalog-oracle",
+    caseId: "gamebanana-single",
+    attempt: 1,
+    fixtureOrigin: "http://127.0.0.1:43123",
+  });
+  worlds.push(world.directory);
+  const { roots } = world.configuration;
+  await writeFile(
+    path.join(world.artifactsDirectory, "files-before.json"),
+    JSON.stringify({
+      game: await collectFileInventory(roots.game),
+      steam: await collectFileInventory(roots.steam),
+      steamHttpCache: await collectFileInventory(roots.steamHttpCache),
+    }),
+  );
+  await writeFile(
+    path.join(roots.appData, "state.json"),
+    JSON.stringify({
+      "local-config": JSON.stringify({
+        state: {
+          activeProfileId: "default",
+          profiles: {
+            default: {
+              folderName: null,
+              enabledMods: { [CATALOG_MOD_ID]: { enabled: true } },
+            },
+          },
+          localMods: [
+            {
+              remoteId: CATALOG_MOD_ID,
+              name: CATALOG_MOD_NAME,
+              status: "installed",
+              selectedDownloads: [{ name: "base.zip" }],
+              installedVpks: ["pak01_dir.vpk"],
+              installedFileTree: {
+                files: [
+                  {
+                    name: "base.vpk",
+                    path: "base.vpk",
+                    archive_name: "base.zip",
+                    is_selected: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    }),
+  );
+  const addons = path.join(roots.game, "game", "citadel", "addons");
+  await writeFile(
+    path.join(addons, ".dmm.json"),
+    JSON.stringify({
+      version: 3,
+      mods: {
+        [CATALOG_MOD_ID]: {
+          enabled: true,
+          currentVpks: ["pak01_dir.vpk"],
+          disabledVpks: [],
+          originalVpkNames: ["base.vpk"],
+        },
+      },
+    }),
+  );
+  const target = path.join(addons, "pak01_dir.vpk");
+  await writeFile(target, catalogVpk("base.vpk"));
+  await assertCatalogDisk(world.directory, "gamebanana-single", "valid");
+  await writeFile(target, catalogVpk("red.vpk"));
+  await expect(
+    assertCatalogDisk(world.directory, "gamebanana-single", "wrong-variant"),
+  ).rejects.toThrow();
+  await writeFile(target, catalogVpk("base.vpk"));
+  await writeFile(path.join(addons, "pak02_dir.vpk"), catalogVpk("red.vpk"));
+  await expect(
+    assertCatalogDisk(world.directory, "gamebanana-single", "extra-file"),
+  ).rejects.toThrow();
+});

--- a/apps/desktop/e2e/support/gamebanana-oracle.ts
+++ b/apps/desktop/e2e/support/gamebanana-oracle.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { assertOwnedWorld, collectFileInventory } from "./world";
+import {
+  catalogRecipe,
+  catalogVpk,
+  CATALOG_MOD_ID,
+  CATALOG_MOD_NAME,
+  installedCatalogFiles,
+} from "./gamebanana-fixtures";
+
+const fileSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  archive_name: z.string(),
+  is_selected: z.boolean(),
+});
+const modSchema = z.object({
+  remoteId: z.string(),
+  name: z.string(),
+  status: z.string(),
+  selectedDownloads: z.array(z.object({ name: z.string() })),
+  installedVpks: z.array(z.string()).optional(),
+  installedFileTree: z.object({ files: z.array(fileSchema) }).optional(),
+});
+export const readCatalogState = async (world: string) => {
+  const { configuration } = await assertOwnedWorld(world);
+  const store = z
+    .object({ "local-config": z.string() })
+    .parse(
+      JSON.parse(
+        await readFile(
+          path.join(configuration.roots.appData, "state.json"),
+          "utf8",
+        ),
+      ),
+    );
+  return z
+    .object({
+      state: z.object({
+        localMods: z.array(modSchema).default([]),
+        activeProfileId: z.string(),
+        profiles: z.record(
+          z.string(),
+          z.object({
+            folderName: z.string().nullable(),
+            enabledMods: z.record(
+              z.string(),
+              z.object({ enabled: z.boolean() }),
+            ),
+          }),
+        ),
+      }),
+    })
+    .parse(JSON.parse(store["local-config"])).state;
+};
+
+export const assertCatalogDisk = async (
+  world: string,
+  scenario: string,
+  phase: string,
+): Promise<void> => {
+  const {
+    configuration: { roots },
+  } = await assertOwnedWorld(world);
+  const state = await readCatalogState(world);
+  assert.equal(state.localMods.length, 1);
+  const mod = state.localMods[0];
+  assert.equal(mod.remoteId, CATALOG_MOD_ID);
+  assert.equal(mod.name, CATALOG_MOD_NAME);
+  assert.equal(mod.status, "installed");
+  const profile = state.profiles[state.activeProfileId];
+  assert.equal(profile.folderName, null);
+  assert.equal(profile.enabledMods[CATALOG_MOD_ID]?.enabled, true);
+  assert.deepEqual(
+    mod.selectedDownloads.map((download) => download.name).sort(),
+    catalogRecipe(scenario)
+      .filter((archive) => archive.selected)
+      .map((archive) => archive.name)
+      .sort(),
+  );
+  const names = installedCatalogFiles(scenario);
+  assert(mod.installedFileTree);
+  assert.deepEqual(
+    mod.installedFileTree.files
+      .filter((file) => file.is_selected)
+      .map((file) => file.name)
+      .sort(),
+    names,
+  );
+  for (const file of mod.installedFileTree.files.filter(
+    (file) => file.is_selected,
+  ))
+    assert.equal(
+      file.archive_name,
+      catalogRecipe(scenario).find((archive) =>
+        archive.files.includes(file.name),
+      )?.name,
+    );
+  const addons = path.join(roots.game, "game", "citadel", "addons");
+  const manifest = z
+    .object({
+      version: z.literal(3),
+      mods: z.record(
+        z.string(),
+        z.object({
+          enabled: z.boolean(),
+          currentVpks: z.array(z.string()),
+          disabledVpks: z.array(z.string()),
+          originalVpkNames: z.array(z.string()),
+        }),
+      ),
+    })
+    .parse(JSON.parse(await readFile(path.join(addons, ".dmm.json"), "utf8")));
+  assert.deepEqual(Object.keys(manifest.mods), [CATALOG_MOD_ID]);
+  const entry = manifest.mods[CATALOG_MOD_ID];
+  assert.equal(entry.enabled, true);
+  assert.deepEqual(entry.disabledVpks, []);
+  assert.deepEqual(entry.originalVpkNames.toSorted(), names);
+  assert.deepEqual(mod.installedVpks, entry.currentVpks);
+  const inventory = await collectFileInventory(addons);
+  assert.deepEqual(
+    Object.keys(inventory).sort(),
+    [".dmm.json", ...entry.currentVpks].sort(),
+  );
+  const hash = (name: string) => {
+    const bytes = catalogVpk(name);
+    return `${bytes.length}:${createHash("sha256").update(bytes).digest("hex")}`;
+  };
+  assert.deepEqual(
+    entry.currentVpks.map((vpk) => inventory[vpk]).sort(),
+    names.map(hash).sort(),
+  );
+  for (const [index, name] of entry.originalVpkNames.entries())
+    assert.equal(
+      inventory[entry.currentVpks[index]],
+      hash(name),
+      `Wrong bytes for ${name}`,
+    );
+  const before = z
+    .object({
+      game: z.record(z.string(), z.string()),
+      steam: z.record(z.string(), z.string()),
+      steamHttpCache: z.record(z.string(), z.string()),
+    })
+    .parse(
+      JSON.parse(
+        await readFile(
+          path.join(world, "artifacts", "files-before.json"),
+          "utf8",
+        ),
+      ),
+    );
+  const game = await collectFileInventory(roots.game);
+  for (const [name, value] of Object.entries(before.game))
+    if (!name.endsWith("gameinfo.gi"))
+      assert.equal(game[name], value, `Protected game file changed: ${name}`);
+  assert.deepEqual(await collectFileInventory(roots.steam), before.steam);
+  assert.deepEqual(
+    await collectFileInventory(roots.steamHttpCache),
+    before.steamHttpCache,
+  );
+  await writeFile(
+    path.join(world, "artifacts", `catalog-${phase}.json`),
+    JSON.stringify({ state, manifest, inventory }, null, 2),
+  );
+};

--- a/apps/desktop/e2e/support/scenarios.ts
+++ b/apps/desktop/e2e/support/scenarios.ts
@@ -1,4 +1,7 @@
 export type ScenarioId =
+  | "gamebanana-single"
+  | "gamebanana-multifile"
+  | "gamebanana-variants"
   | "filesystem-backup-replace"
   | "filesystem-backup-merge"
   | "filesystem-lock"
@@ -21,6 +24,9 @@ export type ScenarioId =
 
 export const parseScenarioId = (value = "about-smoke"): ScenarioId => {
   if (
+    value === "gamebanana-single" ||
+    value === "gamebanana-multifile" ||
+    value === "gamebanana-variants" ||
     value === "filesystem-backup-replace" ||
     value === "filesystem-backup-merge" ||
     value === "filesystem-lock" ||
@@ -46,23 +52,27 @@ export const parseScenarioId = (value = "about-smoke"): ScenarioId => {
 };
 
 export const scenarioPhases = (scenario: ScenarioId): readonly string[] =>
-  scenario.startsWith("filesystem-")
-    ? ["mutate", "restart-filesystem"]
-    : scenario.startsWith("downloads-")
-      ? ["transfer", "restart-download"]
-      : scenario === "local-mod-lifecycle"
-        ? ["import-toggle", "restart-delete"]
-        : scenario === "about-smoke"
-          ? ["smoke"]
-          : ["reorder-switch", "restart-profiles"];
+  scenario.startsWith("gamebanana-")
+    ? ["catalog-install", "restart-catalog"]
+    : scenario.startsWith("filesystem-")
+      ? ["mutate", "restart-filesystem"]
+      : scenario.startsWith("downloads-")
+        ? ["transfer", "restart-download"]
+        : scenario === "local-mod-lifecycle"
+          ? ["import-toggle", "restart-delete"]
+          : scenario === "about-smoke"
+            ? ["smoke"]
+            : ["reorder-switch", "restart-profiles"];
 
 export const scenarioSpec = (scenario: ScenarioId): string =>
-  scenario.startsWith("filesystem-")
-    ? "./specs/filesystem.e2e.ts"
-    : scenario.startsWith("downloads-")
-      ? "./specs/downloads.e2e.ts"
-      : scenario === "local-mod-lifecycle"
-        ? "./specs/local-mod-lifecycle.e2e.ts"
-        : scenario === "about-smoke"
-          ? "./specs/about.e2e.ts"
-          : "./specs/profiles-ordering.e2e.ts";
+  scenario.startsWith("gamebanana-")
+    ? "./specs/gamebanana.e2e.ts"
+    : scenario.startsWith("filesystem-")
+      ? "./specs/filesystem.e2e.ts"
+      : scenario.startsWith("downloads-")
+        ? "./specs/downloads.e2e.ts"
+        : scenario === "local-mod-lifecycle"
+          ? "./specs/local-mod-lifecycle.e2e.ts"
+          : scenario === "about-smoke"
+            ? "./specs/about.e2e.ts"
+            : "./specs/profiles-ordering.e2e.ts";

--- a/apps/desktop/e2e/support/supervisor.ts
+++ b/apps/desktop/e2e/support/supervisor.ts
@@ -3,6 +3,10 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { DriverProvider } from "./contracts";
 import { scenarioPhases, type ScenarioId } from "./scenarios";
+import {
+  createCatalogRoutes,
+  assertCatalogNetwork,
+} from "./gamebanana-fixtures";
 import { writeSyntheticVpk } from "./vpk";
 import { prepareProfileWorld } from "./profile-fixtures";
 import { prepareFilesystemWorld } from "./filesystem-fixtures";
@@ -203,7 +207,11 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
   };
 
   try {
-    fixtureServer = await startFixtureServer([
+    const catalogRoutes = options.caseId.startsWith("gamebanana-")
+      ? await createCatalogRoutes(options.caseId)
+      : () => [];
+    fixtureServer = await startFixtureServer((origin) => [
+      ...catalogRoutes(origin),
       ...(options.fixtureRoutes ?? []),
       ...(options.caseId.startsWith("downloads-")
         ? downloadRoutes(options.caseId)
@@ -228,6 +236,11 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
       fixtureOrigin: fixtureServer.origin,
     });
     const roots = world.configuration.roots;
+    if (options.caseId.startsWith("gamebanana-"))
+      await writeFile(
+        path.join(roots.game, "protected.txt"),
+        "Keep the synthetic game intact\n",
+      );
     if (options.caseId.startsWith("filesystem-"))
       await prepareFilesystemWorld(world);
     if (options.caseId.startsWith("downloads-"))
@@ -324,6 +337,8 @@ export const runE2eWorld = async (options: RunOptions): Promise<RunResult> => {
     }
     if (wdioResult.exitCode === 0 && options.caseId.startsWith("downloads-"))
       assertDownloadNetwork(options.caseId, fixtureServer.requests());
+    if (wdioResult.exitCode === 0 && options.caseId.startsWith("gamebanana-"))
+      assertCatalogNetwork(options.caseId, fixtureServer.requests());
     await closeResources();
     const after = Object.fromEntries(
       await Promise.all(

--- a/apps/desktop/src/components/mod-detail/installed-files-display.tsx
+++ b/apps/desktop/src/components/mod-detail/installed-files-display.tsx
@@ -20,16 +20,16 @@ export const InstalledFilesDisplay = ({
   fileTree,
   modName,
 }: InstalledFilesDisplayProps) => {
-  const filesByArchive = fileTree.files.reduce(
-    (acc, file) => {
-      if (!acc[file.archive_name]) {
-        acc[file.archive_name] = [];
-      }
-      acc[file.archive_name].push(file);
-      return acc;
-    },
-    {} as Record<string, typeof fileTree.files>,
-  );
+  const filesByArchive = fileTree.files.reduce<
+    Record<string, ModFileTree["files"]>
+  >((acc, file) => {
+    if (!file.is_selected) return acc;
+    if (!acc[file.archive_name]) {
+      acc[file.archive_name] = [];
+    }
+    acc[file.archive_name].push(file);
+    return acc;
+  }, {});
 
   const archiveNames = Object.keys(filesByArchive);
 


### PR DESCRIPTION
Adds three end-to-end flows from an empty library through the GameBanana catalog, download, extraction, and installation. HTTP fixtures replace the remote service; the app's provider, UI, IPC, and filesystem operations run unchanged.

- `gamebanana-single`: download one ZIP and install its VPK.
- `gamebanana-multifile`: choose two of three archives and verify both installed files retain their archive attribution. The unselected download has no fixture route.
- `gamebanana-variants`: deselect one VPK inside an archive and install the remaining two.

Every case closes the app normally and verifies the result in a new process. Assertions compare visible installed-file names, archive groups/counts, active VPK labels, persisted selections, profile state, manifest entries, and SHA-256 hashes. Strict request assertions reject unexpected or duplicate payload downloads. Screenshots, DOM snapshots, and disk evidence are retained with `--keep`.

The variant scenario reproduced a product bug: the Installed Files section displayed unselected VPKs from the stored file tree. It now renders and counts only selected entries. A patch changeset is included.

Stacked on #711 (`feature/tauri-e2e-filesystem-recovery`). This fills the initial catalog-selection/install gap in M4; M6 CI and release coverage remains planned.

Validation:
- All three native Windows/Wry embedded-provider scenarios passed both phases, with zero unexpected requests and no retries.
- 22 harness unit tests passed, including rejection of wrong variant bytes, extra files, duplicate downloads, and unselected archive requests.
- `pnpm lint:fix`, `pnpm format:fix`, `pnpm check-types`, and desktop `e2e:check-types` passed.
- `e2e:build` passed; retained screenshots were inspected for single, multi-file, and variant installations.

AI disclosure: Implementation, tests, and description prepared with OpenAI Codex. Human review required before merge.

## Stack tracking

Tracked in #673 (PR 17 of 19). Based on #711. Followed by #713.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Windows/Wry E2E coverage for GameBanana catalog installation:
  - Single archive installation.
  - Selection of two archives from three.
  - Selection of two VPKs from one archive.
- Added HTTP fixtures for catalog metadata, archive downloads, VPK extraction, and download validation.
- Added disk, manifest, profile, hash, and installed-file assertions.
- Fixed the desktop Installed Files view so it shows only selected VPKs.
- Added restart persistence checks and diagnostic artifact retention.

## Affected apps

- **Desktop:** GameBanana installation flow, E2E scenarios, fixture support, and installed-file rendering.
- **Other apps/packages:** No changes.

## Validation

- Passed the three native E2E scenarios.
- Passed 22 harness unit tests, linting, formatting, type checks, build, and screenshot inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->